### PR TITLE
Fix typos chapter 6

### DIFF
--- a/chapters/en/chapter6/2.mdx
+++ b/chapters/en/chapter6/2.mdx
@@ -46,7 +46,7 @@ Dataset({
 })
 ```
 
-We can see the dataset separates docstrings from code and suggests a tokenization of both. Here. we'll just use the `whole_func_string` column to train our tokenizer. We can look at an example of one these functions by indexing into the `train` split:
+We can see the dataset separates docstrings from code and suggests a tokenization of both. Here we'll just use the `whole_func_string` column to train our tokenizer. We can look at an example of one these functions by indexing into the `train` split:
 
 ```py
 print(raw_datasets["train"][123456]["whole_func_string"])
@@ -157,7 +157,7 @@ tokens
  'Ġnumbers', 'Ġ`', 'a', '`', 'Ġand', 'Ġ`', 'b', '`', '."', '""', 'Ċ', 'Ġ', 'Ġ', 'Ġ', 'Ġreturn', 'Ġa', 'Ġ+', 'Ġb']
 ```
 
-This tokenizer has a few special symbols, like `Ġ` and `Ċ`, which denote spaces and newlines, respectively. As we can see, this is not too efficient: the tokenizer returns individual tokens for each space, when it could group together indentation levels (since having sets of four or eight spaces is going to be very common in code). It also split the function name a bit weirdly, not being used to seeing words with the `_` character.
+This tokenizer has a few special symbols, like `Ġ` and `Ċ`, which denote spaces and newlines, respectively. As we can see, this is not too efficient: the tokenizer returns individual tokens for each space, when it could group together indentation levels (since having sets of four or eight spaces is going to be very common in code). It also splits the function name a bit weirdly, not being used to seeing words with the `_` character.
 
 Let's train a new tokenizer and see if it solves those issues. For this, we'll use the method `train_new_from_iterator()`:
 

--- a/chapters/en/chapter6/3.mdx
+++ b/chapters/en/chapter6/3.mdx
@@ -115,7 +115,7 @@ The notion of what a word is complicated. For instance, does "I'll" (a contracti
 
 </Tip>
 
-Similarly, there is a `sentence_ids()` method that we can use to map a token to the sentence it came from (though in this case, the `token_type_ids` returned by the tokenizer can give us the same information).
+Similarly, there is a `sequence_ids()` method that we can use to map a token to the sentence it came from (though in this case, the `token_type_ids` returned by the tokenizer can give us the same information).
 
 Lastly, we can map any word or token to characters in the original text, and vice versa, via the `word_to_chars()` or `token_to_chars()` and `char_to_word()` or `char_to_token()` methods. For instance, the `word_ids()` method told us that `##yl` is part of the word at index 3, but which word is it in the sentence? We can find out like this:
 
@@ -322,7 +322,7 @@ for idx, pred in enumerate(predictions):
     label = model.config.id2label[pred]
     if label != "O":
         results.append(
-            {"entity": label, "score": probabilities[idx][pred], "word": tokens[idx]}
+            {"entity": label, "score": probabilities[idx][pred], "index": idx, "word": tokens[idx]}
         )
 
 print(results)
@@ -380,6 +380,7 @@ for idx, pred in enumerate(predictions):
             {
                 "entity": label,
                 "score": probabilities[idx][pred],
+                "index": idx,
                 "word": tokens[idx],
                 "start": start,
                 "end": end,

--- a/chapters/en/chapter6/5.mdx
+++ b/chapters/en/chapter6/5.mdx
@@ -325,7 +325,7 @@ To tokenize a new text, we pre-tokenize it, split it, then apply all the merge r
 
 ```python
 def tokenize(text):
-    pre_tokenize_result = tokenizer._tokenizer.pre_tokenizer.pre_tokenize_str(text)
+    pre_tokenize_result = tokenizer.backend_tokenizer.pre_tokenizer.pre_tokenize_str(text)
     pre_tokenized_text = [word for word, offset in pre_tokenize_result]
     splits = [[l for l in word] for word in pre_tokenized_text]
     for pair, merge in merges.items():

--- a/chapters/en/chapter6/6.mdx
+++ b/chapters/en/chapter6/6.mdx
@@ -67,11 +67,11 @@ Vocabulary: ["b", "h", "p", "##g", "##n", "##s", "##u", "##gs", "hu"]
 Corpus: ("hu" "##g", 10), ("p" "##u" "##g", 5), ("p" "##u" "##n", 12), ("b" "##u" "##n", 4), ("hu" "##gs", 5)
 ```
 
-Then the next best score is shared by `("hu", "##g")` and `("hu", "##gs")` (with 1/15, compared to 1/21 for all the other pairs), so the first pair with the biggest score is merged:
+Then the next best score is the one of `("hu", "##gs")` (with 1/15), so this pair is merged:
 
 ```
-Vocabulary: ["b", "h", "p", "##g", "##n", "##s", "##u", "##gs", "hu", "hug"]
-Corpus: ("hug", 10), ("p" "##u" "##g", 5), ("p" "##u" "##n", 12), ("b" "##u" "##n", 4), ("hu" "##gs", 5)
+Vocabulary: ["b", "h", "p", "##g", "##n", "##s", "##u", "##gs", "hu", "hugs"]
+Corpus: ("hu" "##g", 10), ("p" "##u" "##g", 5), ("p" "##u" "##n", 12), ("b" "##u" "##n", 4), ("hugs", 5)
 ```
 
 and we continue like this until we reach the desired vocabulary size.
@@ -84,7 +84,7 @@ and we continue like this until we reach the desired vocabulary size.
 
 ## Tokenization algorithm[[tokenization-algorithm]]
 
-Tokenization differs in WordPiece and BPE in that WordPiece only saves the final vocabulary, not the merge rules learned. Starting from the word to tokenize, WordPiece finds the longest subword that is in the vocabulary, then splits on it. For instance, if we use the vocabulary learned in the example above, for the word `"hugs"` the longest subword starting from the beginning that is inside the vocabulary is `"hug"`, so we split there and get `["hug", "##s"]`. We then continue with `"##s"`, which is in the vocabulary, so the tokenization of `"hugs"` is `["hug", "##s"]`.
+Tokenization differs in WordPiece and BPE in that WordPiece only saves the final vocabulary, not the merge rules learned. Starting from the word to tokenize, WordPiece finds the longest subword that is in the vocabulary, then splits on it. For instance, if we use the vocabulary learned in the example above, for the word `"hugs"` the longest subword starting from the beginning that is inside the vocabulary is `"hugs"` itself, so there's no need for a split and we get the tokenization of `"hugs"` to be `["hugs"]`.
 
 With BPE, we would have applied the merges learned in order and tokenized this as `["hu", "##gs"]`, so the encoding is different.
 
@@ -354,7 +354,7 @@ Now, let's write a function that tokenizes a text:
 
 ```python
 def tokenize(text):
-    pre_tokenize_result = tokenizer._tokenizer.pre_tokenizer.pre_tokenize_str(text)
+    pre_tokenize_result = tokenizer.backend_tokenizer.pre_tokenizer.pre_tokenize_str(text)
     pre_tokenized_text = [word for word, offset in pre_tokenize_result]
     encoded_words = [encode_word(word) for word in pre_tokenized_text]
     return sum(encoded_words, [])

--- a/chapters/en/chapter6/7.mdx
+++ b/chapters/en/chapter6/7.mdx
@@ -64,20 +64,20 @@ So, the sum of all frequencies is 210, and the probability of the subword `"ug"`
 
 Now, to tokenize a given word, we look at all the possible segmentations into tokens and compute the probability of each according to the Unigram model. Since all tokens are considered independent, this probability is just the product of the probability of each token. For instance, the tokenization `["p", "u", "g"]` of `"pug"` has the probability:
 
-$$P([``p", ``u", ``g"]) = P(``p") \times P(``u") \times P(``g") = \frac{5}{210} \times \frac{36}{210} \times \frac{20}{210} = 0.000389$$
+$$P([``p", ``u", ``g"]) = P(``p") \times P(``u") \times P(``g") = \frac{17}{210} \times \frac{36}{210} \times \frac{20}{210} = 0.001322$$
 
 Comparatively, the tokenization `["pu", "g"]` has the probability:
 
-$$P([``pu", ``g"]) = P(``pu") \times P(``g") = \frac{5}{210} \times \frac{20}{210} = 0.0022676$$
+$$P([``pu", ``g"]) = P(``pu") \times P(``g") = \frac{17}{210} \times \frac{20}{210} = 0.0077098$$
 
 so that one is way more likely. In general, tokenizations with the least tokens possible will have the highest probability (because of that division by 210 repeated for each token), which corresponds to what we want intuitively: to split a word into the least number of tokens possible.
 
 The tokenization of a word with the Unigram model is then the tokenization with the highest probability. In the example of `"pug"`, here are the probabilities we would get for each possible segmentation:
 
 ```
-["p", "u", "g"] : 0.000389
-["p", "ug"] : 0.0022676
-["pu", "g"] : 0.0022676
+["p", "u", "g"] : 0.001322
+["p", "ug"] : 0.0077098
+["pu", "g"] : 0.0077098
 ```
 
 So, `"pug"` would be tokenized as `["p", "ug"]` or `["pu", "g"]`, depending on which of those segmentations is encountered first (note that in a larger corpus, equality cases like this will be rare).


### PR DESCRIPTION
Hi everybody :)
first off, thank you for the amazing course and for your work on the HF ecosystem!

Here are a couple of fixes related to chapter 6 that I hope could be helpful:

- 6.2: simple typos
- 6.3: `sequence_ids()` (rather than `sentence_ids()`) helps mapping each token to the sentence it comes from (perhaps it was called `sentence_ids()` in previous versions?); then I'm adding the `index` keys to `result` so as to align with the provided output
- 6.5: substitution of attribute `_tokenizer` with `backend_tokenizer` (despite being the same) for coherence with 6.4 where `backend_tokenizer` is referenced
- 6.6: there seems to be an issue in the computation of WordPiece scores of token pairs `('hu', '##g')` and `('hu', '##gs')`; score for `('hu', '##g')` should rather be 2/45 and this also affects the tokenization of word `'hugs'` which is referred to in the next section (also referenced in https://github.com/huggingface/course/issues/500)
- 6.7: there seems to be an issue in the computation of the unigram probabilities of word `'pug'` (also referenced in https://discuss.huggingface.co/t/chapter-6-questions/11745/30).