### PR TITLE
Add all the course contributors!

### DIFF
--- a/chapters/chapter8/section6.mdx
+++ b/chapters/chapter8/section6.mdx
@@ -10,4 +10,4 @@ Congratulations, you've made it through the second part of the course! We're act
 
 You should now be able to tackle a range of NLP tasks, and fine-tune or pretrain a model on them. Don't forget to share your results with the community on the [Model Hub](https://huggingface.co/models).
 
-We can't wait to see what you will build with the knowledge that you've gained!!!
+We can't wait to see what you will build with the knowledge that you've gained!


### PR DESCRIPTION
This PR adds all the [course contributors](https://github.com/huggingface/huggingface-course/graphs/contributors) from the legacy repo. Note that I excluded `hboyce`, `ines`, and `arokem` as their commits seems to be on the spaCy framework, not the course material per se.

I used this [nifty app](https://coauthoredby.netlify.app/) to extract the private `noreply` email addresses of each contributor.