### PR TITLE
Fix inequalities in answer spans for QA chapter

### DIFF
--- a/chapters/en/chapter7/section7.mdx
+++ b/chapters/en/chapter7/section7.mdx
@@ -291,7 +291,7 @@ for i, offset in enumerate(inputs["offset_mapping"]):
     context_end = idx - 1
 
     # If the answer is not fully inside the context, label is (0, 0)
-    if offset[context_start][0] > end_char or offset[context_end][1] < start_char:
+    if offset[context_start][0] > start_char or offset[context_end][1] < end_char:
         start_positions.append(0)
         end_positions.append(0)
     else:
@@ -398,7 +398,7 @@ def preprocess_training_examples(examples):
         context_end = idx - 1
 
         # If the answer is not fully inside the context, label is (0, 0)
-        if offset[context_start][0] > end_char or offset[context_end][1] < start_char:
+        if offset[context_start][0] > start_char or offset[context_end][1] < end_char:
             start_positions.append(0)
             end_positions.append(0)
         else:


### PR DESCRIPTION
This PR fixes a small bug reported by a [course participant](https://discuss.huggingface.co/t/chapter-7-questions/11746/27?u=lewtun) on the forums. 

The bug concerns the inequalities used to determine whether an answer span lies within the context or not. In the original implementation, we missed cases where the answer span partially overlapped with the context (e.g. the end answer character occurs after the start context character).

With this fix, we are now consistent with the logic in the [question-answering scripts](https://github.com/huggingface/transformers/blob/319cbbe19153d935f1e706b9bb2e9a294defe9e5/examples/pytorch/question-answering/run_qa.py#L403) (which are simply the negation of the course logic).

Asking for a review here to double-check I haven't misunderstood the original logic 😄 

## TODO

- [ ] Update the notebook if this fix is merged.