### PR TITLE
fix: correct chat template examples and formatting

### DIFF
--- a/chapters/en/chapter11/2.mdx
+++ b/chapters/en/chapter11/2.mdx
@@ -56,7 +56,8 @@ Hello!<|im_end|>
 <|im_start|>assistant
 Hi! How can I help you today?<|im_end|>
 <|im_start|>user
-What's the weather?<|im_start|>assistant
+What's the weather?<|im_end|>
+<|im_start|>assistant
 ```
 
 This is using the `mistral` template format:
@@ -64,7 +65,23 @@ This is using the `mistral` template format:
 ```sh
 <s>[INST] You are a helpful assistant. [/INST]
 Hi! How can I help you today?</s>
-[INST] Hello! [/INST]
+<s>[INST] Hello! [/INST]
+Hi! How can I help you today?</s>
+<s>[INST] What's the weather? [/INST]
+```
+
+And here's the Llama 3 template format:
+
+```sh
+<|system|>
+You are a helpful assistant.</s>
+<|user|>
+Hello!</s>
+<|assistant|>
+Hi! How can I help you today?</s>
+<|user|>
+What's the weather?</s>
+<|assistant|>
 ```
 
 Key differences between these formats include:
@@ -121,7 +138,8 @@ Hello!<|im_end|>
 <|im_start|>assistant
 Hi! How can I help you today?<|im_end|>
 <|im_start|>user
-What's the weather?<|im_start|>assistant
+What's the weather?<|im_end|>
+<|im_start|>assistant
 ```
 
 Mistral template:


### PR DESCRIPTION
- Fix incorrect closing tags in ChatML examples (<|im_start|> -> <|im_end|>)
- Correct Mistral template example to show proper message order and formatting
- Add missing Llama 3 template format example with proper role tags
- Fix template examples in details section to use proper closing tags

These changes improve accuracy and clarity of the chat template documentation.