### PR TITLE
changed 'perspires' to 'persists' in chapter 1 quiz

### DIFF
--- a/chapters/en/chapter1/10.mdx
+++ b/chapters/en/chapter1/10.mdx
@@ -241,7 +241,7 @@ result = classifier("This is a course about the Transformers library")
 	choices={[
 		{
 			text: "The model is a fine-tuned version of a pretrained model and it picked up its bias from it.",
-			explain: "When applying Transfer Learning, the bias in the pretrained model used perspires in the fine-tuned model.",
+			explain: "When applying Transfer Learning, the bias in the pretrained model used persists in the fine-tuned model.",
 			correct: true
 		},
 		{


### PR DESCRIPTION
# Description
Changed 'perspires' to 'persists' in Chapter 1 quiz

Fixes #585 

I'm new to open source - please let me know if anything needs to be changed or if my process is wrong. Figured I'd start with something simple. Thanks all!