### PR TITLE
Stop using a deprecated AdamW implementation

### DIFF
--- a/chapters/en/chapter3/2.mdx
+++ b/chapters/en/chapter3/2.mdx
@@ -27,7 +27,8 @@ Continuing with the example from the [previous chapter](/course/chapter2), here 
 
 ```python
 import torch
-from transformers import AdamW, AutoTokenizer, AutoModelForSequenceClassification
+from torch.optim import AdamW
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
 
 # Same as before
 checkpoint = "bert-base-uncased"


### PR DESCRIPTION
According to the [transformers library](https://github.com/huggingface/transformers/blob/main/src/transformers/optimization.py#L306), `transformers.AdamW` is deprecated, and instead users should use `torch.optim.AdamW`

This PR changes the import in this exact way, so that `AdamW` is still imported to the global namespace (so no other code changes are necessary)