### PR TITLE
Fix typo

### DIFF
--- a/chapters/en/chapter6/10.mdx
+++ b/chapters/en/chapter6/10.mdx
@@ -96,7 +96,7 @@ Let's test what you learned in this chapter!
 			correct: true
 		},
         {
-			text: "When a token is has the label of a given entity, any other following token with the same label is considered part of the same entity, unless it's labeled as the start of a new entity.",
+			text: "When a token has the label of a given entity, any other following token with the same label is considered part of the same entity, unless it's labeled as the start of a new entity.",
 			explain: "That's the most common way to group entities together -- it's not the only right answer, though.",
 			correct: true
 		}


### PR DESCRIPTION
Remove unnecessary "is" from an option in the quiz of Chapter 6.