### PR TITLE
Fix typos in Gradio course (chapter 9)

### DIFF
--- a/chapters/en/chapter9/1.mdx
+++ b/chapters/en/chapter9/1.mdx
@@ -1,6 +1,6 @@
 # Introduction to Gradio
 
-In this chapter we will be learning about how to build **interactive demos** for your machine learning models. 
+In this chapter we will be learning about how to build **interactive demos** for your machine learning models.
 
 Why build a demo or a GUI for your machine learning model in the first place? Demos allow:
 
@@ -13,11 +13,11 @@ We'll be using the Gradio library to build demos for our models. Gradio allows y
 
 Here are some examples of machine learning demos built with Gradio:
 
-* A **sketch recognition** model that takes in a sketch and outputs labels of what it thinks is being drawn: 
+* A **sketch recognition** model that takes in a sketch and outputs labels of what it thinks is being drawn:
 
 <iframe src="https://hf.space/gradioiframe/abidlabs/draw2/+" frameBorder="0" height="400" title="Gradio app" class="container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
 
-* An extractive **question answering** model that takes in a context paragraph and a quest and outputs a response and a probability score (we discussed this kind of model [in Chapter 7]((/course/chapter7/7))): 
+* An extractive **question answering** model that takes in a context paragraph and a quest and outputs a response and a probability score (we discussed this kind of model [in Chapter 7](/course/chapter7/7)):
 
 <iframe src="https://hf.space/gradioiframe/abidlabs/question-answering-simple/+" frameBorder="0" height="420" title="Gradio app" class="container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
 
@@ -25,7 +25,7 @@ Here are some examples of machine learning demos built with Gradio:
 
 <iframe src="https://hf.space/gradioiframe/abidlabs/remove-bg/+" frameBorder="0" height="640" title="Gradio app" class="container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
 
-This chapter is broken down into sections which include both _concepts_ and _applications_. After you learn the concept in each section, you'll apply it to build a particular kind of demo, ranging from image classification to speech recognition. By the time you finish this chapter, you'll be able to build these demos (and many more!) in just a few lines of Python code. 
+This chapter is broken down into sections which include both _concepts_ and _applications_. After you learn the concept in each section, you'll apply it to build a particular kind of demo, ranging from image classification to speech recognition. By the time you finish this chapter, you'll be able to build these demos (and many more!) in just a few lines of Python code.
 
 <Tip>
 👀 Check out <a href="https://huggingface.co/spaces" target="_blank">Hugging Face Spaces</a> to see many recent examples of machine learning demos built by the machine learning community!

--- a/chapters/en/chapter9/2.mdx
+++ b/chapters/en/chapter9/2.mdx
@@ -25,8 +25,8 @@ demo.launch()
 Let's walk through the code above:
 
 - First, we define a function called `greet()`. In this case, it is a simple function that adds "Hello" before your name, but it can be *any* Python function in general. For example, in machine learning applications, this function would *call a model to make a prediction* on an input and return the output.
-- Then, we create a Gradio `Interface` with three arguments, `fn`, `inputs`, and `outputs`. These arguments define the prediction function, as well as the _type_ of input and output components we would like. In our case, both components are simple text boxes. 
-- We then call the `launch()` method on the `Interface` that we created. 
+- Then, we create a Gradio `Interface` with three arguments, `fn`, `inputs`, and `outputs`. These arguments define the prediction function, as well as the _type_ of input and output components we would like. In our case, both components are simple text boxes.
+- We then call the `launch()` method on the `Interface` that we created.
 
 If you run this code, the interface below will appear automatically within a Jupyter/Colab notebook, or pop in a browser on **[http://localhost:7860](http://localhost:7860/)** if running from a script.
 
@@ -36,8 +36,8 @@ Try using this GUI right now with your own name or some other input!
 
 You'll notice that in this GUI, Gradio automatically inferred the name of the input parameter (`name`)
 and applied it as a label on top of the textbox. What if you'd like to change that?
-Or if you'd like to customize the textbox in some other way? In that case, you can 
-instantiate a class object representing the input component. 
+Or if you'd like to customize the textbox in some other way? In that case, you can
+instantiate a class object representing the input component.
 
 Take a look at the example below:
 
@@ -60,8 +60,8 @@ gr.Interface(fn=greet, inputs=textbox, outputs="text").launch()
 Here, we've created an input textbox with a label, a placeholder, and a set number of lines.
 You could do the same for the output textbox, but we'll leave that for now.
 
-We've seen that with just a few lines of code, Gradio lets you create a simple interface around any function 
-with any kind of inputs or outputs. In this section, we've started with a 
+We've seen that with just a few lines of code, Gradio lets you create a simple interface around any function
+with any kind of inputs or outputs. In this section, we've started with a
 simple textbox, but in the next sections, we'll cover other kinds of inputs and outputs. Let's now take a look at including some NLP in a Gradio application.
 
 
@@ -69,8 +69,8 @@ simple textbox, but in the next sections, we'll cover other kinds of inputs and 
 
 Let's now build a simple interface that allows you to demo a **text-generation** model like GPT-2.
 
-We'll load our model using the the `pipeline()` function from 🤗 Transformers. 
-If you need a quick refresher, you can go back to [that section in Chapter 1](/course/chapter1/3#text-generation).   
+We'll load our model using the `pipeline()` function from 🤗 Transformers.
+If you need a quick refresher, you can go back to [that section in Chapter 1](/course/chapter1/3#text-generation).
 
 First, we define a prediction function that takes in a text prompt and returns the text completion:
 

--- a/chapters/en/chapter9/3.mdx
+++ b/chapters/en/chapter9/3.mdx
@@ -5,17 +5,17 @@ main parameters used to create one.
 
 ## How to create an Interface
 
-You'll notice that the `Interface` class has 3 required parameters:  
+You'll notice that the `Interface` class has 3 required parameters:
 
 `Interface(fn, inputs, outputs, ...)`
 
 These parameters are:
 
   - `fn`: the prediction function that is wrapped by the Gradio interface. This function can take one or more parameters and return one or more values
-  - `inputs`: the input component type(s). Gradio provides many pre-built components such as`"image"` or `"mic"`. 
+  - `inputs`: the input component type(s). Gradio provides many pre-built components such as`"image"` or `"mic"`.
   - `outputs`: the output component type(s). Again, `gradio` provides many pre-built components e.g. `"image"` or `"label"`.
 
-For a complete list of components, [see the Gradio docs ](https://gradio.app/docs). Each pre-built component can be customized by instantiating the class corresponding to the component. 
+For a complete list of components, [see the Gradio docs ](https://gradio.app/docs). Each pre-built component can be customized by instantiating the class corresponding to the component.
 
 For example, as we saw in the [previous section](/course/chapter9/2),
 instead of passing in `"textbox"` to the `inputs` parameter, you can pass in a `Textbox(lines=7, label="Prompt")` component to create a textbox with 7 lines and a label.
@@ -24,13 +24,13 @@ Let's take a look at another example, this time with an `Audio` component.
 
 ## A simple example with audio
 
-As mentioned earlier, Gradio provides many different inputs and outputs. 
+As mentioned earlier, Gradio provides many different inputs and outputs.
 So let's build an `Interface` that works with audio.
 
-In this example, we'll build an audio-to-audio function that takes an 
+In this example, we'll build an audio-to-audio function that takes an
 audio file and simply reverses it.
 
-We will use for the input the `Audio` component. When using the `Audio` component, 
+We will use for the input the `Audio` component. When using the `Audio` component,
 you can specify whether you want the `source` of the audio to be a file that the user
 uploads or a microphone that the user records their voice with. In this case, let's
 set it to a `"microphone"`. Just for fun, we'll add a label to our `Audio` that says
@@ -41,8 +41,8 @@ In addition, we'd like to receive the audio as a numpy array so that we can easi
 data as a tuple of (`sample_rate`, `data`) into our function.
 
 We will also use the `Audio` output component which can automatically
-render a tuple with a sample rate and numpy array of data as a playable audio file. 
-In this case, we do not need to do any customization, so we will use the string 
+render a tuple with a sample rate and numpy array of data as a playable audio file.
+In this case, we do not need to do any customization, so we will use the string
 shortcut `"audio"`.
 
 
@@ -70,9 +70,9 @@ You should now be able to record your voice and hear yourself speaking in revers
 
 ## Handling multiple inputs and outputs
 
-Let's say we had a more complicated function, with multiple inputs and outputs. 
-In the example below, we have a function that takes a dropdown index, a slider value, and number, 
-and returns an audio sample of a musical tone. 
+Let's say we had a more complicated function, with multiple inputs and outputs.
+In the example below, we have a function that takes a dropdown index, a slider value, and number,
+and returns an audio sample of a musical tone.
 
 Take a look how we pass a list of input and output components,
 and see if you can follow along what's happening.
@@ -116,10 +116,10 @@ gr.Interface(
 
 ### The `launch()` method
 
-So far, we have used the `launch()` method to launch the interface, but we 
-haven't really discussed what it does. 
+So far, we have used the `launch()` method to launch the interface, but we
+haven't really discussed what it does.
 
-By default, the `launch()` method will launch the demo in a web server that 
+By default, the `launch()` method will launch the demo in a web server that
 is running locally. If you are running your code in a Jupyter or Colab notebook, then
 Gradio will embed the demo GUI in the notebook so you can easily use it.
 
@@ -136,7 +136,7 @@ We'll cover the `share` parameter in a lot more detail in the next section!
 Let's build an interface that allows you to demo a **speech-recognition** model.
 To make it interesting, we will accept *either* a mic input or an uploaded file.
 
-As usual, we'll load our speech recognition model using the the `pipeline()` function 🤗 Transformers. 
+As usual, we'll load our speech recognition model using the `pipeline()` function from 🤗 Transformers.
 If you need a quick refresher, you can go back to [that section in Chapter 1](/course/chapter1/3).   Next, we'll implement a `transcribe_audio()` function that processes the audio and returns the transcription. Finally, we'll wrap this function in an `Interface` with the `Audio` components for the inputs and just text for the output. Altogether, the code for this application is the following:
 
 ```py

--- a/chapters/en/chapter9/4.mdx
+++ b/chapters/en/chapter9/4.mdx
@@ -23,7 +23,7 @@ Using the options above, we end up with a more complete interface. Run the code 
 
 ```python out
 title = "Ask Rick a Question"
-description = 
+description =
 """
 The bot was trained to answer questions based on Rick and Morty dialogues. Ask Rick anything!
 <img src="https://huggingface.co/spaces/course-demos/Rick_and_Morty_QA/resolve/main/rick.png" width=200px>
@@ -32,14 +32,14 @@ The bot was trained to answer questions based on Rick and Morty dialogues. Ask R
 article = "Check out [the original Rick and Morty Bot](https://huggingface.co/spaces/kingabzpro/Rick_and_Morty_Bot) that this demo is based off of."
 
 gr.Interface(
-    fn=predict, 
-    inputs="textbox", 
+    fn=predict,
+    inputs="textbox",
     outputs="text",
-    title=title, 
-    description=description, 
+    title=title,
+    description=description,
     article=article,
-    examples=[["What are you doing?"], ["Where should we time travel to?"]] 
-).launch() 
+    examples=[["What are you doing?"], ["Where should we time travel to?"]]
+).launch()
 ```
 
 Using the options above, we end up with a more complete interface. Try the interface below:
@@ -53,7 +53,7 @@ Interfaces can be easily shared publicly by setting `share=True` in the `launch(
 ```python
 gr.Interface(classify_image, "image", "label").launch(share=True)
 ```
-        
+
 This generates a public, shareable link that you can send to anybody! When you send this link, the user on the other side can try out the model in their browser for up to 72 hours. Because the processing happens on your device (as long as your device stays on!), you don't have to worry about packaging any dependencies. If you're working out of a Google Colab notebook, a share link is always automatically created. It usually looks something like this: **XXXXX.gradio.app**. Although the link is served through a Gradio link, we are only a proxy for your local server, and do not store any data sent through the interfaces.
 
 Keep in mind, however, that these links are publicly accessible, meaning that anyone can use your model for prediction! Therefore, make sure not to expose any sensitive information through the functions you write, or allow any critical changes to occur on your device. If you set `share=False` (the default), only a local link is created.
@@ -62,8 +62,8 @@ Keep in mind, however, that these links are publicly accessible, meaning that an
 
 A share link that you can pass around to collegues is cool, but how can you permanently host your demo and have it exist in its own "space" on the internet?
 
-Hugging Face Spaces provides the infrastructure to permanently host your Gradio model on the internet, **for free**! Spaces allows you to create and push to a (public or private) repo, 
-where your Gradio 
+Hugging Face Spaces provides the infrastructure to permanently host your Gradio model on the internet, **for free**! Spaces allows you to create and push to a (public or private) repo,
+where your Gradio
 interface code will exist in an `app.py` file. [Read a step-by-step tutorial](https://huggingface.co/blog/gradio-spaces) to get started, or watch an example video below.
 
 <Youtube id="LS9Y2wDVI0k" />
@@ -129,12 +129,12 @@ interface.launch(share=True)
 
 
 Notice the `live=True` parameter in `Interface`, which means that the sketch demo makes
-a prediction every time someone draws on the sketchpad (no submit button!). 
+a prediction every time someone draws on the sketchpad (no submit button!).
 
-Furthermore, we also set the `share=True` argument in the `launch()` method. 
-This will create a public link that you can 
-send to anyone! When you send this link, the user on the other side can try out the 
-sketch recognition model. To reiterate, you culd also host the model on Hugging Face Spaces,
+Furthermore, we also set the `share=True` argument in the `launch()` method.
+This will create a public link that you can
+send to anyone! When you send this link, the user on the other side can try out the
+sketch recognition model. To reiterate, you could also host the model on Hugging Face Spaces,
 which is how we are able to embed the demo above.
 
 Next up, we'll cover other ways that Gradio can be used with the Hugging Face ecosystem!

--- a/chapters/en/chapter9/6.mdx
+++ b/chapters/en/chapter9/6.mdx
@@ -4,15 +4,15 @@ Now that we can build and share a basic interface, let's explore some more advan
 
 ### Using state to persist data
 
-Gradio supports *session state*, where data persists across multiple submits within a 
+Gradio supports *session state*, where data persists across multiple submits within a
 page load. Session state is useful for building demos of, for example, chatbots where you want to
-persist data as the user interacts with the model. Note that session state does not shared data between different users of your model.
+persist data as the user interacts with the model. Note that session state does not share data between different users of your model.
 
-To store data in a session state, you need to do three things: 
+To store data in a session state, you need to do three things:
 
-1. Pass in an *extra parameter* into your function, which represents the state of the interface. 
+1. Pass in an *extra parameter* into your function, which represents the state of the interface.
 1. At the end of the function, return the updated value of the state as an *extra return value*.
-1. Add the 'state' input and 'state' output components when creating your `Interface`. 
+1. Add the 'state' input and 'state' output components when creating your `Interface`.
 
 See the chatbot example below:
 
@@ -48,9 +48,9 @@ iface.launch()
 
 <iframe src="https://hf.space/gradioiframe/dawood/Chatbot-Demo/+" frameBorder="0" height="350" title="Gradio app" class="container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
 
-Notice how the state of the output component persists across submits. 
-Note: you can pass in a default value to the state parameter, 
-which is used as the initial value of the state. 
+Notice how the state of the output component persists across submits.
+Note: you can pass in a default value to the state parameter,
+which is used as the initial value of the state.
 
 ### Using interpretation to understand predictions
 
@@ -95,9 +95,9 @@ Lastly, you can also pass in your own interpretation function into the `interpre
 
 ### Adding authentication
 
-You may want to authentication to your Gradio interface in order to control who can access and use your demo.
+You may want to authenticate to your Gradio interface in order to control who can access and use your demo.
 
-Authentication can be added by provided a list of username/password tuples to the `auth` parameter in the `launch()` method. For more complex authentication handling, you can pass a function that takes a username and password as arguments, and returns `True` to allow authentication, `False` otherwise.
+Authentication can be added by providing a list of username/password tuples to the `auth` parameter in the `launch()` method. For more complex authentication handling, you can pass a function that takes a username and password as arguments, and returns `True` to allow authentication, `False` otherwise.
 
 Let's take the image classification demo above and add authentication:
 

--- a/chapters/en/chapter9/7.mdx
+++ b/chapters/en/chapter9/7.mdx
@@ -53,7 +53,7 @@ demo.launch()
 
 This simple example above introduces 4 concepts that underlie Blocks:
 
-1. Blocks allow you to build web applications that combine markdown, HTML, buttons, and interactive components simply by instantiating objects in Python inside of a `with gradio.Blocks` context. 
+1. Blocks allow you to build web applications that combine markdown, HTML, buttons, and interactive components simply by instantiating objects in Python inside of a `with gradio.Blocks` context.
 <Tip>
 🙋If you're not familiar with the `with` statement in Python, we recommend checking out the excellent [tutorial](https://realpython.com/python-with-statement/) from Real Python. Come back here after reading that 🤗
 </Tip>
@@ -129,7 +129,7 @@ You can attach event trigger to none, one, or more of these events. You create a
 
 - `fn`: the function to run
 - `inputs`: a (list of) component(s) whose values should supplied as the input parameters to the function. Each component's value gets mapped to the corresponding function parameter, in order. This parameter can be None if the function does not take any parameters.
-- `outputs`: a (list of) component(s) whose values should be updated based on the values returned by the function. Each return value gets sets the corresponding component's value, in order. This parameter can be None if the function does not return anything.
+- `outputs`: a (list of) component(s) whose values should be updated based on the values returned by the function. Each return value sets the corresponding component's value, in order. This parameter can be None if the function does not return anything.
 
 You can even make the input and output component be the same component, as we do in this example that uses a GPT model to do text completion:
 
@@ -157,7 +157,7 @@ demo.launch()
 
 ### Creating multi-step demos
 
-In some cases, you might want want a _multi-step demo_, in which you reuse the output of one function as the input to the next. This is really easy to do with `Blocks`, as you can use a component for the input of one event trigger but the output of another. Take a look at the text component in the example below, its value is the result of a speech-to-text model, but also gets passed into a sentiment analysis model:
+In some cases, you might want a _multi-step demo_, in which you reuse the output of one function as the input to the next. This is really easy to do with `Blocks`, as you can use a component for the input of one event trigger but the output of another. Take a look at the text component in the example below, its value is the result of a speech-to-text model, but also gets passed into a sentiment analysis model:
 
 ```py
 from transformers import pipeline


### PR DESCRIPTION
Fix a few typos in Gradio course.

VSCode trimmed all the extra whitespaces it seems, I can remove that if that's an issue.