### PR TITLE
Fix Score Postprocessing in QA Task for English and French Versions

### DIFF
--- a/chapters/en/chapter6/3b.mdx
+++ b/chapters/en/chapter6/3b.mdx
@@ -242,20 +242,20 @@ scores = start_probabilities[:, None] * end_probabilities[None, :]
 
 {#if fw === 'pt'}
 
-Then we'll mask the values where `start_index > end_index` by setting them to `0` (the other probabilities are all positive numbers). The `torch.triu()` function returns the upper triangular part of the 2D tensor passed as an argument, so it will do that masking for us:
+Then we'll mask the values where `start_index >= end_index` by setting them to `0` (the other probabilities are all positive numbers). The `torch.triu()` function  with `diagonal=1` returns the strictly upper triangular part of the 2D tensor passed as an argument, so it will do that masking for us:
 
 ```py
-scores = torch.triu(scores)
+scores = torch.triu(scores, diagonal=1)
 ```
 
 {:else}
 
-Then we'll mask the values where `start_index > end_index` by setting them to `0` (the other probabilities are all positive numbers). The `np.triu()` function returns the upper triangular part of the 2D tensor passed as an argument, so it will do that masking for us:
+Then we'll mask the values where `start_index >= end_index` by setting them to `0` (the other probabilities are all positive numbers). The `np.triu()` function with `k=1` returns the strictly upper triangular part of the 2D tensor passed as an argument, so it will do that masking for us:
 
 ```py
 import numpy as np
 
-scores = np.triu(scores)
+scores = np.triu(scores, k=1)
 ```
 
 {/if}

--- a/chapters/fr/chapter6/3b.mdx
+++ b/chapters/fr/chapter6/3b.mdx
@@ -288,18 +288,18 @@ scores = start_probabilities[:, None] * end_probabilities[None, :]
 
 {#if fw === 'pt'}
 
-Ensuite, nous masquerons les valeurs où `start_index > end_index` en les mettant à `0` (les autres probabilités sont toutes des nombres positifs). La fonction `torch.triu()` renvoie la partie triangulaire supérieure du tenseur 2D passé en argument, elle fera donc ce masquage pour nous :
+Ensuite, nous masquerons les valeurs où `start_index >= end_index` en les mettant à `0` (les autres probabilités sont toutes des nombres positifs). La fonction `torch.triu()` avec `diagonal=1` renvoie la partie strictement triangulaire supérieure du tenseur 2D passé en argument, elle fera donc ce masquage pour nous :
 
 ```py
-scores = torch.triu(scores)
+scores = torch.triu(scores, diagonal=1)
 ```
 
 {:else}
 
-Ensuite, nous masquerons les valeurs où `start_index > end_index` en les mettant à `0` (les autres probabilités sont toutes des nombres positifs). La fonction `np.triu()` renvoie la partie triangulaire supérieure du tenseur 2D passé en argument, elle fera donc ce masquage pour nous :
+Ensuite, nous masquerons les valeurs où `start_index >= end_index` en les mettant à `0` (les autres probabilités sont toutes des nombres positifs). La fonction `np.triu()` avec `k=1` renvoie la partie strictement triangulaire supérieure du tenseur 2D passé en argument, elle fera donc ce masquage pour nous :
 
 ```py
-scores = np.triu(scores)
+scores = np.triu(scores, k=1)
 ```
 
 {/if}


### PR DESCRIPTION
Fixed scores postprocessing for the QA task specifically when using `torch.triu`, which sometimes gives the same start and end indices if the `diagonal` parameter is not set to 1, and similarly the `np.triu` with the `k` parameter, which may give same start and end indices if `k` is not set to `0`.

* Both _English_ and _French_ version are fixed in this Pull Request.
* Both _Torch_ and _Tensorflow_ code is fixed in this Pull Request. 