### PR TITLE
[de] Fix keywords in quiz chapter 3

### DIFF
--- a/chapters/de/chapter3/6.mdx
+++ b/chapters/de/chapter3/6.mdx
@@ -29,7 +29,7 @@ Teste, was du in diesem Kapitel gelernt hast!
             correct: true
 		},
         {
-			Text: "Surprise (Überraschung)",
+			text: "Surprise (Überraschung)",
 			explain: "Überraschung! Probier eine andere!"
 		}
 	]}
@@ -216,7 +216,7 @@ Teste, was du in diesem Kapitel gelernt hast!
             correct: true
 		},
         {
-			Text: "Es bietet mehr Funktionen zur Optimierung.",
+			text: "Es bietet mehr Funktionen zur Optimierung.",
 			explain: "Nein, die 🤗 Accelerate Bibliothek stellt keine Optimierungsfunktionen zur Verfügung."
 		}
 	]}


### PR DESCRIPTION
Noticed two `undefined` in the new render, because the `text` key was capitalized.

Relates to #43 