### PR TITLE
Typo in `Now your turn!` section in the `Unigram tokenization` section

### DIFF
--- a/chapters/en/chapter6/7.mdx
+++ b/chapters/en/chapter6/7.mdx
@@ -58,7 +58,7 @@ So, the sum of all frequencies is 210, and the probability of the subword `"ug"`
 
 <Tip>
 
-✏️ **Now your turn!** Write the code to compute the the frequencies above and double-check that the results shown are correct, as well as the total sum.
+✏️ **Now your turn!** Write the code to compute the frequencies above and double-check that the results shown are correct, as well as the total sum.
 
 </Tip>
 


### PR DESCRIPTION
Duplicated `the` was removed:

> Now your turn! Write the code to compute the ~the~ frequencies above and double-check that the results shown are correct, as well as the total sum.