### PR TITLE
Typo in Chapter 2, Section 2

### DIFF
--- a/chapters/en/chapter2/2.mdx
+++ b/chapters/en/chapter2/2.mdx
@@ -257,7 +257,7 @@ outputs = model(inputs)
 ```
 {/if}
 
-Now if we look at the shape of our inputs, the dimensionality will be much lower: the model head takes as input the high-dimensional vectors we saw before, and outputs vectors containing two values (one per label):
+Now if we look at the shape of our outputs, the dimensionality will be much lower: the model head takes as input the high-dimensional vectors we saw before, and outputs vectors containing two values (one per label):
 
 ```python
 print(outputs.logits.shape)


### PR DESCRIPTION
Replace "inputs" with "outputs".