### PR TITLE
Changing `tokenized_dataset` to `tokenized_datasets`

### DIFF
--- a/chapters/en/chapter7/6.mdx
+++ b/chapters/en/chapter7/6.mdx
@@ -383,13 +383,13 @@ Now we can use the `prepare_tf_dataset()` method to convert our datasets to Tens
 
 ```python
 tf_train_dataset = model.prepare_tf_dataset(
-    tokenized_dataset["train"],
+    tokenized_datasets["train"],
     collate_fn=data_collator,
     shuffle=True,
     batch_size=32,
 )
 tf_eval_dataset = model.prepare_tf_dataset(
-    tokenized_dataset["valid"],
+    tokenized_datasets["valid"],
     collate_fn=data_collator,
     shuffle=False,
     batch_size=32,
@@ -726,9 +726,9 @@ Let's start with the dataloaders. We only need to set the dataset's format to `"
 ```py
 from torch.utils.data.dataloader import DataLoader
 
-tokenized_dataset.set_format("torch")
-train_dataloader = DataLoader(tokenized_dataset["train"], batch_size=32, shuffle=True)
-eval_dataloader = DataLoader(tokenized_dataset["valid"], batch_size=32)
+tokenized_datasets.set_format("torch")
+train_dataloader = DataLoader(tokenized_datasets["train"], batch_size=32, shuffle=True)
+eval_dataloader = DataLoader(tokenized_datasets["valid"], batch_size=32)
 ```
 
 Next, we group the parameters so that the optimizer knows which ones will get an additional weight decay. Usually, all bias and LayerNorm weights terms are exempt from this; here's how we can do this:


### PR DESCRIPTION
The variable `tokenized_dataset` isn't initialized in the code. Leading to exception when the cell is reached. On the other hand `tokenized_datasets` var does exist. It was probably intended to be used in the first place. 

Closes: #702 