### PR TITLE
Fix dead GPT model docs link.

### DIFF
--- a/chapters/de/chapter1/6.mdx
+++ b/chapters/de/chapter1/6.mdx
@@ -16,6 +16,6 @@ Diese Modelle sind am besten für Aufgaben geeignet, bei denen es um die Generie
 Zu dieser Modellfamilie gehören unter anderem:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transformerxl.html)

--- a/chapters/en/chapter1/6.mdx
+++ b/chapters/en/chapter1/6.mdx
@@ -16,6 +16,6 @@ These models are best suited for tasks involving text generation.
 Representatives of this family of models include:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transfo-xl.html)

--- a/chapters/es/chapter1/6.mdx
+++ b/chapters/es/chapter1/6.mdx
@@ -16,6 +16,6 @@ Estos modelos son más adecuados para tareas que implican la generación de text
 Los miembros de esta familia de modelos incluyen:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transformerxl.html)

--- a/chapters/fr/chapter1/6.mdx
+++ b/chapters/fr/chapter1/6.mdx
@@ -16,6 +16,6 @@ Ces modèles sont vraiment adaptés aux tâches qui impliquent la génération d
 Les modèles qui représentent le mieux la famille des modèles décodeurs sont :
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transformerxl.html)

--- a/chapters/hi/chapter1/6.mdx
+++ b/chapters/hi/chapter1/6.mdx
@@ -16,6 +16,6 @@
 मॉडल के इस परिवार के प्रतिनिधियों में शामिल हैं:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transfo-xl.html)

--- a/chapters/it/chapter1/6.mdx
+++ b/chapters/it/chapter1/6.mdx
@@ -16,6 +16,6 @@ Questi modelli sono particolarmente adatti a compiti di generazione testuale.
 Alcuni rappresentanti di questa famiglia includono:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transfo-xl.html)

--- a/chapters/ja/chapter1/6.mdx
+++ b/chapters/ja/chapter1/6.mdx
@@ -17,6 +17,6 @@
 デコーダーモデルでは以下のものが代表的です：
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transfo-xl.html)

--- a/chapters/ko/chapter1/6.mdx
+++ b/chapters/ko/chapter1/6.mdx
@@ -16,6 +16,6 @@
 디코더 모델 계열의 대표 주자들은 다음과 같습니다:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transformerxl.html)

--- a/chapters/pt/chapter1/6.mdx
+++ b/chapters/pt/chapter1/6.mdx
@@ -14,6 +14,6 @@ Esses modelos são mais adequados para tarefas que envolvem geração de texto.
 Os representantes desta família de modelos incluem:
 
 -   [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
--   [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+-   [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 -   [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 -   [Transformer XL](https://huggingface.co/transformers/model_doc/transfo-xl.html)

--- a/chapters/ru/chapter1/6.mdx
+++ b/chapters/ru/chapter1/6.mdx
@@ -16,6 +16,6 @@
 Представителями этого семейства моделей являются:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transformerxl.html)

--- a/chapters/th/chapter1/6.mdx
+++ b/chapters/th/chapter1/6.mdx
@@ -14,6 +14,6 @@
 ตัวแทนโมเดลในกลุ่มนี้ได้แก่:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transformerxl.html)

--- a/chapters/tr/chapter1/6.mdx
+++ b/chapters/tr/chapter1/6.mdx
@@ -16,6 +16,6 @@ Bu modeller, en çok metin oluşturmayı içeren görevler için uygundur.
 Bu model ailelerinin temsilcileri şunları kapsar:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transformerxl.html)

--- a/chapters/vi/chapter1/6.mdx
+++ b/chapters/vi/chapter1/6.mdx
@@ -16,6 +16,6 @@ Các mô hình này phù hợp nhất cho các tác vụ liên quan đến việ
 Một số mô hình tiêu biểu của nhóm này bao gồm:
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transfo-xl.html)

--- a/chapters/zh-CN/chapter1/6.mdx
+++ b/chapters/zh-CN/chapter1/6.mdx
@@ -17,6 +17,6 @@
 
 
 - [CTRL](https://huggingface.co/transformers/model_doc/ctrl.html)
-- [GPT](https://huggingface.co/transformers/model_doc/gpt.html)
+- [GPT](https://huggingface.co/docs/transformers/model_doc/openai-gpt)
 - [GPT-2](https://huggingface.co/transformers/model_doc/gpt2.html)
 - [Transformer XL](https://huggingface.co/transformers/model_doc/transformerxl.html)


### PR DESCRIPTION
GPT link to the model docs is dead. Added new correct link.