### PR TITLE
[doc-fix] Add accelerate required for notebook 3/3

### DIFF
--- a/utils/generate_notebooks.py
+++ b/utils/generate_notebooks.py
@@ -131,6 +131,7 @@ def build_notebook(fname, title, output_dir="."):
     """
     sections = read_and_split_frameworks(fname)
     sections_with_accelerate = [
+        "chapter3/3",  # "Fine-tuning a model with the Trainer API or Keras",
         "chapter3/4",  # "A full training",
         "chapter7/2_pt",  # "Token classification (PyTorch)",
         "chapter7/3_pt",  # "Fine-tuning a masked language model (PyTorch)"


### PR DESCRIPTION
Hello, when I followed notebook ["Fine-tuning a model with the Trainer API or Keras"](https://huggingface.co/learn/nlp-course/en/chapter3/3?fw=pt) I encountered this issue:

<img width="945" alt="image" src="https://github.com/huggingface/course/assets/41271764/7e60f40b-0ed6-41fa-869c-ede2b654e25a">

Hope this PR will fix that in the docs
