### PR TITLE
[Zh-CN] ch3-6 Correct translation mistake 

### DIFF
--- a/chapters/zh-CN/chapter3/6.mdx
+++ b/chapters/zh-CN/chapter3/6.mdx
@@ -15,7 +15,7 @@ Test what you learned in this chapter!
 <Question
 	choices={[
 		{
-			text: "乔伊",
+			text: "喜悦",
 			explain: "再试一次ーー这种情绪出现在那个数据集中！"
 		},
 		{


### PR DESCRIPTION
`Joy` should be translated into `喜悦`, instead of `乔伊`