### PR TITLE
Refactor tokenization of targets for transformers v4.22

### DIFF
--- a/chapters/en/chapter7/4.mdx
+++ b/chapters/en/chapter7/4.mdx
@@ -224,7 +224,9 @@ max_target_length = 128
 def preprocess_function(examples):
     inputs = [ex["en"] for ex in examples["translation"]]
     targets = [ex["fr"] for ex in examples["translation"]]
-    model_inputs = tokenizer(inputs, text_target=targets, max_length=max_input_length, truncation=True)
+    model_inputs = tokenizer(
+        inputs, text_target=targets, max_length=max_input_length, truncation=True
+    )
     return model_inputs
 ```
 

--- a/chapters/en/chapter7/4.mdx
+++ b/chapters/en/chapter7/4.mdx
@@ -214,11 +214,10 @@ print(tokenizer.convert_ids_to_tokens(inputs["labels"]))
 
 As we can see, using the English tokenizer to preprocess a French sentence results in a lot more tokens, since the tokenizer doesn't know any French words (except those that also appear in the English language, like "discussion").
 
-Both `inputs` and `targets` are dictionaries with our usual keys (input IDs, attention mask, etc.), so the last step is to set a `"labels"` key inside the inputs. We do this in the preprocessing function we will apply on the datasets:
+Both `inputs` is a dictionary with our usual keys (input IDs, attention mask, etc.), the last step is to define the preprocessing function we will apply on the datasets:
 
 ```python
-max_input_length = 128
-max_target_length = 128
+max_length = 128
 
 
 def preprocess_function(examples):
@@ -230,7 +229,7 @@ def preprocess_function(examples):
     return model_inputs
 ```
 
-Note that we set similar maximum lengths for our inputs and outputs. Since the texts we're dealing with seem pretty short, we use 128.
+Note that we set the same maximum length for our inputs and outputs. Since the texts we're dealing with seem pretty short, we use 128.
 
 <Tip>
 
@@ -712,7 +711,7 @@ trainer = Seq2SeqTrainer(
 Before training, we'll first look at the score our model gets, to double-check that we're not making things worse with our fine-tuning. This command will take a bit of time, so you can grab a coffee while it executes:
 
 ```python
-trainer.evaluate(max_length=max_target_length)
+trainer.evaluate(max_length=max_length)
 ```
 
 ```python out
@@ -736,7 +735,7 @@ Note that while the training happens, each time the model is saved (here, every 
 Once training is done, we evaluate our model again -- hopefully we will see some amelioration in the BLEU score!
 
 ```py
-trainer.evaluate(max_length=max_target_length)
+trainer.evaluate(max_length=max_length)
 ```
 
 ```python out

--- a/chapters/en/chapter7/4.mdx
+++ b/chapters/en/chapter7/4.mdx
@@ -172,7 +172,7 @@ You should know the drill by now: the texts all need to be converted into sets o
 from transformers import AutoTokenizer
 
 model_checkpoint = "Helsinki-NLP/opus-mt-en-fr"
-tokenizer = AutoTokenizer.from_pretrained(model_checkpoint, return_tensors="tf")
+tokenizer = AutoTokenizer.from_pretrained(model_checkpoint, return_tensors="pt")
 ```
 
 You can also replace the `model_checkpoint` with any other model you prefer from the [Hub](https://huggingface.co/models), or a local folder where you've saved a pretrained model and a tokenizer.
@@ -183,36 +183,28 @@ You can also replace the `model_checkpoint` with any other model you prefer from
 
 </Tip>
 
-The preparation of our data is pretty straightforward. There's just one thing to remember: you process the inputs as usual, but for the targets, you need to wrap the tokenizer inside the context manager `as_target_tokenizer()`.
+The preparation of our data is pretty straightforward. There's just one thing to remember; you need to ensure that the tokenizer processes the targets in the output language (here, French). You can do this by passing the targets to the `text_targets` argument of the tokenizer's `__call__` method.
 
-A context manager in Python is introduced with the `with` statement and is useful when you have two related operations to execute as a pair. The most common example of this is when you write or read a file, which is often done inside an instruction like:
-
-```
-with open(file_path) as f:
-    content = f.read()
-```
-
-Here the two related operations that are executed as a pair are the actions of opening and closing the file. The object corresponding to the opened file `f` only exists inside the indented block under the `with`; the opening happens before that block and the closing at the end of the block.
-
-In the case at hand, the context manager `as_target_tokenizer()` will set the tokenizer in the output language (here, French) before the indented block is executed, then set it back in the input language (here, English).
-
-So, preprocessing one sample looks like this:
+To see how this works, let's process one sample of each language in the training set:
 
 ```python
 en_sentence = split_datasets["train"][1]["translation"]["en"]
 fr_sentence = split_datasets["train"][1]["translation"]["fr"]
 
-inputs = tokenizer(en_sentence)
-with tokenizer.as_target_tokenizer():
-    targets = tokenizer(fr_sentence)
+inputs = tokenizer(en_sentence, text_target=fr_sentence)
+inputs
 ```
 
-If we forget to tokenize the targets inside the context manager, they will be tokenized by the input tokenizer, which in the case of a Marian model is not going to go well at all:
+```python out
+{'input_ids': [47591, 12, 9842, 19634, 9, 0], 'attention_mask': [1, 1, 1, 1, 1, 1], 'labels': [577, 5891, 2, 3184, 16, 2542, 5, 1710, 0]}
+```
+
+As we can see, the output contains the input IDs associated with the English sentence, while the IDs associated with the French one are stored in the `labels` field. If you forget to indicate that you are tokenizing labels, they will be tokenized by the input tokenizer, which in the case of a Marian model is not going to go well at all:
 
 ```python
 wrong_targets = tokenizer(fr_sentence)
 print(tokenizer.convert_ids_to_tokens(wrong_targets["input_ids"]))
-print(tokenizer.convert_ids_to_tokens(targets["input_ids"]))
+print(tokenizer.convert_ids_to_tokens(inputs["labels"]))
 ```
 
 ```python out
@@ -232,13 +224,7 @@ max_target_length = 128
 def preprocess_function(examples):
     inputs = [ex["en"] for ex in examples["translation"]]
     targets = [ex["fr"] for ex in examples["translation"]]
-    model_inputs = tokenizer(inputs, max_length=max_input_length, truncation=True)
-
-    # Set up the tokenizer for targets
-    with tokenizer.as_target_tokenizer():
-        labels = tokenizer(targets, max_length=max_target_length, truncation=True)
-
-    model_inputs["labels"] = labels["input_ids"]
+    model_inputs = tokenizer(inputs, text_target=targets, max_length=max_input_length, truncation=True)
     return model_inputs
 ```
 

--- a/chapters/en/chapter7/4.mdx
+++ b/chapters/en/chapter7/4.mdx
@@ -214,7 +214,7 @@ print(tokenizer.convert_ids_to_tokens(inputs["labels"]))
 
 As we can see, using the English tokenizer to preprocess a French sentence results in a lot more tokens, since the tokenizer doesn't know any French words (except those that also appear in the English language, like "discussion").
 
-Both `inputs` is a dictionary with our usual keys (input IDs, attention mask, etc.), the last step is to define the preprocessing function we will apply on the datasets:
+Since `inputs` is a dictionary with our usual keys (input IDs, attention mask, etc.), the last step is to define the preprocessing function we will apply on the datasets:
 
 ```python
 max_length = 128
@@ -224,7 +224,7 @@ def preprocess_function(examples):
     inputs = [ex["en"] for ex in examples["translation"]]
     targets = [ex["fr"] for ex in examples["translation"]]
     model_inputs = tokenizer(
-        inputs, text_target=targets, max_length=max_input_length, truncation=True
+        inputs, text_target=targets, max_length=max_length, truncation=True
     )
     return model_inputs
 ```

--- a/chapters/en/chapter7/5.mdx
+++ b/chapters/en/chapter7/5.mdx
@@ -276,7 +276,7 @@ tokenizer.convert_ids_to_tokens(inputs.input_ids)
 
 The special Unicode character `▁` and end-of-sequence token `</s>` indicate that we're dealing with the SentencePiece tokenizer, which is based on the Unigram segmentation algorithm discussed in [Chapter 6](/course/chapter6). Unigram is especially useful for multilingual corpora since it allows SentencePiece to be agnostic about accents, punctuation, and the fact that many languages, like Japanese, do not have whitespace characters.
 
-To tokenize our corpus, we have to deal with a subtlety associated with summarization: because our labels are also text, it is possible that they exceed the model's maximum context size. This means we need to apply truncation to both the reviews and their titles to ensure we don't pass excessively long inputs to our model. The tokenizers in 🤗 Transformers provide a nifty `as_target_tokenizer()` function that allows you to tokenize the labels in parallel to the inputs. This is typically done using a context manager inside a preprocessing function that first encodes the inputs, and then encodes the labels as a separate column. Here is an example of such a function for mT5:
+To tokenize our corpus, we have to deal with a subtlety associated with summarization: because our labels are also text, it is possible that they exceed the model's maximum context size. This means we need to apply truncation to both the reviews and their titles to ensure we don't pass excessively long inputs to our model. The tokenizers in 🤗 Transformers provide a nifty `text_target` argument that allows you to tokenize the labels in parallel to the inputs. Here is an example of how the inputs and targets are processed for mT5:
 
 ```python
 max_input_length = 512
@@ -285,19 +285,12 @@ max_target_length = 30
 
 def preprocess_function(examples):
     model_inputs = tokenizer(
-        examples["review_body"], max_length=max_input_length, truncation=True
+        examples["review_body"], text_target=examples["review_title"], max_length=max_input_length, truncation=True
     )
-    # Set up the tokenizer for targets
-    with tokenizer.as_target_tokenizer():
-        labels = tokenizer(
-            examples["review_title"], max_length=max_target_length, truncation=True
-        )
-
-    model_inputs["labels"] = labels["input_ids"]
     return model_inputs
 ```
 
-Let's walk through this code to understand what's happening. The first thing we've done is define values for `max_input_length` and `max_target_length`, which set the upper limits for how long our reviews and titles can be. Since the review body is typically much larger than the title, we've scaled these values accordingly. Then, in the  `preprocess_function()` itself we can see the reviews are first tokenized, followed by the titles with `as_target_tokenizer()`.
+Let's walk through this code to understand what's happening. The first thing we've done is define values for `max_input_length` and `max_target_length`, which set the upper limits for how long our reviews and titles can be. Since the review body is typically much larger than the title, we've scaled these values accordingly.
 
 With `preprocess_function()`, it is then a simple matter to tokenize the whole corpus using the handy `Dataset.map()` function we've used extensively throughout this course:
 

--- a/chapters/en/chapter7/5.mdx
+++ b/chapters/en/chapter7/5.mdx
@@ -286,10 +286,12 @@ max_target_length = 30
 def preprocess_function(examples):
     model_inputs = tokenizer(
         examples["review_body"],
-        text_target=examples["review_title"],
         max_length=max_input_length,
         truncation=True,
     )
+    labels = tokenizer(text_target=targets, max_length=max_target_length, truncation=True)
+    model_inputs["labels"] = labels["input_ids"]
+    model_inputs["labels_mask"] = labels["attention_mask"]
     return model_inputs
 ```
 

--- a/chapters/en/chapter7/5.mdx
+++ b/chapters/en/chapter7/5.mdx
@@ -285,7 +285,10 @@ max_target_length = 30
 
 def preprocess_function(examples):
     model_inputs = tokenizer(
-        examples["review_body"], text_target=examples["review_title"], max_length=max_input_length, truncation=True
+        examples["review_body"],
+        text_target=examples["review_title"],
+        max_length=max_input_length,
+        truncation=True,
     )
     return model_inputs
 ```


### PR DESCRIPTION
With the release of `transformers` v4.22.0, the `as_target_tokenizer` context managers have been deprecated. This PR refactors the translation and summarisation chapters to accommodate the new API