### PR TITLE
solved calculatoin errors

### DIFF
--- a/chapters/en/chapter6/7.mdx
+++ b/chapters/en/chapter6/7.mdx
@@ -75,9 +75,9 @@ so that one is way more likely. In general, tokenizations with the least tokens 
 The tokenization of a word with the Unigram model is then the tokenization with the highest probability. In the example of `"pug"`, here are the probabilities we would get for each possible segmentation:
 
 ```
-["p", "u", "g"] : 0.000389
-["p", "ug"] : 0.0022676
-["pu", "g"] : 0.0022676
+["p", "u", "g"] : 0.0013215
+["p", "ug"] : 0.007701
+["pu", "g"] : 0.007701
 ```
 
 So, `"pug"` would be tokenized as `["p", "ug"]` or `["pu", "g"]`, depending on which of those segmentations is encountered first (note that in a larger corpus, equality cases like this will be rare).


### PR DESCRIPTION
As observed in the given example problem, the vocabulary frequency numbers are different and the updated answer doesn't match with the actual answer.

Vocabulary - ("h", 15) ("u", 36) ("g", 20) ("hu", 15) ("ug", 20) ("p", 17) ("pu", 17) ("n", 16)
("un", 16) ("b", 4) ("bu", 4) ("s", 5) ("hug", 15) ("gs", 5) ("ugs", 5)

Please check the values and calculate the answer, I have made the calculations and I have updated the final answer correctly. Please check with that.