### PR TITLE
Replace Gradio deprecated methods in 3.mdx

### DIFF
--- a/chapters/en/chapter9/3.mdx
+++ b/chapters/en/chapter9/3.mdx
@@ -112,7 +112,7 @@ gr.Interface(
     [
         gr.Dropdown(notes, type="index"),
         gr.Slider(minimum=4, maximum=6, step=1),
-        gr.Textbox(type="number", value=1, label="Duration in seconds"),
+        gr.Number(value=1, label="Duration in seconds"),
     ],
     "audio",
 ).launch()
@@ -153,23 +153,14 @@ import gradio as gr
 model = pipeline("automatic-speech-recognition")
 
 
-def transcribe_audio(mic=None, file=None):
-    if mic is not None:
-        audio = mic
-    elif file is not None:
-        audio = file
-    else:
-        return "You must either provide a mic recording or a file"
+def transcribe_audio(audio):
     transcription = model(audio)["text"]
     return transcription
 
 
 gr.Interface(
     fn=transcribe_audio,
-    inputs=[
-        gr.Audio(source="microphone", type="filepath", optional=True),
-        gr.Audio(source="upload", type="filepath", optional=True),
-    ],
+    inputs=gr.Audio(type="filepath"),
     outputs="text",
 ).launch()
 ```


### PR DESCRIPTION
Replace the deprecated methods by those in Gradio 5.13.2:

1. `gr.Textbox(type="number")` --> `gr.Number()`.
2. `gr.Audio` covers both microphone and file upload without specifying `source`.

Error about `gr.Textbox(type="number"):

```
Device set to use cuda:0
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[8], line 21
     14     transcription = model(audio)["text"]
     15     return transcription
     18 gr.Interface(
     19     fn=transcribe_audio,
     20     inputs=[
---> 21         gr.Audio(source="microphone", type="filepath", optional=True),
     22         gr.Audio(source="upload", type="filepath", optional=True),
     23     ],
     24     outputs="text",
     25 ).launch()

File ~/anaconda3/envs/llm/lib/python3.12/site-packages/gradio/component_meta.py:179, in updateable.<locals>.wrapper(*args, **kwargs)
    177     return None
    178 else:
--> 179     return fn(self, **kwargs)

TypeError: Audio.__init__() got an unexpected keyword argument 'source'
```


Error about `gr.Audio(source="")`:

```
Device set to use cuda:0
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
Cell In[8], line 21
     14     transcription = model(audio)["text"]
     15     return transcription
     18 gr.Interface(
     19     fn=transcribe_audio,
     20     inputs=[
---> 21         gr.Audio(source="microphone", type="filepath", optional=True),
     22         gr.Audio(source="upload", type="filepath", optional=True),
     23     ],
     24     outputs="text",
     25 ).launch()

File ~/anaconda3/envs/llm/lib/python3.12/site-packages/gradio/component_meta.py:179, in updateable.<locals>.wrapper(*args, **kwargs)
    177     return None
    178 else:
--> 179     return fn(self, **kwargs)

TypeError: Audio.__init__() got an unexpected keyword argument 'source'
```