### PR TITLE
Refactor dataset upload in Chapter 5 / section 5

### DIFF
--- a/chapters/en/chapter5/5.mdx
+++ b/chapters/en/chapter5/5.mdx
@@ -321,34 +321,13 @@ issues_with_comments_dataset = issues_dataset.map(
 )
 ```
 
-The final step is to save the augmented dataset alongside our raw data so we can push them both to the Hub:
-
-```py
-issues_with_comments_dataset.to_json("issues-datasets-with-comments.jsonl")
-```
+The final step is to push our dataset to the Hub. Let's take a look at how we can do that.
 
 ## Uploading the dataset to the Hugging Face Hub
 
 <Youtube id="HaN6qCr_Afc"/>
 
-Now that we have our augmented dataset, it's time to push it to the Hub so we can share it with the community! To upload the dataset we'll use the [🤗 Hub library](https://github.com/huggingface/huggingface_hub), which allows us to interact with the Hugging Face Hub through a Python API. 🤗 Hub comes preinstalled with 🤗 Transformers, so we can use it directly. For example, we can use the `list_datasets()` function to get information about all the public datasets currently hosted on the Hub:
-
-```py
-from huggingface_hub import list_datasets
-
-all_datasets = list_datasets()
-print(f"Number of datasets on Hub: {len(all_datasets)}")
-print(all_datasets[0])
-```
-
-```python out
-Number of datasets on Hub: 1487
-Dataset Name: acronym_identification, Tags: ['annotations_creators:expert-generated', 'language_creators:found', 'languages:en', 'licenses:mit', 'multilinguality:monolingual', 'size_categories:10K<n<100K', 'source_datasets:original', 'task_categories:structure-prediction', 'task_ids:structure-prediction-other-acronym-identification']
-```
-
-We can see that there are currently nearly 1,500 datasets on the Hub, and the `list_datasets()` function also provides some basic metadata about each dataset repository.
-
-For our purposes, the first thing we need to do is create a new dataset repository on the Hub. To do that we need an authentication token, which can be obtained by first logging into the Hugging Face Hub with the `notebook_login()` function:
+Now that we have our augmented dataset, it's time to push it to the Hub so we can share it with the community! Uploading a dataset is very simple: just like models and tokenizers from 🤗 Transformers, we can use a `push_to_hub()` method to push a dataset. To do that we need an authentication token, which can be obtained by first logging into the Hugging Face Hub with the `notebook_login()` function:
 
 ```py
 from huggingface_hub import notebook_login
@@ -362,53 +341,11 @@ This will create a widget where you can enter your username and password, and an
 huggingface-cli login
 ```
 
-Once we've done this, we can create a new dataset repository with the `create_repo()` function:
+Once we've done this, we can upload our dataset by running:
 
 ```py
-from huggingface_hub import create_repo
-
-repo_url = create_repo(name="github-issues", repo_type="dataset")
-repo_url
+issues_with_comments_dataset.push_to_hub("github-issues")
 ```
-
-```python out
-'https://huggingface.co/datasets/lewtun/github-issues'
-```
-
-In this example, we've created an empty dataset repository called `github-issues` under the `lewtun` username (the username should be your Hub username when you're running this code!).
-
-<Tip>
-
-✏️ **Try it out!** Use your Hugging Face Hub username and password to obtain a token and create an empty repository called `github-issues`. Remember to **never save your credentials** in Colab or any other repository, as this information can be exploited by bad actors.
-
-</Tip>
-
-Next, let's clone the repository from the Hub to our local machine and copy our dataset file into it. 🤗 Hub provides a handy `Repository` class that wraps many of the common Git commands, so to clone the remote repository we simply need to provide the URL and local path we wish to clone to:
-
-```py
-from huggingface_hub import Repository
-
-repo = Repository(local_dir="github-issues", clone_from=repo_url)
-!cp issues-datasets-with-comments.jsonl github-issues/
-```
-
-By default, various file extensions (such as *.bin*, *.gz*, and *.zip*) are tracked with Git LFS so that large files can be versioned within the same Git workflow. You can find a list of tracked file extensions inside the repository's *.gitattributes* file. To include the JSON Lines format in the list, we can run the following command:
-
-```py
-repo.lfs_track("*.jsonl")
-```
-
-Then we can use `Repository.push_to_hub()` to push the dataset to the Hub:
-
-```py
-repo.push_to_hub()
-```
-
-If we navigate to the URL contained in `repo_url`, we should now see that our dataset file has been uploaded.
-
-<div class="flex justify-center">
-<img src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter5/hub-repo.png" alt="Our dataset repository on the Hugging Face Hub." width="80%"/>
-</div>
 
 From here, anyone can download the dataset by simply providing `load_dataset()` with the repository ID as the `path` argument:
 

--- a/chapters/en/chapter5/6.mdx
+++ b/chapters/en/chapter5/6.mdx
@@ -39,24 +39,12 @@ In this section we'll use embeddings to develop a semantic search engine. These 
 
 ## Loading and preparing the dataset
 
-The first thing we need to do is download our dataset of GitHub issues, so let's use the 🤗 Hub library to resolve the URL where our file is stored on the Hugging Face Hub:
-
-```py
-from huggingface_hub import hf_hub_url
-
-data_files = hf_hub_url(
-    repo_id="lewtun/github-issues",
-    filename="datasets-issues-with-comments.jsonl",
-    repo_type="dataset",
-)
-```
-
-With the URL stored in `data_files`, we can then load the remote dataset using the method introduced in [section 2](/course/chapter5/2):
+The first thing we need to do is download our dataset of GitHub issues, so let's use `load_dataset()` function as usual:
 
 ```py
 from datasets import load_dataset
 
-issues_dataset = load_dataset("json", data_files=data_files, split="train")
+issues_dataset = load_dataset("lewtun/github-issues", split="train")
 issues_dataset
 ```
 


### PR DESCRIPTION
Thanks to a bug report from a community member, I took the opportunity to refactor the dataset upload to use the much simpler `push_to_hub()` method instead of the clunky repo creation.

cc @albertvillanova @lhoestq 

Fixes https://github.com/huggingface/datasets/issues/5086