### PR TITLE
Fix code bug

### DIFF
--- a/chapters/en/chapter9/3.mdx
+++ b/chapters/en/chapter9/3.mdx
@@ -112,7 +112,7 @@ gr.Interface(
     [
         gr.Dropdown(notes, type="index"),
         gr.Slider(minimum=4, maximum=6, step=1),
-        gr.Textbox(type="number", value=1, label="Duration in seconds"),
+        gr.Textbox(type="text", value=1, label="Duration in seconds"),
     ],
     "audio",
 ).launch()


### PR DESCRIPTION
for the function 
gr.Textbox(...)
  the value of the parameter `type` was set to `number` which is not in the accepted values list. Instead changed to `text`; The function that further accepts this value was already set to cast to int

![image](https://github.com/user-attachments/assets/c231fc1a-3bb4-4aaf-9724-93a89febedf2)

