### PR TITLE
tf_default_data_collator import

### DIFF
--- a/chapters/en/chapter7/3.mdx
+++ b/chapters/en/chapter7/3.mdx
@@ -533,7 +533,7 @@ def whole_word_masking_data_collator(features):
 import collections
 import numpy as np
 
-from transformers.data import tf_default_data_collator
+from transformers.data.data_collator import tf_default_data_collator
 
 wwm_probability = 0.2
 

--- a/chapters/fr/chapter7/3.mdx
+++ b/chapters/fr/chapter7/3.mdx
@@ -534,7 +534,7 @@ def whole_word_masking_data_collator(features):
 import collections
 import numpy as np
 
-from transformers.data import tf_default_data_collator
+from transformers.data.data_collator import tf_default_data_collator
 
 wwm_probability = 0.2
 

--- a/chapters/ja/chapter7/3.mdx
+++ b/chapters/ja/chapter7/3.mdx
@@ -545,7 +545,7 @@ def whole_word_masking_data_collator(features):
 import collections
 import numpy as np
 
-from transformers.data import tf_default_data_collator
+from transformers.data.data_collator import tf_default_data_collator
 
 wwm_probability = 0.2
 


### PR DESCRIPTION
The original import doesn't work. Not sure if the fix should be updating the import of exporting the `tf_default_data_collator` as per this PR or to export it in `__init__.py`