### PR TITLE
The GPT2 course link is broken

### DIFF
--- a/chapters/en/chapter7/3.mdx
+++ b/chapters/en/chapter7/3.mdx
@@ -1035,7 +1035,7 @@ Neat -- our model has clearly adapted its weights to predict words that are more
 
 <Youtube id="0Oxphw4Q9fo"/>
 
-This wraps up our first experiment with training a language model. In [section 6](/course/en/chapter7/section6) you'll learn how to train an auto-regressive model like GPT-2 from scratch; head over there if you'd like to see how you can pretrain your very own Transformer model!
+This wraps up our first experiment with training a language model. In [section 6](/course/en/chapter7/6) you'll learn how to train an auto-regressive model like GPT-2 from scratch; head over there if you'd like to see how you can pretrain your very own Transformer model!
 
 <Tip>
 


### PR DESCRIPTION
The link `/course/en/chapter7/section6` does not exist in the course.  Corrected to `/course/en/chapter7/6`.