### PR TITLE
Update 5.mdx

### DIFF
--- a/chapters/pt/chapter1/5.mdx
+++ b/chapters/pt/chapter1/5.mdx
@@ -1,4 +1,4 @@
-# Modelos decodificadores
+# Modelos codificadores
 
 <CourseFloatingBanner
     chapter={1}
@@ -7,7 +7,7 @@
 
 <Youtube id="MUqNwgPjJvQ" />
 
-Os modelos de encoder (decodificadores) usam apenas o encoder de um modelo Transformer. Em cada estágio, as camadas de atenção podem acessar todas as palavras da frase inicial. Esses modelos geralmente são caracterizados como tendo atenção "bidirecional" e são frequentemente chamados de *modelos de codificação automática*.
+Os modelos de encoder (codificadores) usam apenas o encoder de um modelo Transformer. Em cada estágio, as camadas de atenção podem acessar todas as palavras da frase inicial. Esses modelos geralmente são caracterizados como tendo atenção "bidirecional" e são frequentemente chamados de *modelos de codificação automática*.
 
 O pré-treinamento desses modelos geralmente gira em torno de corromper de alguma forma uma determinada frase (por exemplo, mascarando palavras aleatórias nela) e encarregando o modelo de encontrar ou reconstruir a frase inicial.
 


### PR DESCRIPTION
Ajuste na tradução de "encoders". São "codificadores", não "decodificadores". Decoders são "decodificadores".

Adjustment of the translation of "encoders".  They are "encoders", not "decoders".  Decoders are "decoders".