### PR TITLE
Mark third option on chapter 8, question 8 as correct

### DIFF
--- a/chapters/en/chapter8/7.mdx
+++ b/chapters/en/chapter8/7.mdx
@@ -193,6 +193,7 @@ Which of the following might be a good choice for the title of a forum topic to 
 		{
 			text: "It allows the maintainers to know whether you're running code on a GPU or CPU.",
 			explain: "Correct! As we've seen in this chapter, errors on GPUs and CPUs can quite different in flavor, and knowing which hardware you're using can help focus the maintainers' attention. But this isn't the only benefit...",
+			correct: true
 		}
 	]}
 />


### PR DESCRIPTION
In the quiz for chapter 8, question 8 the final option when selected shows as incorrect, although I think is should be correct. 

![image](https://user-images.githubusercontent.com/22614925/164713752-7fb8f0b3-c2bd-4133-831c-2f57a2c661aa.png)

Marking as correct in the corresponding `.mdx` file