### PR TITLE
created new script for converting bilingual captions to monolingual caption

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.8
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - name: Install Python dependencies
       run: pip install black
     - name: Run Quality check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.6
+    - name: Set up Python 3.11
       uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.11
     - name: Install Python dependencies
       run: pip install black
     - name: Run Quality check

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -11,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.11
+    - name: Set up Python 3.6
       uses: actions/setup-python@v2
       with:
-        python-version: 3.11
+        python-version: 3.6
     - name: Install Python dependencies
       run: pip install black
     - name: Run Quality check

--- a/subtitles/README.md
+++ b/subtitles/README.md
@@ -27,3 +27,16 @@ python utils/generate_subtitles.py --language zh-CN --youtube_language_code zh-H
 ```
 
 Once you have the `.srt` files you can manually fix any translation errors and then open a pull request with the new files.
+
+# How to convert bilingual subtitle to monolingual subtitle
+
+# Logic
+
+The english caption line is conventionally placed at the last line of each subtitle block in srt files. So removing the last line of each subtitle block would make the bilingual subtitle a monolingual subtitle. 
+
+# Usage
+> python3 convert_bilingual_monolingual.py -i \<input_file\> -o \<output_file\>
+
+**Example**
+* For instance, the input file name is "test.cn.en.srt", and you name your output file as "output_test.cn.srt" *
+> python3 convert_bilingual_monolingual.py -i test.cn.en.srt -o output_test.cn.srt

--- a/utils/convert_bilingual_monolingual.py
+++ b/utils/convert_bilingual_monolingual.py
@@ -1,0 +1,61 @@
+#!/usr/bin/python3
+import getopt
+import re
+import sys
+
+PATTERN_TIMESTAMP = re.compile('^[0-9][0-9]:[0-9][0-9]:[0-9][0-9],[0-9][0-9][0-9] --> [0-9][0-9]:[0-9][0-9]:[0-9][0-9],[0-9][0-9][0-9]')
+PATTERN_NUM = re.compile('\\d+')
+
+
+def main(argv):
+    inputfile = ''
+    outputfile = ''
+    try:
+        opts, args = getopt.getopt(argv, "hi:o:", ["ifile=", "ofile="])
+    except getopt.GetoptError:
+        print('srt_worker.py -i <inputfile> -o <outputfile>')
+        sys.exit(2)
+    for opt, arg in opts:
+          if opt == '-h':
+             print( 'Usage: convert_bilingual_monolingual.py -i <inputfile> -o <outputfile>')
+             sys.exit(-2)
+          elif opt in ("-i", "--ifile"):
+             inputfile = arg
+          elif opt in ("-o", "--ofile"):
+             outputfile = arg
+
+    if not inputfile:
+        print('no input file is specified.\nUsage: convert_bilingual_monolingual.py -i <inputfile> -o <outputfile>')
+    elif not outputfile:
+        print('no output file is specified.\nUsage: convert_bilingual_monolingual.py -i <inputfile> -o <outputfile>')
+    else:
+        process(inputfile, outputfile)
+
+
+def process(input_file, output):
+    """
+    Convert bilingual caption file to monolingual caption, supported caption file type is srt.
+    """
+    line_count = 0
+    with open(input_file) as file:
+        with open(output, 'a') as output:
+            for line in file:
+                if line_count == 0:
+                    line_count += 1
+                    output.write(line)
+                elif PATTERN_TIMESTAMP.match(line):
+                    line_count += 1
+                    output.write(line)
+                elif line == '\n':
+                    line_count = 0
+                    output.write(line)
+                else:
+                    if line_count == 2:
+                        output.write(line)
+                    line_count += 1
+        output.close()
+        print('conversion completed!')
+
+
+if __name__ == "__main__":
+    main(sys.argv[1:])


### PR DESCRIPTION
## This pull request contains a new script written in python for converting bilingual cation to monolingual caption.

# Introduction
This script is used for removing english caption from bilingual caption files to make it monolingual.

The english caption line is conventionally placed at the last line of each caption block in srt files. So the newly created script is aimed at removing the last line of each caption block of committed bilingual caption. 

# Env
This script is developed and tested in *python v3.11*.
# Usage
> python3 convert_bilingual_monolingual.py -i \<input_file\> -o \<output_file\>

**Example**
* For instance, the input file name is "test.cn.en.srt", and you name your output file as "output_test.cn.srt" *
> python3 convert_bilingual_monolingual.py -i test.cn.en.srt -o output_test.cn.srt