### PR TITLE
[ru] Added the glossary and translation guide

### DIFF
--- a/chapters/ru/TRANSLATING.txt
+++ b/chapters/ru/TRANSLATING.txt
@@ -1,0 +1,47 @@
+1. We use the formal "you" (i.e. "вы" instead of "ты") to keep the neutral tone.
+     However, don't make the text too formal to keep it more engaging.
+
+2. Don't translate industry-accepted acronyms. e.g. TPU or GPU.
+
+3. The Russian language accepts English words especially in modern contexts more than 
+    many other languages (i.e. Anglicisms). Check for the correct usage of terms in 
+    computer science and commonly used terms in other publications.
+
+4. Russian word order is often different from English. If after translating a sentence
+    it sounds unnatural try to change the word or clause order to make it more natural.
+
+5. Beware of "false friends" in Russian and English translations. Translators are trained 
+    for years to specifically avoid false English friends and avoid anglicised translations.
+    e.g. "точность" is "accuracy", but "carefulness" is "аккуратность". For more examples refer to:
+    http://falsefriends.ru/ffslovar.htm
+
+6. Keep voice active and consistent. Don't overdo it but try to avoid a passive voice.
+
+7. Refer and contribute to the glossary frequently to stay on top of the latest
+    choices we make. This minimizes the amount of editing that is required.
+
+8. Keep POV consistent.
+
+9. Smaller sentences are better sentences. Apply with nuance.
+
+10. If translating a technical word, keep the choice of Russian translation consistent.
+   This does not apply for non-technical choices, as in those cases variety actually
+   helps keep the text engaging.
+
+11. This is merely a translation. Don't add any technical/contextual information
+    not present in the original text. Also don't leave stuff out. The creative
+    choices in composing this information were the original authors' to make.
+    Our creative choices are in doing a quality translation.
+
+12. Be exact when choosing equivalents for technical words. Package is package.
+      Library is library. Don't mix and match. Also, since both "batch" and "package"
+      can be translated as "пакет", use "батч" for "batch" and "пакет" for "package" to
+      avoid ambiguity.
+
+13. Library names are kept in the original forms, e.g. "🤗 Datasets", however,
+      the word dataset in a sentence gets a translation to "датасет".
+
+14. As a style choice prefer the imperative over constructions with auxiliary words
+      to avoid unnecessary verbosity and addressing of the reader, which seems 
+      unnatural in Russian. e.g. "см. главу X" - "See chapter X" instead of 
+      "Вы можете найти это в главе X" - "You can see this in chapter X".

--- a/chapters/ru/_toctree.yml
+++ b/chapters/ru/_toctree.yml
@@ -88,3 +88,7 @@
     title: Введение
   - local: chapter6/2
     title: Обучение токенизатора на основе существующего
+- title: Глоссарий
+  sections:
+  - local: glossary/1
+    title: Глоссарий

--- a/chapters/ru/glossary/1.mdx
+++ b/chapters/ru/glossary/1.mdx
@@ -6,14 +6,14 @@
 | Account                         | учетная запись                          |
 | Accuracy                        | accuracy                                |
 | Artificial General Intelligence | сильный искусственный интеллект         |
-| Attention                       | внимание                               |
-| Attention mask (layer)          | маска внимания (слой)                  |
-| Backward Pass                   | backward pass                           |
+| Attention                       | внимание                                |
+| Attention mask (layer)          | маска внимания (слой)                   |
+| Backward Pass\*                 | обратный проход                         |
 | Batch                           | батч                                    |
-| Bias                            | bias (смещение)                         |
+| Bias                            | смещение                                |
 | Causal Language Modeling        | каузальное языковое моделирование       |
 | Chapter                         | глава                                   |
-| Checkpoint(s)                   | checkpoint(s)                           |
+| Checkpoint(s)                   | чекпоинт                                |
 | Class                           | класс                                   |
 | Classification                  | классификация                           |
 | Code                            | код                                     |
@@ -32,17 +32,17 @@
 | Encoder                         | кодировщик                              |
 | Extractive question answering   | выделительная вопросно-ответная система |
 | F1 score                        | F1-мера                                 |
-| Feature                         | feature                                 |
+| Feature                         | признак                                 |
 | Fine-tune                       | дообучать                               |
 | Fine-tuning                     | дообучение                              |
 | Folder                          | папка / директория                      |
-| Forward Pass                    | forward pass                            |
+| Forward Pass\*                  | прямой проход                           |
 | Function                        | функция                                 |
 | Generative question answering   | генеративная вопросно-ответная система  |
 | Google                          | Google                                  |
 | Hugging Face                    | Hugging Face                            |
 | Incompatibility                 | несовместимость                         |
-| Inference                       | inference                                |
+| Inference                       | инференс                                |
 | Input                           | вход                                    |
 | Input data                      | входные данные                          |
 | Label (verb)                    | размечать                               |
@@ -69,12 +69,12 @@
 | Package Manager                 | менеджер пакетов                        |
 | Padding                         | padding / выравнивание                  |
 | Parameter                       | параметр                                |
-| Postprocessing                  | постпроцессинг                          |
-| Preprocessing                   | препроцессинг                           |
+| Postprocessing                  | постобработка / последующая обработка   |
+| Preprocessing                   | предобработка / предварительная обработка|
 | Pretraining                     | предварительное обучение / предобучение |
 | Pretrained model                | предварительно обученная модель         |
 | Pretrained model                | предобученная модель                    |
-| Prompt                          | запрос                                  |
+| Prompt                          | начальный текст                         |
 | Python                          | Python                                  |
 | Pytorch                         | Pytorch                                 |
 | Question Answering              | вопросно-ответная система               |
@@ -109,6 +109,8 @@
 | Workspace                       | Workspace                               |
 | Zero-shot classification        | zero-shot классификация                 |
 =======
+
+\* Данные термины могут употребляться взаимозаменяемо с их английской версией
 
 ## Сокращения
 

--- a/chapters/ru/glossary/1.mdx
+++ b/chapters/ru/glossary/1.mdx
@@ -1,0 +1,142 @@
+# Глоссарий
+
+|             Оригинал            |               Перевод                   |
+|---------------------------------|-----------------------------------------|
+| Abstraction                     | абстракция                              |
+| Account                         | учетная запись                          |
+| Accuracy                        | Accuracy                                |
+| Artificial General Intelligence | сильный искусственный интеллект         |
+| Attention                       | Attention                               |
+| Attention mask (layer)          | маска Attention (слой)                  |
+| Backward Pass                   | Backward Pass                           |
+| Batch                           | батч                                    |
+| Bias                            | Bias (смещение)                         |
+| Causal Language Modeling        | каузальное языковое моделирование       |
+| Chapter                         | глава                                   |
+| Checkpoint(s)                   | Checkpoint(s)                           |
+| Class                           | класс                                   |
+| Classification                  | классификация                           |
+| Code                            | код                                     |
+| Colab Notebook                  | блокнот Colab                           |
+| Command                         | команда                                 |
+| Computer Vision                 | компьютерное зрение                     |
+| Configuration                   | конфигурация                            |
+| Course                          | курс                                    |
+| Decoder                         | декодировщик                            |
+| Dependency                      | зависимость                             |
+| Deployment                      | развертывание (программного обеспечения)|
+| Development                     | разработка                              |
+| Dictionary                      | Dictionary                              |
+| Distribution                    | распределение                           |
+| Download                        | Download                                |
+| Encoder                         | кодировщик                              |
+| Extractive question answering   | выделительная вопросно-ответная система |
+| F1 score                        | F1-мера                                 |
+| Feature                         | Feature                                 |
+| Fine-tune                       | дообучать                               |
+| Fine-tuning                     | дообучение                              |
+| Folder                          | папка                                   |
+| Forward Pass                    | Forward Pass                            |
+| Function                        | функция                                 |
+| Generative question answering   | генеративная вопросно-ответная система  |
+| Google                          | Google                                  |
+| Hugging Face                    | Hugging Face                            |
+| Incompatibility                 | несовместимость                         |
+| Inference                       | Inferenz                                |
+| Input                           | вход                                    |
+| Input data                      | входные данные                          |
+| Label (verb)                    | размечать                               |
+| Label (subj)                    | метка класса                            |
+| Layer                           | слой                                    |
+| Library                         | библиотека                              |
+| Linux                           | Linux                                   |
+| Load                            | загружать                               |
+| Loss function                   | функция потерь                          |
+| Machine Learning                | машинное обучение                       |
+| macOS                           | macOS                                   |
+| Mask                            | маска                                   |
+| Mask Filling                    | предсказание замаскированного токена    |
+| Mask Token                      | токен-маска                             |
+| Masked Language Modeling        | маскированное языковое моделирование    |
+| Model                           | модель                                  |
+| Model Hub                       | Model Hub                               |
+| Module                          | модуль                                  |
+| Named Entities                  | именованные сущности                    |
+| Named Entity Recognition        | распознавание именованных сущностей     |
+| Natural Language Processing     | обработка естественного языка           |
+| Output                          | выход                                   |
+| Package                         | пакет                                   |
+| Package Manager                 | менеджер пакетов                        |
+| Padding                         | padding / выравнивание                  |
+| Parameter                       | параметр                                |
+| Postprocessing                  | постпроцессинг                          |
+| Preprocessing                   | препроцессинг                           |
+| Pretraining                     | предварительное обучение / предобучение |
+| Pretrained model                | предварительно обученная модель         |
+| Pretrained model                | предобученная модель                    |
+| Prompt                          | запрос                                  |
+| Python                          | Python                                  |
+| Pytorch                         | Pytorch                                 |
+| Question Answering              | вопросно-ответная система               |
+| Save                            | сохранять                               |
+| Sample                          | пример                                  |
+| Script                          | скрипт                                  |
+| Self-Contained                  | самостоятельный                         |
+| Sentiment analysis              | анализ тональности текста (сентимент-анализ)|
+| Sequence-to-sequence models     | Sequence-to-Sequence модель             |
+| Setup                           | установка (программы) / настройка (среды)|
+| Speech Processing               | обработка речи                          |
+| Speech Recognition              | распознавание речи                      |
+| Summarization                   | автоматическое реферирование            |
+| Target                          | целевая переменная                      |
+| Task                            | задача                                  |
+| TensorFlow                      | Tensorflow                              |
+| Terminal                        | терминал                                |
+| Text generation                 | генерация текста                        |
+| Tokenizer                       | Tokenizer (библиотека) / токенизатор    |
+| Train                           | обучение (обучать)                      |
+| Transfer Learning               | Transfer Learning / трансферное обучение|
+| Transformer                     | трансформер                             |
+| Transformer models              | архитектура трансформер                 |
+| Translation                     | (машинный) перевод                      |
+| Virtual Environment             | виртуальное окружение                   |
+| Weight                          | вес                                     |
+| Weights                         | веса                                    |
+| Windows                         | Windows                                 |
+| Working Environment             | рабочее окружение                       |
+| Workload                        | нагрузка                                |
+| Workspace                       | Workspace                               |
+| Zero-shot classification        | Zero-shot классификация                 |
+=======
+
+## Сокращения
+
+| Оригинал  | Перевод     |
+|-----------|-------------|
+| NLP       | ОЕЯ         |
+| API       | API         |
+| GPU       | GPU         |
+| TPU       | TPU         |
+| ML        | ML          |
+
+## Notes
+
+Please refer to [TRANSLATING.txt](/chapters/ru/TRANSLATING.txt) for a translation guide. Here are some excerpts relevant to the glossary:
+
+- Refer and contribute to the glossary frequently to stay on top of the latest
+  choices we make. This minimizes the amount of editing that is required.
+  Add new terms alphabetically sorted.
+
+- The Russian language accepts English words especially in modern contexts more 
+    than many other languages (i.e. Anglicisms). Check for the correct usage of 
+    terms in computer science and commonly used terms in other publications.
+
+- Don't translate industry-accepted acronyms. e.g. TPU or GPU.
+
+- If translating a technical word, keep the choice of Russian translation consistent.
+   This does not apply for non-technical choices, as in those cases variety actually
+   helps keep the text engaging.
+
+- Be exact when choosing equivalents for technical words. Package is package.
+  Library is library. Don't mix and match.
+

--- a/chapters/ru/glossary/1.mdx
+++ b/chapters/ru/glossary/1.mdx
@@ -6,8 +6,8 @@
 | Account                         | учетная запись                          |
 | Accuracy                        | accuracy                                |
 | Artificial General Intelligence | сильный искусственный интеллект         |
-| Attention                       | attention                               |
-| Attention mask (layer)          | маска attention (слой)                  |
+| Attention                       | внимание                               |
+| Attention mask (layer)          | маска внимания (слой)                  |
 | Backward Pass                   | backward pass                           |
 | Batch                           | батч                                    |
 | Bias                            | bias (смещение)                         |
@@ -81,6 +81,7 @@
 | Save                            | сохранять                               |
 | Sample                          | пример                                  |
 | Script                          | скрипт                                  |
+| Self-Attention                  | самовнимание                            |
 | Self-Contained                  | самостоятельный                         |
 | Sentiment analysis              | анализ тональности текста (сентимент-анализ)|
 | Sequence-to-sequence models     | sequence-to-sequence модель             |

--- a/chapters/ru/glossary/1.mdx
+++ b/chapters/ru/glossary/1.mdx
@@ -22,14 +22,14 @@
 | Computer Vision                 | компьютерное зрение                     |
 | Configuration                   | конфигурация                            |
 | Course                          | курс                                    |
-| Decoder                         | декодировщик                            |
+| Decoder                         | декодировщик / декодер                  |
 | Dependency                      | зависимость                             |
 | Deployment                      | развертывание (программного обеспечения)|
 | Development                     | разработка                              |
 | Dictionary                      | dictionary                              |
 | Distribution                    | распределение                           |
 | Download                        | download                                |
-| Encoder                         | кодировщик                              |
+| Encoder                         | кодировщик / энкодер                    |
 | Extractive question answering   | выделительная вопросно-ответная система |
 | F1 score                        | F1-мера                                 |
 | Feature                         | признак                                 |
@@ -67,7 +67,8 @@
 | Output                          | выход                                   |
 | Package                         | пакет                                   |
 | Package Manager                 | менеджер пакетов                        |
-| Padding                         | padding / выравнивание                  |
+| Padding (объект)                | padding                                 |
+| Padding (действие)              | дополнение                              |
 | Parameter                       | параметр                                |
 | Postprocessing                  | постобработка / последующая обработка   |
 | Preprocessing                   | предобработка / предварительная обработка|

--- a/chapters/ru/glossary/1.mdx
+++ b/chapters/ru/glossary/1.mdx
@@ -88,7 +88,7 @@
 | Setup                           | установка (программы) / настройка (среды)|
 | Speech Processing               | обработка речи                          |
 | Speech Recognition              | распознавание речи                      |
-| Summarization                   | автоматическое реферирование            |
+| Summarization                   | суммаризация                            |
 | Target                          | целевая переменная                      |
 | Task                            | задача                                  |
 | TensorFlow                      | Tensorflow                              |

--- a/chapters/ru/glossary/1.mdx
+++ b/chapters/ru/glossary/1.mdx
@@ -35,7 +35,7 @@
 | Feature                         | feature                                 |
 | Fine-tune                       | дообучать                               |
 | Fine-tuning                     | дообучение                              |
-| Folder                          | папка                                   |
+| Folder                          | папка / директория                      |
 | Forward Pass                    | forward pass                            |
 | Function                        | функция                                 |
 | Generative question answering   | генеративная вопросно-ответная система  |
@@ -113,7 +113,7 @@
 
 | Оригинал  | Перевод     |
 |-----------|-------------|
-| NLP       | ОЕЯ         |
+| NLP       | NLP         |
 | API       | API         |
 | GPU       | GPU         |
 | TPU       | TPU         |

--- a/chapters/ru/glossary/1.mdx
+++ b/chapters/ru/glossary/1.mdx
@@ -4,16 +4,16 @@
 |---------------------------------|-----------------------------------------|
 | Abstraction                     | абстракция                              |
 | Account                         | учетная запись                          |
-| Accuracy                        | Accuracy                                |
+| Accuracy                        | accuracy                                |
 | Artificial General Intelligence | сильный искусственный интеллект         |
-| Attention                       | Attention                               |
-| Attention mask (layer)          | маска Attention (слой)                  |
-| Backward Pass                   | Backward Pass                           |
+| Attention                       | attention                               |
+| Attention mask (layer)          | маска attention (слой)                  |
+| Backward Pass                   | backward pass                           |
 | Batch                           | батч                                    |
-| Bias                            | Bias (смещение)                         |
+| Bias                            | bias (смещение)                         |
 | Causal Language Modeling        | каузальное языковое моделирование       |
 | Chapter                         | глава                                   |
-| Checkpoint(s)                   | Checkpoint(s)                           |
+| Checkpoint(s)                   | checkpoint(s)                           |
 | Class                           | класс                                   |
 | Classification                  | классификация                           |
 | Code                            | код                                     |
@@ -26,23 +26,23 @@
 | Dependency                      | зависимость                             |
 | Deployment                      | развертывание (программного обеспечения)|
 | Development                     | разработка                              |
-| Dictionary                      | Dictionary                              |
+| Dictionary                      | dictionary                              |
 | Distribution                    | распределение                           |
-| Download                        | Download                                |
+| Download                        | download                                |
 | Encoder                         | кодировщик                              |
 | Extractive question answering   | выделительная вопросно-ответная система |
 | F1 score                        | F1-мера                                 |
-| Feature                         | Feature                                 |
+| Feature                         | feature                                 |
 | Fine-tune                       | дообучать                               |
 | Fine-tuning                     | дообучение                              |
 | Folder                          | папка                                   |
-| Forward Pass                    | Forward Pass                            |
+| Forward Pass                    | forward pass                            |
 | Function                        | функция                                 |
 | Generative question answering   | генеративная вопросно-ответная система  |
 | Google                          | Google                                  |
 | Hugging Face                    | Hugging Face                            |
 | Incompatibility                 | несовместимость                         |
-| Inference                       | Inferenz                                |
+| Inference                       | inference                                |
 | Input                           | вход                                    |
 | Input data                      | входные данные                          |
 | Label (verb)                    | размечать                               |
@@ -83,7 +83,7 @@
 | Script                          | скрипт                                  |
 | Self-Contained                  | самостоятельный                         |
 | Sentiment analysis              | анализ тональности текста (сентимент-анализ)|
-| Sequence-to-sequence models     | Sequence-to-Sequence модель             |
+| Sequence-to-sequence models     | sequence-to-sequence модель             |
 | Setup                           | установка (программы) / настройка (среды)|
 | Speech Processing               | обработка речи                          |
 | Speech Recognition              | распознавание речи                      |
@@ -106,7 +106,7 @@
 | Working Environment             | рабочее окружение                       |
 | Workload                        | нагрузка                                |
 | Workspace                       | Workspace                               |
-| Zero-shot classification        | Zero-shot классификация                 |
+| Zero-shot classification        | zero-shot классификация                 |
 =======
 
 ## Сокращения


### PR DESCRIPTION
The first version of the glossary and the translation guide for Russian. It has been mostly adapted from the German one since most of the guidelines apply to Russian as well.

Any discussion about the choice of terms in the glossary is very welcome here. Once everyone is happy, we can merge it into the main branch.

Issue #75 

@pdumin @blademoon