### PR TITLE
Add translating notes and glossary to Spanish

### DIFF
--- a/chapters/es/TRANSLATING.txt
+++ b/chapters/es/TRANSLATING.txt
@@ -1,0 +1,23 @@
+1. We use the informal "you" (i.e. "Tu" instead of "Usted") to keep the tone jovial. However, don't use slang or local language.
+
+2. Don't translate industry-accepted acronyms. e.g. TPU or GPU.
+
+3. In certain cases is better to accept an Enlish word. Check for the correct usage of terms in computer science and commonly used terms in other publications.
+
+4. Keep voice active and consistent. Don't overdo it but try to avoid a passive voice.
+
+5. Refer and contribute to the glossary frequently to stay on top of the latest choices we make. This minimizes the amount of editing that is required.
+
+6. Keep POV consistent.
+
+7. Smaller sentences are better sentences. Apply with nuance.
+
+8. If translating a technical word, keep the choice of Spanish translation consistent. This does not apply for non-technical choices, as in those cases variety actually helps keep the text engaging.
+
+9. This is merely a translation. Don't add any technical/contextual information not present in the original text. Also don't leave stuff out. The creative choices in composing this information were the original authors' to make. Our creative choices are in doing a quality translation.
+
+10. Be exact when choosing equivalents for technical words. Package is package. Library is library. Don't mix and match.
+
+11. Library names are kept in the original forms, e.g. "🤗 Datasets", however, the word dataset in a sentence gets a translation to "Conjunto de datos".
+
+12. As a style choice prefer the imperative over constructions with auxiliary words to avoid unnecessary verbosity and addressing of the reader, which seems unnatural. e.g. "Ver capítulo X" - "See chapter X" instead of "Puedes ver esto en el capítulo X" - "You can see this in chapter X".

--- a/chapters/es/_toctree.yml
+++ b/chapters/es/_toctree.yml
@@ -40,3 +40,8 @@
     title: Introducción
   - local: chapter3/2
     title: Procesamiento de los datos
+
+- title: Glosario
+  sections:
+  - local: glossary/1
+    title: Glosario

--- a/chapters/es/glossary/1.mdx
+++ b/chapters/es/glossary/1.mdx
@@ -1,0 +1,94 @@
+# Vocabulario
+
+| Original                    | Spanish                           |
+|-----------------------------|---------------------------------  |
+| Abstraction                 | Abstracción                       |
+| Accuracy                    | Exactitud                         |
+| Backward Pass               | Pasada en reverso                 |
+| Batch                       | Lote                              |
+| Benchmark                   | Punto de referencia               |
+| Cache                       | Almacenamiento                    |
+| Caching                     | Almacenar                         |
+| Chapter                     | Capítulo                          |
+| Checkpoint                  | Punto de control                  |
+| Class                       | Clase                             |
+| Code                        | Código                            |
+| Colab Notebook              | Colab Notebook                    |
+| Command                     | Comando                           |
+| Configuration               | Configuración                     |
+| Course                      | Curso                             |
+| Dependency                  | Dependencia                       |
+| Deployment                  | Deployment                        |
+| Development                 | Desarrollo                        |
+| Dictionary                  | Diccionario                       |
+| Distribution                | Distribución                      |
+| Download                    | Descargar                         |
+| F1 score                    | F1 score                          |
+| Feature                     | Feature                           |
+| Field                       | Atributo                          |
+| Fine-tuning                 | Ajustar                           |
+| Folder                      | Carpeta                           |
+| Forward Pass                | Pasada hacia delante              |
+| Function                    | Función                           |
+| Google                      | Google                            |
+| Hugging Face                | Hugging Face                      |
+| Incompatibility             | Incompatibilidad                  |
+| Inference                   | Inferencia                        |
+| Key (in a dictionary)       | Llave                             |
+| Library                     | Libreria                          |
+| Linux                       | Linux                             |
+| Load                        | Cargar                            |
+| Loss function               | Función de pérdida                |
+| Loop                        | Bucle                             |
+| macOS                       | macOS                             |
+| Model                       | Modelo                            |
+| Model Hub                   | Hub de Modelos                    |
+| Module                      | Módulo                            |
+| Natural Language Processing | Procesamiento de Lenguaje Natural |
+| Package                     | Paquete                           |
+| Package Manager             | Manejador de paquete              |
+| Padding                     | Relleno                           |
+| Parameter                   | Parámetro                         |
+| Python                      | Python                            |
+| Pytorch                     | Pytorch                           |
+| Save                        | Guardar                           |
+| Script                      | Script                            |
+| Self-Contained              | Auto-contenido                    |
+| Setup                       | Instalación                       |
+| TensorFlow                  | Tensorflow                        |
+| Terminal                    | Terminal                          |
+| Tokenizer                   | Tokenizador                       |
+| Train                       | Entrenar                          |
+| Transformer                 | Transformer                       |
+| Virtual Environment         | Ambiente Virtual                  |
+| Weight                      | Peso                              |
+| Weights                     | Pesos                             |
+| Windows                     | Windows                           |
+| Working Environment         | Ambiente de Trabajo               |
+| Workload                    | Carga de trabajo                  |
+| Workspace                   | Workspace                         |
+      
+
+## Abbreviations
+
+| Original  | Spanish     |
+|-----------|-------------|
+| NLP       | PLN         |
+| API       | API         |
+| GPU       | GPU         |
+| TPU       | TPU         |
+| ML        | ML          |
+
+## Notes
+
+Please refer to [TRANSLATING.txt](/chapters/es/TRANSLATING.txt) for a translation guide. Here are some excerpts relevant to the glossary:
+
+- Refer and contribute to the glossary frequently to stay on top of the latest choices we make. This minimizes the amount of editing that is required. Add new terms alphabetically sorted.
+
+- In certain cases is better to accept an Enlish word. Check for the correct usage of terms in computer science and commonly used terms in other publications.
+
+- Don't translate industry-accepted acronyms. e.g. TPU or GPU.
+
+- If translating a technical word, keep the choice of Spanish translation consistent. This does not apply for non-technical choices, as in those cases variety actually helps keep the text engaging.
+
+- Be exact when choosing equivalents for technical words. Package is Paquete. Library is Libreria. Don't mix and match.


### PR DESCRIPTION
The goal of this PR:

* Follow up on a suggestion made by @lewtun in a previous [PR](https://github.com/huggingface/course/pull/162)
* Provide both TRANSLATING.TXT and glossary which are adaptations from the German translation.
* Provide basic documentation for the Spanish translations conventions.
* Increase consistency and speed when translating new chapters.