### PR TITLE
Update model card URL

### DIFF
--- a/chapters/en/chapter4/section4.mdx
+++ b/chapters/en/chapter4/section4.mdx
@@ -85,4 +85,4 @@ datasets:
 
 This metadata is parsed by the Hugging Face Hub, which then identifies this model as being a French model, with an MIT license, trained on the Oscar dataset. 
 
-The [full model card specification](https://raw.githubusercontent.com/huggingface/huggingface_hub/main/modelcard.md) allows specifying languages, licenses, tags, datasets, metrics, as well as the evaluation results the model obtained when training. 
+The [full model card specification](https://github.com/huggingface/hub-docs/blame/main/modelcard.md) allows specifying languages, licenses, tags, datasets, metrics, as well as the evaluation results the model obtained when training. 


### PR DESCRIPTION
Updates the model card URL to account for the split of `huggingface_hub` in https://github.com/huggingface/hub-docs/pull/60#pullrequestreview-912248296