### PR TITLE
Fix question answering indices

### DIFF
--- a/chapters/en/chapter6/3b.mdx
+++ b/chapters/en/chapter6/3b.mdx
@@ -576,8 +576,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = torch.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 
@@ -592,8 +592,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = np.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 

--- a/chapters/fr/chapter6/3b.mdx
+++ b/chapters/fr/chapter6/3b.mdx
@@ -654,8 +654,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = torch.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 
@@ -670,8 +670,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = np.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 

--- a/chapters/th/chapter6/3b.mdx
+++ b/chapters/th/chapter6/3b.mdx
@@ -583,8 +583,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = torch.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 
@@ -599,8 +599,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = np.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 

--- a/chapters/vi/chapter6/3b.mdx
+++ b/chapters/vi/chapter6/3b.mdx
@@ -576,8 +576,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = torch.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 
@@ -592,8 +592,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = np.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 

--- a/chapters/zh-CN/chapter6/3b.mdx
+++ b/chapters/zh-CN/chapter6/3b.mdx
@@ -573,8 +573,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = torch.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 
@@ -589,8 +589,8 @@ for start_probs, end_probs in zip(start_probabilities, end_probabilities):
     scores = start_probs[:, None] * end_probs[None, :]
     idx = np.triu(scores).argmax().item()
 
-    start_idx = idx // scores.shape[0]
-    end_idx = idx % scores.shape[0]
+    start_idx = idx // scores.shape[1]
+    end_idx = idx % scores.shape[1]
     score = scores[start_idx, end_idx].item()
     candidates.append((start_idx, end_idx, score))
 


### PR DESCRIPTION
For consistency with earlier logic in this section, we take the second dimension of the `scores` tensor to compute the start and end indices. It has no effect on the outputs since `scores` is square, but helps avoid confusion.

Closes #282 