### PR TITLE
Improve Installation Instructions for Local Development Environment

### DIFF
--- a/chapters/en/chapter0/1.mdx
+++ b/chapters/en/chapter0/1.mdx
@@ -101,10 +101,19 @@ which python
 
 ### Installing dependencies[[installing-dependencies]]
 
-As in the previous section on using Google Colab instances, you'll now need to install the packages required to continue. Again, you can install the development version of 🤗 Transformers using the `pip` package manager:
+As in the previous section on using Google Colab instances, you'll now need to install the packages required to continue. 
+Note that Google Colab comes bundled with many pre-installed packages commonly used in data science and machine learning, including PyTorch and TensorFlow.
 
-```
+In your local environment, you need to explicitly install both the 🤗 Transformers library and a machine learning framework (PyTorch or TensorFlow). You can install the development version of 🤗 Transformers with PyTorch using either of these methods:
+
+``` bash
+# Install in two separate lines
+pip install "transformers[torch]"
 pip install "transformers[sentencepiece]"
+
+# Or install both in a single line (recommended)
+pip install "transformers[torch, sentencepiece]"
 ```
+Note: If you prefer to use TensorFlow instead of PyTorch, replace `[torch]` with `[tf]` in the commands above.
 
 You're now all set up and ready to go!


### PR DESCRIPTION
## Problem
The current installation instructions don't clearly explain why code that works in Colab might fail in a local environment. This leads to confusion when users encounter errors about missing ML frameworks (PyTorch/TensorFlow) in their local setup.

## Solution
Updated the installation instructions to:
- Explain why Colab works "out of the box" (pre-installed ML frameworks)
- Make explicit that local environments need both transformers and an ML framework
- Provide clear installation commands with options for PyTorch or TensorFlow
- Show both separate and combined installation methods

## Before
```
pip install "transformers[sentencepiece]"
```

## After
```bash
# Install in two separate lines
pip install "transformers[torch]"
pip install "transformers[sentencepiece]"

# Or install both in a single line (recommended)
pip install "transformers[torch,sentencepiece]"
```
Plus added explanatory text about local vs. Colab environments.

## Testing Done
- Verified installation commands work in a fresh virtual environment
- Confirmed both PyTorch and TensorFlow options work as expected
- Tested the example code from the course with these installation methods

## Related Issues
This should help prevent common "RuntimeError: At least one of TensorFlow 2.0 or PyTorch should be installed" errors that new users encounter when moving from Colab to local development.