### PR TITLE
Including "index": idx under section "From inputs to Predictions"

### DIFF
--- a/chapters/en/chapter6/3.mdx
+++ b/chapters/en/chapter6/3.mdx
@@ -322,7 +322,7 @@ for idx, pred in enumerate(predictions):
     label = model.config.id2label[pred]
     if label != "O":
         results.append(
-            {"entity": label, "score": probabilities[idx][pred], "word": tokens[idx]}
+            {"entity": label, "score": probabilities[idx][pred],"index": idx, "word": tokens[idx]}
         )
 
 print(results)
@@ -380,6 +380,7 @@ for idx, pred in enumerate(predictions):
             {
                 "entity": label,
                 "score": probabilities[idx][pred],
+                "index": idx,
                 "word": tokens[idx],
                 "start": start,
                 "end": end,


### PR DESCRIPTION
The "index": idx, wasn't included in the code under the section "From inputs to Predictions", however, it was being shown as an output. Made the necessary changes.