### PR TITLE
minor change to avoid confusion in ch2-5

### DIFF
--- a/chapters/en/chapter2/5.mdx
+++ b/chapters/en/chapter2/5.mdx
@@ -87,7 +87,7 @@ InvalidArgumentError: Input to reshape is a tensor with 14 values, but the reque
 
 Oh no! Why did this fail? "We followed the steps from the pipeline in section 2.
 
-The problem is that we sent a single sequence to the model, whereas 🤗 Transformers models expect multiple sentences by default. Here we tried to do everything the tokenizer did behind the scenes when we applied it to a `sequence`, but if you look closely, you'll see that it didn't just convert the list of input IDs into a tensor, it added a dimension on top of it:
+The problem is that we sent a single sequence to the model, whereas 🤗 Transformers models expect multiple sentences by default. Here we tried to do everything the tokenizer did behind the scenes when we applied it to a `sequence`, but if you look closely, you'll see that the tokenizer didn't just convert the list of input IDs into a tensor, it added a dimension on top of it:
 
 {#if fw === 'pt'}
 ```py


### PR DESCRIPTION
very small PR
### Change
Replaced "it" with "the tokenizer" on one line in ch2-5
### Motivation
I was going through the course (which is fantastic by the way), and I was a little confused by this one line; perhaps it's just me, but I think it's better to replace "it" with the exact thing here to avoid confusion.