### PR TITLE
Chapter 2's 2.mdx format typo for model architectures

### DIFF
--- a/chapters/en/chapter2/2.mdx
+++ b/chapters/en/chapter2/2.mdx
@@ -226,13 +226,13 @@ In this diagram, the model is represented by its embeddings layer and the subseq
 
 There are many different architectures available in 🤗 Transformers, with each one designed around tackling a specific task. Here is a non-exhaustive list:
 
-- `*Model` (retrieve the hidden states)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (retrieve the hidden states)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - and others 🤗
 
 {#if fw === 'pt'}

--- a/chapters/fa/chapter2/2.mdx
+++ b/chapters/fa/chapter2/2.mdx
@@ -278,13 +278,13 @@ print(outputs.last_hidden_state.shape)
 
 تعداد زیادی از معماری‌‌های مختلف در ترنسفورمر‌های هاگینگ‌فِیس موجود است و هرکدام برای حل یک مسئله خاص طراحی شده‌اند. در این‌جا فهرست کوتاهی از‌ آنها را می‌آوریم:
 
-- `*Model` (برای دسترسی به وضعیت‌های پنهان)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (برای دسترسی به وضعیت‌های پنهان)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - و نمونه‌های دیگر در ‌هاگینگ‌فِیس
 
 {#if fw === 'pt'}

--- a/chapters/fr/chapter2/2.mdx
+++ b/chapters/fr/chapter2/2.mdx
@@ -229,13 +229,13 @@ Les têtes des modèles prennent en entrée le vecteur de grande dimension des �
 La sortie du *transformer* est envoyée directement à la tête du modèle pour être traitée.
 Dans ce diagramme, le modèle est représenté par sa couche d’enchâssement et les couches suivantes. La couche d’enchâssement convertit chaque identifiant d'entrée dans l'entrée tokenisée en un vecteur qui représente le *token* associé. Les couches suivantes manipulent ces vecteurs en utilisant le mécanisme d'attention pour produire la représentation finale des phrases.
 Il existe de nombreuses architectures différentes disponibles dans la bibliothèque 🤗 *Transformers*, chacune étant conçue autour de la prise en charge d'une tâche spécifique. En voici une liste non exhaustive :
-- `*Model` (récupérer les états cachés)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (récupérer les états cachés)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - et autres 🤗
 
 {#if fw === 'pt'}

--- a/chapters/it/chapter2/2.mdx
+++ b/chapters/it/chapter2/2.mdx
@@ -226,13 +226,13 @@ In questo diagramma, il modello è rappresentato dallo strato embeddings e dagli
 
 Esistono diverse architetture disponibili nei 🤗 Transformers, ognuna delle quali è stata progettata per affrontare un compito specifico. Ecco un elenco non esaustivo:
 
-- `*Model` (retrieve the hidden states)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (retrieve the hidden states)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - e altre 🤗
 
 {#if fw === 'pt'}

--- a/chapters/ja/chapter2/2.mdx
+++ b/chapters/ja/chapter2/2.mdx
@@ -231,13 +231,13 @@ Transformerモデルの出力は直接モデルヘッドに送られ、処理さ
 
 🤗 Transformers には多くの異なるアーキテクチャがあり、それぞれが特定のタスクに取り組むために設計されています。以下はその一部のリストです。
 
-- `*Model` (隠れ状態を取り出す)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (隠れ状態を取り出す)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 
 {#if fw === 'pt'}
 

--- a/chapters/ko/chapter2/2.mdx
+++ b/chapters/ko/chapter2/2.mdx
@@ -226,13 +226,13 @@ Transformer 모델의 출력은 처리할 모델 헤드로 바로 전달됩니�
 
 🤗 Transformer에는 다양한 아키텍처가 있으며, 각각의 아키텍처는 특정 작업을 처리하도록 설계되었습니다. 아래는 일부 아키텍처입니다.
 
-- `*Model` (retrieve the hidden states)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (retrieve the hidden states)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - 그 외 🤗
 
 {#if fw === 'pt'}

--- a/chapters/pt/chapter2/2.mdx
+++ b/chapters/pt/chapter2/2.mdx
@@ -227,13 +227,13 @@ Neste diagrama, o modelo é representado por sua camada de embeddings (vetores) 
 
 Há muitas arquiteturas diferentes disponíveis no 🤗 Transformers, com cada uma projetada em torno de uma tarefa específica. Aqui está uma lista por **algumas** destas tarefas:
 
-- `*Model` (recuperar os hidden states)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (recuperar os hidden states)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - e outros 🤗
 
 {#if fw === 'pt'}

--- a/chapters/ru/chapter2/2.mdx
+++ b/chapters/ru/chapter2/2.mdx
@@ -227,13 +227,13 @@ print(outputs.last_hidden_state.shape)
 
 В 🤗 Transformersдоступно множество различных архитектур, каждая из которых предназначена для решения конкретной задачи. Вот неполный список:
 
-- `*Model` (извлекает скрытые состояния)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (извлекает скрытые состояния)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - и другие 🤗
 
 {#if fw === 'pt'}

--- a/chapters/th/chapter2/2.mdx
+++ b/chapters/th/chapter2/2.mdx
@@ -226,13 +226,13 @@ print(outputs.last_hidden_state.shape)
 
 มีหลายสถาปัตยกรรมใน 🤗 Transformers โดยที่หนึ่งสถาปัตยกรรมถูกออกแบบมาให้ใช้กับงานเฉพาะหนึ่งงาน นี่เป็นเพียงส่วนหนึ่งจากหลายๆโมเดล :
 
-- `*Model` (retrieve the hidden states)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (retrieve the hidden states)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - and others 🤗
 
 {#if fw === 'pt'}

--- a/chapters/vi/chapter2/2.mdx
+++ b/chapters/vi/chapter2/2.mdx
@@ -226,13 +226,13 @@ Trong biểu đồ này, mô hình được biểu diễn bằng lớp nhúng c�
 
 Có nhiều kiến trúc khác nhau có sẵn trong 🤗 Transformers, với mỗi kiến trúc được thiết kế xoay quanh một tác vụ cụ thể. Đây là danh sách không đầy đủ:
 
-- `*Model` (truy xuất các trạng thái ẩn)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (truy xuất các trạng thái ẩn)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - and others 🤗
 
 {#if fw === 'pt'}

--- a/chapters/zh-CN/chapter2/2.mdx
+++ b/chapters/zh-CN/chapter2/2.mdx
@@ -228,13 +228,13 @@ Transformers模型的输出直接发送到模型头进行处理。
 
 🤗 Transformers中有许多不同的体系结构，每种体系结构都是围绕处理特定任务而设计的。以下是一个非详尽的列表：
 
-- `*Model` (retrieve the hidden states)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (retrieve the hidden states)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - 以及其他 🤗
 
 {#if fw === 'pt'}

--- a/chapters/zh-TW/chapter2/2.mdx
+++ b/chapters/zh-TW/chapter2/2.mdx
@@ -228,13 +228,13 @@ Transformers 模型的輸出直接發送到模型頭進行處理。
 
 🤗 Transformers中有許多不同的體系結構，每種體系結構都是圍繞處理特定任務而設計的。以下是一個非詳盡的列表：
 
-- `*Model` (retrieve the hidden states)
-- `*ForCausalLM`
-- `*ForMaskedLM`
-- `*ForMultipleChoice`
-- `*ForQuestionAnswering`
-- `*ForSequenceClassification`
-- `*ForTokenClassification`
+- `Model` (retrieve the hidden states)
+- `ForCausalLM`
+- `ForMaskedLM`
+- `ForMultipleChoice`
+- `ForQuestionAnswering`
+- `ForSequenceClassification`
+- `ForTokenClassification`
 - 以及其他 🤗
 
 {#if fw === 'pt'}


### PR DESCRIPTION
Fixes #559 for all languages/translations where an extra `*` was included. Likely a simple formatting error.