### PR TITLE
Normalize TensorFlow training steps by batch size

### DIFF
--- a/chapters/en/chapter3/section3_tf.mdx
+++ b/chapters/en/chapter3/section3_tf.mdx
@@ -118,7 +118,7 @@ batch_size = 8
 num_epochs = 3
 # The number of training steps is the number of samples in the dataset, divided by the batch size then multiplied
 # by the total number of epochs
-num_train_steps = len(tf_train_dataset) * num_epochs
+num_train_steps = (len(tf_train_dataset) // batch_size) * num_epochs
 lr_scheduler = PolynomialDecay(
     initial_learning_rate=5e-5, end_learning_rate=0.0, decay_steps=num_train_steps
 )

--- a/chapters/en/chapter7/section2.mdx
+++ b/chapters/en/chapter7/section2.mdx
@@ -449,7 +449,8 @@ import tensorflow as tf
 tf.keras.mixed_precision.set_global_policy("mixed_float16")
 
 num_epochs = 3
-num_train_steps = len(tf_train_dataset) * num_epochs
+batch_size = 16
+num_train_steps = (len(tf_train_dataset) // batch_size) * num_epochs
 
 optimizer, schedule = create_optimizer(
     init_lr=2e-5,

--- a/chapters/en/chapter7/section4.mdx
+++ b/chapters/en/chapter7/section4.mdx
@@ -595,7 +595,8 @@ from transformers.keras_callbacks import PushToHubCallback
 import tensorflow as tf
 
 num_epochs = 3
-num_train_steps = len(tf_train_dataset) * num_epochs
+batch_size = 16
+num_train_steps = (len(tf_train_dataset) // batch_size) * num_epochs
 
 optimizer, schedule = create_optimizer(
     init_lr=5e-5,

--- a/chapters/en/chapter7/section5.mdx
+++ b/chapters/en/chapter7/section5.mdx
@@ -687,7 +687,8 @@ import tensorflow as tf
 # If you -are- me, then you should probably deal with your GitHub issue backlog
 username = "Rocketknight1"
 num_train_epochs = 8
-num_train_steps = len(tf_train_dataset) * num_train_epochs
+batch_size = 8
+num_train_steps = (len(tf_train_dataset) // batch_size) * num_train_epochs
 model_name = model_checkpoint.split("/")[-1]
 
 optimizer, schedule = create_optimizer(

--- a/chapters/en/chapter7/section7.mdx
+++ b/chapters/en/chapter7/section7.mdx
@@ -880,7 +880,8 @@ from transformers.keras_callbacks import PushToHubCallback
 import tensorflow as tf
 
 num_train_epochs = 3
-num_train_steps = len(tf_train_dataset) * num_train_epochs
+batch_size = 16
+num_train_steps = (len(tf_train_dataset) // batch_size) * num_train_epochs
 optimizer, schedule = create_optimizer(
     init_lr=2e-5,
     num_warmup_steps=0,


### PR DESCRIPTION
This PR addresses a [comment on the forums](https://discuss.huggingface.co/t/chapter-3-questions/6800/48), where a reader was confused why `num_train_steps` wasn't normalized by the batch size. 

Following the official TensorFlow examples in `transformers`, I've included this normalization in all the TensorFlow sections of the course. The only sections I didn't make a change are:

* https://huggingface.co/course/chapter7/3?fw=tf
* https://huggingface.co/course/chapter7/6?fw=tf

because in both those sections we have

```python
num_train_steps = len(tf_train_dataset)
```

and I wasn't sure if this was intentional.