### PR TITLE
chore(chap11): fixing few typos

### DIFF
--- a/chapters/en/chapter11/3.mdx
+++ b/chapters/en/chapter11/3.mdx
@@ -109,7 +109,7 @@ import torch
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
 # Load dataset
-dataset = load_dataset("HuggingFaceTB/smoltalk")
+dataset = load_dataset("HuggingFaceTB/smoltalk", "all")
 
 # Configure trainer
 training_args = SFTConfig(
@@ -119,7 +119,7 @@ training_args = SFTConfig(
     learning_rate=5e-5,
     logging_steps=10,
     save_steps=100,
-    evaluation_strategy="steps",
+    eval_strategy="steps",
     eval_steps=50,
 )
 


### PR DESCRIPTION
- `evaluation_startegy` -> `eval_strategy`: remove depreciation warning
- adding `"all"` to the dataset loader to avoid raising error