### PR TITLE
Add tokenizer to MLM Trainer

### DIFF
--- a/chapters/en/chapter7/3.mdx
+++ b/chapters/en/chapter7/3.mdx
@@ -723,6 +723,7 @@ trainer = Trainer(
     train_dataset=downsampled_dataset["train"],
     eval_dataset=downsampled_dataset["test"],
     data_collator=data_collator,
+    tokenizer=tokenizer,
 )
 ```
 

--- a/chapters/fr/chapter7/3.mdx
+++ b/chapters/fr/chapter7/3.mdx
@@ -728,6 +728,7 @@ trainer = Trainer(
     train_dataset=downsampled_dataset["train"],
     eval_dataset=downsampled_dataset["test"],
     data_collator=data_collator,
+    tokenizer=tokenizer,
 )
 ```
 

--- a/chapters/ja/chapter7/3.mdx
+++ b/chapters/ja/chapter7/3.mdx
@@ -738,6 +738,7 @@ trainer = Trainer(
     train_dataset=downsampled_dataset["train"],
     eval_dataset=downsampled_dataset["test"],
     data_collator=data_collator,
+    tokenizer=tokenizer,
 )
 ```
 

--- a/chapters/vi/chapter7/3.mdx
+++ b/chapters/vi/chapter7/3.mdx
@@ -723,6 +723,7 @@ trainer = Trainer(
     train_dataset=downsampled_dataset["train"],
     eval_dataset=downsampled_dataset["test"],
     data_collator=data_collator,
+    tokenizer=tokenizer,
 )
 ```
 

--- a/chapters/zh-CN/chapter7/3.mdx
+++ b/chapters/zh-CN/chapter7/3.mdx
@@ -724,6 +724,7 @@ trainer = Trainer(
     train_dataset=downsampled_dataset["train"],
     eval_dataset=downsampled_dataset["test"],
     data_collator=data_collator,
+    tokenizer=tokenizer,
 )
 ```
 

--- a/utils/generate_notebooks.py
+++ b/utils/generate_notebooks.py
@@ -201,7 +201,7 @@ def build_notebook(fname, title, output_dir="."):
         installs = ["!pip install datasets evaluate transformers[sentencepiece]"]
         if section_name in sections_with_accelerate:
             installs.append("!pip install accelerate")
-            installs.append("# To run the training on TPU, you will need to uncomment the followin line:")
+            installs.append("# To run the training on TPU, you will need to uncomment the following line:")
             installs.append(
                 "# !pip install cloud-tpu-client==0.10 torch==1.9.0 https://storage.googleapis.com/tpu-pytorch/wheels/torch_xla-1.9-cp37-cp37m-linux_x86_64.whl"
             )


### PR DESCRIPTION
Fixes an issue reported by @xianbaoqian where the pushed models on the Hub were missing the tokenizer files. The fix is to include the tokenizer in the `Trainer` before training / pushing to the Hub