### PR TITLE
Update Chapter 4 "Part 1 completed!" page

### DIFF
--- a/chapters/en/chapter4/5.mdx
+++ b/chapters/en/chapter4/5.mdx
@@ -12,6 +12,6 @@ Congratulations on finishing the first part of this course! To recap, in this ch
 * Learned the different methods of sharing models.
 * Learned the basic structure and importance of the model card.
 
-You should now be able to fine-tune a pretrained model on a text classification problem (single or pairs of sentences) and upload the result to the Model Hub. To demonstrate mastery in this first section, try to do this for a problem and language that interests you! You can find help in the [Hugging Face forums](https://discuss.huggingface.co/) and share your project in [this topic](https://discuss.huggingface.co/t/share-your-projects/6803) once you're finished.
+To finish this first section, try to fine-tune a pretrained model on a classification problem and language that interests you! You can find help in the [Hugging Face forums](https://discuss.huggingface.co/) and share your project in [this topic](https://discuss.huggingface.co/t/share-your-projects/6803) once you're finished.
 
 We can't wait to see what you will build with this!

--- a/chapters/en/chapter4/5.mdx
+++ b/chapters/en/chapter4/5.mdx
@@ -5,8 +5,13 @@
     classNames="absolute z-10 right-0 top-0"
 />
 
-This is the end of the first part of the course! Part 2 will be released on November 15th with a big community event, see more information [here](https://huggingface.co/blog/course-launch-event).
+Congratulations on finishing the first part of this course! To recap, in this chapter you:
 
-You should now be able to fine-tune a pretrained model on a text classification problem (single or pairs of sentences) and upload the result to the Model Hub. To make sure you mastered this first section, you should do exactly that on a problem that interests you (and not necessarily in English if you speak another language)! You can find help in the [Hugging Face forums](https://discuss.huggingface.co/) and share your project in [this topic](https://discuss.huggingface.co/t/share-your-projects/6803) once you're finished.
+* Learned how to navigate the HuggingFace Hub.
+* Compared importing a pretrained model from the pipeline(), directly from the model architecture, and the [Auto* classes](https://huggingface.co/docs/transformers/model_doc/auto?highlight=auto#auto-classes).
+* Learned the different methods of sharing models.
+* Learned the basic structure and importance of the model card.
+
+You should now be able to fine-tune a pretrained model on a text classification problem (single or pairs of sentences) and upload the result to the Model Hub. To demonstrate mastery in this first section, try to do this for a problem and language that interests you! You can find help in the [Hugging Face forums](https://discuss.huggingface.co/) and share your project in [this topic](https://discuss.huggingface.co/t/share-your-projects/6803) once you're finished.
 
 We can't wait to see what you will build with this!


### PR DESCRIPTION
## Description
- - -
This pull request reformats the Chapter 4 "Part 1 completed!" page

## Changes
- - -
* Removes part 2 future post with reference to blog
* Adds list of topics covered
* Rewords final challenge paragraph

## Purpose
- - -
Since part 2 has already been added to the course, the part 2 reference is irrelevant. The list of topics covered more closely resembles the other pages closing the previous chapters. The final paragraph has been reworded to remove parentheses and simplify the instruction's convolutions.   
