### PR TITLE
Interleaving Datasets Bug Fix

### DIFF
--- a/chapters/en/chapter5/4.mdx
+++ b/chapters/en/chapter5/4.mdx
@@ -239,23 +239,20 @@ next(iter(law_dataset_streamed))
  'text': '\n461 U.S. 238 (1983)\nOLIM ET AL.\nv.\nWAKINEKONA\nNo. 81-1581.\nSupreme Court of United States.\nArgued January 19, 1983.\nDecided April 26, 1983.\nCERTIORARI TO THE UNITED STATES COURT OF APPEALS FOR THE NINTH CIRCUIT\n*239 Michael A. Lilly, First Deputy Attorney General of Hawaii, argued the cause for petitioners. With him on the brief was James H. Dannenberg, Deputy Attorney General...'}
 ```
 
-This dataset is large enough to stress the RAM of most laptops, yet we've been able to load and access it without breaking a sweat! Let's now combine the examples from the FreeLaw and PubMed Abstracts datasets with the `interleave_datasets()` function:
+This dataset is large enough to stress the RAM of most laptops, yet we've been able to load and access it without breaking a sweat! The `meta` feature in `pubmed_dataset_streamed` and `law_dataset_streamed` have different number of `keys` and therefore cannot be combined without dropping the `meta` column before combining the datasets. So we drop the `meta` column from both these datasets. Let's now combine the examples from the FreeLaw and PubMed Abstracts datasets with the `interleave_datasets()` function:
 
 ```py
 from itertools import islice
 from datasets import interleave_datasets
 
-combined_dataset = interleave_datasets([pubmed_dataset_streamed, law_dataset_streamed])
+combined_dataset = interleave_datasets([pubmed_dataset_streamed.remove_columns('meta'),
+                                        law_dataset_streamed.remove_columns('meta')])
 list(islice(combined_dataset, 2))
 ```
 
 ```python out
-[{'meta': {'pmid': 11409574, 'language': 'eng'},
-  'text': 'Epidemiology of hypoxaemia in children with acute lower respiratory infection ...'},
- {'meta': {'case_ID': '110921.json',
-   'case_jurisdiction': 'scotus.tar.gz',
-   'date_created': '2010-04-28T17:12:49Z'},
-  'text': '\n461 U.S. 238 (1983)\nOLIM ET AL.\nv.\nWAKINEKONA\nNo. 81-1581.\nSupreme Court of United States.\nArgued January 19, 1983.\nDecided April 26, 1983.\nCERTIORARI TO THE UNITED STATES COURT OF APPEALS FOR THE NINTH CIRCUIT\n*239 Michael A. Lilly, First Deputy Attorney General of Hawaii, argued the cause for petitioners. With him on the brief was James H. Dannenberg, Deputy Attorney General...'}]
+[{'text': 'Epidemiology of hypoxaemia in children with acute lower respiratory infection ...'},
+ {'text': '\n461 U.S. 238 (1983)\nOLIM ET AL.\nv.\nWAKINEKONA\nNo. 81-1581.\nSupreme Court of United States.\nArgued January 19, 1983.\nDecided April 26, 1983.\nCERTIORARI TO THE UNITED STATES COURT OF APPEALS FOR THE NINTH CIRCUIT\n*239 Michael A. Lilly, First Deputy Attorney General of Hawaii, argued the cause for petitioners. With him on the brief was James H. Dannenberg, Deputy Attorney General...'}]
 ```
 
 Here we've used the `islice()` function from Python's `itertools` module to select the first two examples from the combined dataset, and we can see that they match the first examples from each of the two source datasets.


### PR DESCRIPTION
Currently, before interleaving the pubmed_dataset_streamed and law_dataset_streamed datasets, the meta feature isn't being dropped and that's why there's a misalignment in the meta feature causing a ValueError.

Updated the section to drop the meta feature before interleaving the datasets.