### PR TITLE
fix: typo in French course (chapter3/1.mdx)

### DIFF
--- a/chapters/fr/chapter3/1.mdx
+++ b/chapters/fr/chapter3/1.mdx
@@ -15,7 +15,6 @@ Mais que faire si vous souhaitez *finetuner* un modèle pré-entraîné pour vot
 * savoir comment utiliser l'API de haut niveau `Trainer` pour *finetuner* un modèle,
 * savoir comment utiliser une boucle d'entraînement personnalisée,
 * savoir comment tirer parti de la bibliothèque 🤗 *Accelerate* pour exécuter facilement cette boucle d'entraînement personnalisée sur n'importe quelle configuration distribuée.
-configuration distribuée 
 
 {:else}
 * savoir comment préparer un très grand jeu de données à partir du *Hub*, 


### PR DESCRIPTION
Hello,

Thanks a lot for this great course. I propose to fix a small typo in the French course (`chapter3/1.mdx`)

![CleanShot 2025-02-02 at 14 56 29@2x](https://github.com/user-attachments/assets/f2dd53e5-2a91-446a-be91-66278b39590a)

Thank you.

Laurent