### PR TITLE
Pin version of black

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 nbformat>=5.1.3
 PyYAML>=5.4.1
-black
+black==22.3.0


### PR DESCRIPTION
This PR pins version of black to make sure developers can get the right version of black on their dev environment.
Currently, requirements.txt doesn't specify a version of black. As a result, `pip install -r requirements.txt` retains black if it is already installed even if it is older version.
This will help prevent an issue like https://github.com/huggingface/course/issues/114#issuecomment-1154041570 from happening.
 
