### PR TITLE
Remove `get_lr()` from logs which refers to nonexistent function

### DIFF
--- a/chapters/en/chapter7/6.mdx
+++ b/chapters/en/chapter7/6.mdx
@@ -870,7 +870,6 @@ for epoch in range(num_train_epochs):
         if step % 100 == 0:
             accelerator.print(
                 {
-                    "lr": get_lr(),
                     "samples": step * samples_per_step,
                     "steps": completed_steps,
                     "loss/train": loss.item() * gradient_accumulation_steps,


### PR DESCRIPTION
`get_lr()` is called as part of this function, but the function is not declared anywhere in the script. This change removes this portion of the code since it is non-necessary.