### PR TITLE
Bump_release_chapter12

### DIFF
--- a/chapters/en/_toctree.yml
+++ b/chapters/en/_toctree.yml
@@ -211,7 +211,6 @@
 
 - title: 11. Fine-tune Large Language Models
   subtitle: Use Supervised Fine-tuning and Low-Rank Adaptation to fine-tune a large language model
-  new: true
   sections:
   - local: chapter11/1
     title: Introduction
@@ -228,6 +227,23 @@
   - local: chapter11/7
     title: Exam Time!
     quiz: 11
+
+- title: 12. Build Reasoning Models
+  subtitle: Learn how to build reasoning models like DeepSeek R1
+  new: true
+  sections:
+  - local: chapter12/1
+    title: Introduction
+  - local: chapter12/2
+    title: Reinforcement Learning on LLMs
+  - local: chapter12/3
+    title: The Aha Moment in the DeepSeek R1 Paper
+  - local: chapter12/4
+    title: Implementing GRPO in TRL
+  - local: chapter12/5
+    title: Practical Exercise to Fine-tune a model with GRPO
+  - local: chapter12/6
+    title: Coming soon...
 
 - title: Course Events
   sections:

--- a/chapters/en/chapter12/1.mdx
+++ b/chapters/en/chapter12/1.mdx
@@ -1,0 +1,93 @@
+# Open R1 for Students
+
+Welcome to an exciting journey into the world of open-source AI with reinforcement learning! This chapter is designed to help students understand reinforcement learning and its role in LLMs.
+
+We will also explore [Open R1](https://github.com/huggingface/open-r1), a groundbreaking community project that's making advanced AI accessible to everyone. Specifically, this course is to help students and learners to use and contribute to [Open R1](https://github.com/huggingface/open-r1).
+
+## What You'll Learn
+
+In this chapter, we'll break down complex concepts into easy-to-understand pieces and show you how you can be part of this exciting project to make LLMs reason on complex problems. 
+
+LLMs have shown excellent performance on many generative tasks. However, up until recently they have struggled on complex problems that require reasoning. For example, they struggle to deal with puzzles or math problems that require multiple steps of reasoning. 
+
+Open R1 is a project that aims to make LLMs reason on complex problems. It does this by using reinforcement learning to encourage LLMs to 'think' and reason. 
+
+In simple terms, the model is train to generate thoughts as well as outputs, and to structure these thoughts and outputs so that they can be handled separately by the user. 
+
+Let's take a look at an example. A we gave ourself the task of solving the following problem, we might think like this:
+
+```sh
+Problem: "I have 3 apples and 2 oranges. How many pieces of fruit do I have in total?"
+
+Thought: "I need to add the number of apples and oranges to get the total number of pieces of fruit."
+
+Answer: "5"
+```
+
+We can then structure this thought and answer so that they can be handled separately by the user. For reasoning tasks, LLMs can be trained to generate thoughts and answers in the following format:
+
+```sh
+<think>I need to add the number of apples and oranges to get the total number of pieces of fruit.</think>
+5
+```
+
+As a user, we can then extract the thought and answer from the model's output and use them to solve the problem.
+
+## Why This Matters for Students
+
+As a student, understanding Open R1 and the role of reinforcement learning in LLMs is valuable because:
+- It shows you how cutting-edge AI is developed
+- It gives you hands-on opportunities to learn and contribute
+- It helps you understand where AI technology is heading
+- It opens doors to future career opportunities in AI
+
+## Chapter Overview
+
+This chapter is divided into four sections, each focusing on a different aspect of Open R1:
+
+### 1️⃣ Introduction to Reinforcement Learning and its Role in LLMs
+We'll explore the basics of Reinforcement Learning (RL) and its role in training LLMs.
+- What is RL?
+- How is RL used in LLMs?
+- What is DeepSeek R1?
+- What are the key innovations of DeepSeek R1?
+
+### 2️⃣ Understanding the DeepSeek R1 Paper
+We'll break down the research paper that inspired [Open R1](https://huggingface.co/open-r1):
+- Key innovations and breakthroughs
+- The training process and architecture
+- Results and their significance
+
+### 3️⃣ Implementing GRPO in TRL
+We'll get practical with code examples:
+- How to use the Transformer Reinforcement Learning (TRL) library
+- Setting up GRPO training
+
+### 4️⃣ Practical use case to align a model
+We'll look at a practical use case to align a model using Open R1.
+- How to train a model using GRPO in TRL
+- Share your model on the [Hugging Face Hub](https://huggingface.co/models)
+
+## Prerequisites
+
+To get the most out of this chapter, it's helpful to have:
+- Solid understanding of Python programming
+- Familiarity with machine learning concepts
+- Interest in AI and language models
+
+Don't worry if you're missing some of these – we'll explain key concepts as we go along! 🚀
+
+<Tip>
+
+If you don't have all the prerequisites, check out this [course](chapter1/1.mdx) from units 1 to 11
+
+</Tip>
+
+## How to Use This Chapter
+
+1. **Read Sequentially**: The sections build on each other, so it's best to read them in order
+2. **Share Notes**: Write down key concepts and questions and discuss them with in the community in [Discord](https://discord.gg/F3vZujJH)
+3. **Try the Code**: When we get to practical examples, try them yourself
+4. **Join the Community**: Use the resources we provide to connect with other learners
+
+Let's begin our exploration of Open R1 and discover how you can be part of making AI more accessible to everyone! 🚀

--- a/chapters/en/chapter12/2.mdx
+++ b/chapters/en/chapter12/2.mdx
@@ -1,0 +1,244 @@
+# Introduction to Reinforcement Learning and its Role in LLMs
+
+Welcome to the first page! 
+
+We're going to start our journey into the exciting world of Reinforcement Learning (RL) and discover how it's revolutionizing the way we train Language Models like the ones you might use every day.
+
+<Tip>
+In this chapter, we are focusing on reinforcement learning for language models. However, reinforcement learning is a broad field with many applications beyond language models. If you're interested in learning more about reinforcement learning, you should check out the [Deep Reinforcement Learning course](https://huggingface.co/courses/deep-rl-course/en/unit1/introduction).
+</Tip>
+
+This page will give you a friendly and clear introduction to RL, even if you've never encountered it before. We'll break down the core ideas and see why RL is becoming so important in the field of Large Language Models (LLMs).
+
+## What is Reinforcement Learning (RL)?
+
+Imagine you're training a dog. You want to teach it to sit. You might say "Sit!" and then, if the dog sits, you give it a treat and praise. If it doesn't sit, you might gently guide it or just try again. Over time, the dog learns to associate sitting with the positive reward (treat and praise) and is more likely to sit when you say "Sit!" again. In reinforcement learning, we refer to this feedback as a **reward**.
+
+That, in a nutshell, is the basic idea behind Reinforcement Learning! Instead of a dog, we have a **language model** (in reinforcement learning, we call it an **agent**), and instead of you, we have the **environment** that gives feedback.
+
+![RL terms Process](https://huggingface.co/reasoning-course/images/resolve/main/grpo/3.jpg)
+
+Let's break down the key pieces of RL:
+
+### Agent
+
+This is our learner. In the dog example, the dog is the agent. In the context of LLMs, the LLM itself becomes the agent we want to train. The agent is the one making decisions and learning from the environment and its rewards.
+
+### Environment
+
+This is the world the agent lives in and interacts with. For the dog, the environment is your house and you. For an LLM, the environment is a bit more abstract – it could be the users it interacts with, or a simulated scenario we set up for it. The environment provides feedback to the agent. 
+
+### Action
+
+These are the choices the agent can make in the environment. The dog's actions are things like "sit", "stand", "bark", etc. For an LLM, actions could be generating words in a sentence, choosing which answer to give to a question, or deciding how to respond in a conversation.
+
+### Reward
+
+This is the feedback the environment gives to the agent after it takes an action. Rewards are usually numbers. 
+
+**Positive rewards** are like treats and praise – they tell the agent "good job, you did something right!". 
+
+**Negative rewards** (or penalties) are like a gentle "no" – they tell the agent "that wasn't quite right, try something else". For the dog, the treat is the reward. 
+
+For an LLM, rewards are designed to reflect how well the LLM is doing at a specific task – maybe it's how helpful, truthful, or harmless its response is.
+
+### Policy
+
+This is the agent's strategy for choosing actions. It's like the dog's understanding of what it should do when you say "Sit!". In RL, the policy is what we're really trying to learn and improve. It's a set of rules or a function that tells the agent what action to take in different situations. Initially, the policy might be random, but as the agent learns, the policy becomes better at choosing actions that lead to higher rewards.
+
+## The RL Process: Trial and Error
+
+![RL Process](https://huggingface.co/reasoning-course/images/resolve/main/grpo/1.jpg)
+
+Reinforcement Learning happens through a process of trial and error:
+
+| Step | Process | Description |
+|------|---------|-------------|
+| 1. Observation | The agent observes the environment | The agent takes in information about its current state and surroundings |
+| 2. Action | The agent takes an action based on its current policy | Using its learned strategy (policy), the agent decides what to do next |
+| 3. Feedback | The environment gives the agent a reward | The agent receives feedback on how good or bad its action was |
+| 4. Learning | The agent updates its policy based on the reward | The agent adjusts its strategy - reinforcing actions that led to high rewards and avoiding those that led low rewards |
+| 5. Iteration | Repeat the process | This cycle continues, allowing the agent to continuously improve its decision-making |
+
+Think about learning to ride a bike. You might wobble and fall at first (negative reward!). But when you manage to balance and pedal smoothly, you feel good (positive reward!). You adjust your actions based on this feedback – leaning slightly, pedaling faster, etc. – until you learn to ride well. RL is similar – it's about learning through interaction and feedback.
+
+## Role of RL in Large Language Models (LLMs)
+
+Now, why is RL so important for Large Language Models? 
+
+Well, training really good LLMs is tricky. We can train them on massive amounts of text from the internet, and they become very good at predicting the next word in a sentence. This is how they learn to generate fluent and grammatically correct text, as we learned in [chapter 2](/chapters/en/chapter2/1).
+
+However, just being fluent isn't enough. We want our LLMs to be more than just good at stringing words together. We want them to be:
+
+* **Helpful:** Provide useful and relevant information.  
+* **Harmless:** Avoid generating toxic, biased, or harmful content.  
+* **Aligned with Human Preferences:** Respond in ways that humans find natural, helpful, and engaging.
+
+Pre-training LLM methods, which mostly rely on predicting the next word from text data, sometimes fall short on these aspects.
+
+Whilst supervised training is excellent at producing structured outputs, it can be less effective at producing helpful, harmless, and aligned responses. We explore supervised training in [chapter 11](/chapters/en/chapter11/1).
+
+Fine-tuned models might generate fluent and structured text that is still factually incorrect, biased, or doesn't really answer the user's question in a helpful way.
+
+**Enter Reinforcement Learning\!** RL gives us a way to fine-tune these pre-trained LLMs to better achieve these desired qualities. It's like giving our LLM dog extra training to become a well-behaved and helpful companion, not just a dog that knows how to bark fluently\!
+
+## Reinforcement Learning from Human Feedback (RLHF)
+
+A very popular technique for aligning language models is **Reinforcement Learning from Human Feedback (RLHF)**. In RLHF, we use human feedback as a proxy for the "reward" signal in RL. Here's how it works:
+
+1. **Get Human Preferences:** We might ask humans to compare different responses generated by the LLM for the same input prompt and tell us which response they prefer. For example, we might show a human two different answers to the question "What is the capital of France?" and ask them "Which answer is better?".
+
+2. **Train a Reward Model:** We use this human preference data to train a separate model called a **reward model**. This reward model learns to predict what kind of responses humans will prefer. It learns to score responses based on helpfulness, harmlessness, and alignment with human preferences.
+
+3. **Fine-tune the LLM with RL:** Now we use the reward model as the environment for our LLM agent. The LLM generates responses (actions), and the reward model scores these responses (provides rewards). In essence, we're training the LLM to produce text that our reward model (which learned from human preferences) thinks is good.
+
+![RL Basic Concept](https://huggingface.co/reasoning-course/images/resolve/main/grpo/2.jpg)  
+
+From a general perspective, let's look at the benefits of using RL in LLMs:
+
+| Benefit | Description |
+|---------|-------------|
+| Improved Control | RL allows us to have more control over the kind of text LLMs generate. We can guide them to produce text that is more aligned with specific goals, like being helpful, creative, or concise. |
+| Enhanced Alignment with Human Values | RLHF, in particular, helps us align LLMs with complex and often subjective human preferences. It's hard to write down rules for "what makes a good answer," but humans can easily judge and compare responses. RLHF lets the model learn from these human judgments. |
+| Mitigating Undesirable Behaviors | RL can be used to reduce negative behaviors in LLMs, such as generating toxic language, spreading misinformation, or exhibiting biases. By designing rewards that penalize these behaviors, we can nudge the model to avoid them. |
+
+Reinforcement Learning from Human Feedback has been used to train many of the most popular LLMs today, such as OpenAI's GPT-4, Google's Gemini, and DeepSeek's R1. There are a wide range of techniques for RLHF, with varying degrees of complexity and sophistication. In this chapter, we will focus on Group Relative Policy Optimization (GRPO), which is a technique for RLHF that has been shown to be effective at training LLMs that are helpful, harmless, and aligned with human preferences.
+
+## Why should we care about GRPO (Group Relative Policy Optimization)?
+
+There are many techniques for RLHF but this course is focused on GRPO because it represents a significant advancement in reinforcement learning for language models.
+
+Let's briefly consider two of other popular techniques for RLHF:
+
+- Proximal Policy Optimization (PPO)
+- Direct Preference Optimization (DPO)
+
+Proximal Policy Optimization (PPO) was one of the first highly effective techniques for RLHF. It uses a policy gradient method to update the policy based on the reward from a separate reward model.
+
+Direct Preference Optimization (DPO) was later developed as a simpler technique that eliminates the need for a separate reward model using preference data directly. Essentially, framing the problem as a classification task between the chosen and rejected responses.
+
+<Tip>
+
+DPO and PPO are complex reinforcement learning algorithms in their own right, which we will not cover in this course. If you're interested in learning more about them, you can check out the following resources:
+
+- [Proximal Policy Optimization](https://huggingface.co/docs/trl/main/en/ppo_trainer)
+- [Direct Preference Optimization](https://huggingface.co/docs/trl/main/en/dpo_trainer)
+
+</Tip>
+
+Unlike DPO and PPO, GRPO groups similar samples together and compares them as a group. The group-based approach provides more stable gradients and better convergence properties compared to other methods.
+
+GRPO does not use preference data like DPO, but instead compares groups of similar samples using a reward signal from a model or function.
+
+GRPO is flexible in how it obtains reward signals - it can work with a reward model (like PPO does) but doesn't strictly require one. This is because GRPO can incorporate reward signals from any function or model that can evaluate the quality of responses.
+
+For example, we could use a length function to reward shorter responses, a mathematical solver to verify solution correctness, or a factual correctness function to reward responses that are more factually accurate. This flexibility makes GRPO particularly versatile for different types of alignment tasks.
+
+---
+
+Congratulations on completing Module 1\! You've now got a solid introduction to Reinforcement Learning and its crucial role in shaping the future of Large Language Models. You understand the basic concepts of RL, why it's used for LLMs, and you've been introduced to GRPO, a key algorithm in this field.
+
+In the next module, we'll get our hands dirty and dive into the DeepSeek R1 paper to see these concepts in action\!
+
+## Quiz
+
+### 1. What are the key components of Reinforcement Learning?
+
+<Question
+    choices={[
+        {
+            text: "Agent, Environment, Action, Reward, and Policy",
+            explain: "Correct! These are the fundamental components that make up a reinforcement learning system.",
+            correct: true
+        },
+        {
+            text: "Model, Data, Loss Function, and Optimizer",
+            explain: "These are components more commonly associated with supervised learning."
+        },
+        {
+            text: "Input, Output, and Hidden Layers",
+            explain: "These are components of neural network architecture, not specifically RL components."
+        }
+    ]}
+/>
+
+### 2. What is the main advantage of RLHF for training language models?
+
+<Question
+    choices={[
+        {
+            text: "It helps align models with human preferences and values",
+            explain: "Correct! RLHF uses human feedback to guide models toward more helpful, harmless, and aligned behavior.",
+            correct: true
+        },
+        {
+            text: "It makes models generate text faster",
+            explain: "RLHF isn't primarily about improving generation speed."
+        },
+        {
+            text: "It reduces the model's memory usage",
+            explain: "RLHF doesn't focus on model efficiency or memory optimization."
+        }
+    ]}
+/>
+
+### 3. In the context of RL for LLMs, what represents an "action"?
+
+<Question
+    choices={[
+        {
+            text: "Generating words or choosing responses in a conversation",
+            explain: "Correct! For LLMs, actions typically involve text generation decisions.",
+            correct: true
+        },
+        {
+            text: "Updating model weights",
+            explain: "This is part of the training process, not an action in the RL context."
+        },
+        {
+            text: "Processing input tokens",
+            explain: "This is part of the model's operation, not an action in the RL context."
+        }
+    ]}
+/>
+
+### 4. What is the role of the reward in RL training of language models?
+
+<Question
+    choices={[
+        {
+            text: "To provide feedback on how well the model's responses align with desired behavior",
+            explain: "Correct! Rewards guide the model toward generating more helpful, truthful, and appropriate responses.",
+            correct: true
+        },
+        {
+            text: "To measure the model's vocabulary size",
+            explain: "Rewards aren't used to evaluate vocabulary knowledge."
+        },
+        {
+            text: "To determine the model's training speed",
+            explain: "Rewards provide feedback on response quality, not training efficiency."
+        }
+    ]}
+/>
+
+### 5. What is a reward in the context of RL for LLMs?
+
+<Question
+    choices={[
+        {
+            text: "A numerical score that measures the quality of a response",
+            explain: "Correct! Rewards provide feedback on response quality, guiding the model toward desired behavior.",
+            correct: true
+        },
+        {
+            text: "A function that generates responses",
+            explain: "Rewards are feedback on response quality, not the generation process itself."
+        },
+        {
+            text: "A model that evaluates the quality of responses",
+            explain: "Rewards are feedback on response quality, not an evaluation model."
+        }
+    ]}
+/>
+

--- a/chapters/en/chapter12/3.mdx
+++ b/chapters/en/chapter12/3.mdx
@@ -1,0 +1,333 @@
+# Understanding the DeepSeek R1 Paper
+
+This chapter is a crash course paper reading. We will walk through the paper in simple terms, and then we will break down the key concepts and takeaways.
+
+DeepSeek R1 represents a significant advancement in language model training, particularly in developing reasoning capabilities through reinforcement learning. The paper introduces a new reinforcement learning algorithm called Group Relative Policy Optimization (GRPO).
+
+![DeepSeek R1 Overview](https://huggingface.co/reasoning-course/images/resolve/main/grpo/4.png)
+
+In the next chapter, we will build on this knowledge and implement GRPO in practice.
+
+The initial goal of the paper was to explore whether pure reinforcement learning could develop reasoning capabilities without supervised fine-tuning. 
+
+<Tip>
+Up until that point, all the popular LLMs required some supervised fine-tuning, which we explored in [chapter 11](/chapters/en/chapter11/1).
+</Tip>
+
+## The Breakthrough 'Aha' Moment
+
+![The 'Aha Moment'](https://huggingface.co/reasoning-course/images/resolve/main/grpo/9.png)
+
+One of the most remarkable discoveries in R1-Zero's training was the emergence of a phenomenon known as the "Aha Moment." This phenomenon is somewhat similar to how humans experience sudden realizations while problem-solving. Here's how it works:
+
+1. Initial Attempt: The model makes an initial attempt at solving a problem
+2. Recognition: It recognizes potential errors or inconsistencies
+3. Self-Correction: It adjusts its approach based on this recognition
+4. Explanation: It can explain why the new approach is better
+
+This breakthrough resonates with learners and feels like a "Eureka" moment. It demonstrates learning rather than mere memorization, so let's take a moment to imagine what it feels like to have an "Aha" moment.
+
+For example, imagine you're trying to solve a puzzle:
+- First try: "This piece should go here based on the color"
+- Recognition: "But wait, the shape doesn't quite fit"
+- Correction: "Ah, it actually belongs over there"
+- Explanation: "Because both the color and shape pattern match in this position"
+
+This ability emerged naturally from RL training, without being explicitly programmed, demonstrating learning rather than mere memorization of a process from the training data.
+
+The easiest way to understand the 'Aha' moment is to see it in action. Let's take a look at an example. In the chat below, we ask the model to solve a problem and the UI shows the model's thought process as it solves the problem.
+
+<iframe
+    src="https://reasoning-course-deepseek-ai-deepseek-r1-distill-0f5fad4.hf.space/"
+	frameborder="0"
+	width="850"
+	height="450"
+></iframe>
+
+If you want to try Deepseek's R1, you can also check out [Hugging Chat](https://huggingface.co/chat/models/deepseek-ai/DeepSeek-R1-Distill-Qwen-32B).
+
+## The Training Process
+
+Training R1 was a multi-phase process. Let's break down the phases and the key innovations in each phase.
+
+The final process results in two models:
+- DeepSeek-R1-Zero: A model trained purely using reinforcement learning.
+- DeepSeek-R1: A model that builds on the foundation of DeepSeek-R1-Zero and adds supervised fine-tuning.
+
+| Feature | DeepSeek-R1-Zero | DeepSeek-R1 |
+|---------|------------------|--------------|
+| Training Approach | Pure RL | Multi-phase (SFT + RL) |
+| Fine-tuning | None | Supervised fine-tuning |
+| Reasoning Capability | Emergent | Enhanced |
+| AIME Performance | 71.0% | 79.8% |
+| Key Characteristics | Strong reasoning but readability issues | Better language consistency and readability |
+
+While DeepSeek-R1-Zero demonstrates the potential of pure reinforcement learning for developing reasoning capabilities, DeepSeek-R1 builds upon this foundation with a more balanced approach that prioritizes both reasoning performance and usability.
+
+The training process involves four phases:
+
+1. Cold Start Phase
+2. Reasoning RL Phase
+3. Rejection Sampling Phase
+4. Diverse RL Phase
+
+Let's break down each phase:
+
+### Cold Start Phase (Quality Foundation)
+
+![Cold Start Phase](https://huggingface.co/reasoning-course/images/resolve/main/grpo/5.png)
+
+This phase is designed to establish a strong foundation for the model's readability and response quality. It uses a small dataset of high-quality samples from R1-Zero to fine-tune the V3-Base model. Starting with the DeepSeek-V3-Base model, the team used thousands of validated, high-quality samples from R1-Zero for supervised fine-tuning. This innovative approach uses a small but high quality dataset to establish strong baseline readability and response quality.
+
+### Reasoning RL Phase (Capability Building)
+
+![Reasoning RL Phase](https://huggingface.co/reasoning-course/images/resolve/main/grpo/6.png)
+
+The Reasoning RL Phase focuses on developing core reasoning capabilities across domains including mathematics, coding, science, and logic. This phase employs rule-based reinforcement learning, with rewards directly tied to solution correctness. 
+
+Crucially, all the tasks in this phase are 'verifiable' so we can check if the model's answer is correct or not. For example, in the case of mathematics, we can check if the model's answer is correct by using a mathematical solver.
+
+What makes this phase particularly innovative is its direct optimization approach that eliminates the need for a separate reward model, streamlining the training process.
+
+### Rejection Sampling Phase (Quality Control)
+
+![Rejection Sampling Phase](https://huggingface.co/reasoning-course/images/resolve/main/grpo/7.png)
+
+During the Rejection Sampling Phase, the model generates samples which are then filtered through a quality control process. DeepSeek-V3 serves as the quality judge, evaluating outputs across a broad scope that extends beyond pure reasoning tasks. The filtered data is then used for supervised fine-tuning. This phase's innovation lies in its ability to combine multiple quality signals to ensure high-standard outputs.
+
+### Diverse RL Phase (Broad Alignment)
+
+![Diverse RL Phase](https://huggingface.co/reasoning-course/images/resolve/main/grpo/8.png)
+
+The final Diverse RL Phase tackles multiple task types using a sophisticated hybrid approach. For deterministic tasks, it employs rule-based rewards, while subjective tasks are evaluated through LLM feedback. This phase aims to achieve human preference alignment through its innovative hybrid reward approach, combining the precision of rule-based systems with the flexibility of language model evaluation.
+
+## The Algorithm: Group Relative Policy Optimization (GRPO)
+
+Now that we have a good understanding of the training process, let's look at the algorithm that was used to train the model.
+
+The authors describe GRPO as a breakthrough in model fine-tuning:
+
+![GRPO Process](https://huggingface.co/reasoning-course/images/resolve/main/grpo/10.png)
+
+GRPO's novelty lies in its capacity to "directly optimize for preference rectification." This signifies a more direct and efficient route to aligning the model with desired outputs, contrasting with traditional Reinforcement Learning algorithms such as PPO. Let's break down how GRPO works through its three main components.
+
+### Group Formation: Creating Multiple Solutions
+
+The first step in GRPO is remarkably intuitive - it's similar to how a student might solve a difficult problem by trying multiple approaches. When given a prompt, the model doesn't just generate one response; instead, it creates multiple attempts at solving the same problem (usually 4, 8, or 16 different attempts).
+
+Imagine you're teaching a model to solve math problems. For a question about counting chickens on a farm, the model might generate several different solutions:
+- One solution might break down the problem step by step: first counting total chickens, then subtracting roosters, and finally accounting for non-laying hens
+- Another might use a different but equally valid approach
+- Some attempts might contain mistakes or less efficient solutions
+
+All these attempts are kept together as a group, much like having multiple students' solutions to compare and learn from.
+
+![Group Formation](https://huggingface.co/reasoning-course/images/resolve/main/grpo/11.jpg)
+
+### Preference Learning: Understanding What Makes a Good Solution
+
+This is where GRPO really shines in its simplicity. Unlike other methods for RLHF that need always require a separate reward model to predict how good a solution might be, GRPO can use any function or model to evaluate the quality of a solution. For example, we could use a length function to reward shorter responses or a mathematical solver to reward accurate mathematical solutions.
+
+The evaluation process looks at various aspects of each solution:
+- Is the final answer correct?
+- Did the solution follow proper formatting (like using the right XML tags)?
+- Does the reasoning match the answer provided?
+
+What makes this approach particularly clever is how it handles the scoring. Instead of just giving absolute scores, GRPO normalizes the rewards within each group. It uses a simple but effective formula for group relative advantage estimation:
+
+```
+Advantage = (reward - mean(group_rewards)) / std(group_rewards)
+```
+
+![Preference Learning](https://huggingface.co/reasoning-course/images/resolve/main/grpo/12.jpg)
+
+This normalization is like grading on a curve, but for AI. It helps the model understand which solutions within the group were better or worse compared to their peers, rather than just looking at absolute scores.
+
+### Optimization: Learning from Experience
+
+The final step is where GRPO teaches the model to improve based on what it learned from evaluating the group of solutions. This process is both powerful and stable, using two main principles:
+
+1. It encourages the model to produce more solutions like the successful ones while moving away from less effective approaches
+2. It includes a safety mechanism (called KL divergence penalty) that prevents the model from changing too drastically all at once
+
+This approach proves more stable than traditional methods because:
+- It looks at multiple solutions together rather than comparing just two at a time
+- The group-based normalization helps prevent issues with reward scaling
+- The KL penalty acts like a safety net, ensuring the model doesn't forget what it already knows while learning new things
+
+<Tip>
+
+GRPO's key innovations are:
+- Learning directly from any function or model, eliminating the reliance on a separate reward model.
+- Group-based learning, which is more stable and efficient than traditional methods like pairwise comparisons.
+
+</Tip>
+
+This breakdown is complex, but the key takeaway is that GRPO is a more efficient and stable way to train a model to reason. 
+
+### GRPO Algorithm in Pseudocode
+
+Now that we understand the key components of GRPO, let's look at the algorithm in pseudocode. This is a simplified version of the algorithm, but it captures the key ideas.
+
+```
+Input: 
+- initial_policy: Starting model to be trained
+- reward_function: Function that evaluates outputs
+- training_prompts: Set of training examples
+- group_size: Number of outputs per prompt (typically 4-16)
+
+Algorithm GRPO:
+1. For each training iteration:
+   a. Set reference_policy = initial_policy (snapshot current policy)
+   b. For each prompt in batch:
+      i. Generate group_size different outputs using initial_policy
+      ii. Compute rewards for each output using reward_function
+      iii. Normalize rewards within group:
+           normalized_advantage = (reward - mean(rewards)) / std(rewards)
+      iv. Update policy by maximizing the clipped ratio:
+          min(prob_ratio * normalized_advantage, 
+              clip(prob_ratio, 1-epsilon, 1+epsilon) * normalized_advantage)
+          - kl_weight * KL(initial_policy || reference_policy)
+          
+          where prob_ratio is current_prob / reference_prob
+
+Output: Optimized policy model
+```
+
+This algorithm shows how GRPO combines group-based advantage estimation with policy optimization while maintaining stability through clipping and KL divergence constraints.
+
+## Results and Impact
+
+Now that we've explored the algorithm, let's look at the results. DeepSeek R1 achieves state-of-the-art performance across multiple domains:
+
+| Domain | Key Results |
+|--------|-------------|
+| Mathematics | • 79.8% on AIME 2024<br>• 97.3% on MATH-500 |
+| Coding | • Codeforces Rating: 2029<br>• LiveCodeBench: 65.9% |
+| General Knowledge | • MMLU: 90.8%<br>• GPQA Diamond: 71.5% |
+| Language Tasks | • AlpacaEval 2.0: 87.6% win rate<br>• FRAMES: 82.5% |
+
+The model's practical impact extends beyond benchmarks through its cost-effective API pricing ($0.14 per million input tokens) and successful model distillation across various sizes (1.5B to 70B parameters). Notably, even the 7B model achieves 55.5% on AIME 2024, while the 70B distilled version approaches o1-mini performance on MATH-500 (94.5%), demonstrating effective capability preservation at different scales.
+
+## Limitations and Challenges of GRPO
+
+While GRPO represents a significant advancement in reinforcement learning for language models, it's important to understand its limitations and challenges:
+
+- **Generation Cost**: Generating multiple completions (4-16) for each prompt increases computational requirements compared to methods that generate only one or two completions.
+- **Batch Size Constraints**: The need to process groups of completions together can limit effective batch sizes, adding complexity to the training process and potentially slowing down training.
+- **Reward Function Design**: The quality of training heavily depends on well-designed reward functions. Poorly designed rewards can lead to unintended behaviors or optimization for the wrong objectives.
+- **Group Size Tradeoffs**: Choosing the optimal group size involves balancing diversity of solutions against computational cost. Too few samples may not provide enough diversity, while too many increase training time and resource requirements.
+- **KL Divergence Tuning**: Finding the right balance for the KL divergence penalty requires careful tuning - too high and the model won't learn effectively, too low and it may diverge too far from its initial capabilities.
+
+## Conclusion
+
+The DeepSeek R1 paper represents a significant milestone in language model development. The Group Relative Policy Optimization (GRPO) algorithm has demonstrated that pure reinforcement learning can indeed develop strong reasoning capabilities, challenging previous assumptions about the necessity of supervised fine-tuning.
+
+Perhaps most importantly, DeepSeek R1 has shown that it's possible to balance high performance with practical considerations like cost-effectiveness and accessibility. The successful distillation of the model's capabilities across different sizes, from 1.5B to 70B parameters, demonstrates a path forward for making advanced AI capabilities more widely available.
+
+---
+
+In the next section, we'll explore practical implementations of these concepts, focusing on how to leverage GRPO and RFTrans in your own language model development projects.
+
+## Quiz
+
+### 1. What is the main innovation of the DeepSeek R1 paper?
+
+<Question
+    choices={[
+        {
+            text: "The GRPO algorithm that enables learning from preferences with and without a reward model",
+            explain: "Correct! GRPO's key innovation is its ability to directly optimize for preference rectification, making it more efficient than traditional RL methods.",
+            correct: true
+        },
+        {
+            text: "Using more GPUs for training than any previous model",
+            explain: "The paper's innovation is in its algorithmic approach (GRPO) rather than computational resources used."
+        },
+        {
+            text: "Creating a larger language model than existing ones",
+            explain: "The innovation lies in the training methodology and GRPO algorithm, not in model size."
+        }
+    ]}
+/>
+
+### 2. What are the four phases of the DeepSeek R1 training process?
+
+<Question
+    choices={[
+        {
+            text: "Cold Start, Reasoning RL, Rejection Sampling, and Diverse RL",
+            explain: "Correct! These are the exact four phases described in the paper, each serving a specific purpose in the training pipeline.",
+            correct: true
+        },
+        {
+            text: "Pre-training, Fine-tuning, Testing, and Deployment",
+            explain: "The paper specifically outlines four different phases: Cold Start (quality foundation), Reasoning RL (capability building), Rejection Sampling (quality control), and Diverse RL (broad alignment)."
+        },
+        {
+            text: "Data Collection, Model Training, Evaluation, and Optimization",
+            explain: "The paper describes a specific four-phase process that includes Cold Start, Reasoning RL, Rejection Sampling, and Diverse RL phases."
+        }
+    ]}
+/>
+
+### 3. What is the 'Aha Moment' phenomenon in R1-Zero's training?
+
+<Question
+    choices={[
+        {
+            text: "A process where the model recognizes errors, self-corrects, and explains its corrections",
+            explain: "Correct! The paper describes this as a four-step process: initial attempt, recognition of errors, self-correction, and explanation of the improvement.",
+            correct: true
+        },
+        {
+            text: "The point where the model reaches human-level performance",
+            explain: "The 'Aha Moment' specifically refers to the model's ability to recognize and correct its own mistakes, similar to human problem-solving realizations."
+        },
+        {
+            text: "When the model completes its training process",
+            explain: "The 'Aha Moment' is about the model's emergent ability to recognize errors and self-correct during problem-solving, not about training completion."
+        }
+    ]}
+/>
+
+### 4. How does GRPO's group formation work?
+
+<Question
+    choices={[
+        {
+            text: "It generates multiple solutions (4-16) for the same problem and evaluates them together",
+            explain: "Correct! GRPO generates multiple attempts at solving the same problem, typically 4, 8, or 16 different attempts, which are then evaluated as a group.",
+            correct: true
+        },
+        {
+            text: "It combines multiple models into one ensemble",
+            explain: "GRPO uses a single model to generate multiple solution attempts, not an ensemble of different models."
+        },
+        {
+            text: "It splits the training data into different groups",
+            explain: "GRPO's group formation involves generating multiple solutions for the same problem, not splitting training data."
+        }
+    ]}
+/>
+
+### 5. What is the key difference between DeepSeek-R1-Zero and DeepSeek-R1?
+
+<Question
+    choices={[
+        {
+            text: "R1-Zero uses pure RL while R1 combines RL with supervised fine-tuning",
+            explain: "Correct! As shown in the comparison table, R1-Zero uses pure RL training while R1 uses a multi-phase approach combining supervised fine-tuning with RL, resulting in better language consistency.",
+            correct: true
+        },
+        {
+            text: "R1-Zero is smaller than R1",
+            explain: "The difference is in their training approaches (pure RL vs. multi-phase), not their model sizes."
+        },
+        {
+            text: "R1-Zero was trained on less data",
+            explain: "The key distinction is their training methodology: pure RL for R1-Zero versus a combined SFT and RL approach for R1."
+        }
+    ]}
+/>
+

--- a/chapters/en/chapter12/4.mdx
+++ b/chapters/en/chapter12/4.mdx
@@ -1,0 +1,235 @@
+# Implementing GRPO in TRL
+
+In this page, we'll learn how to implement Group Relative Policy Optimization (GRPO) using the Transformer Reinforcement Learning (TRL) library. We'll focus on practical implementation with minimal code.
+
+We'll explore the core concepts of GRPO as they are embodied in TRL's GRPOTrainer, using snippets from the official TRL documentation to guide us.
+
+<Tip>
+This chapter is aimed at TRL beginners. If you are already familiar with TRL, you might want to also check out the [Open R1 implementation](https://github.com/huggingface/open-r1/blob/main/src/open_r1/grpo.py) of GRPO.
+</Tip>
+
+First, let's remind ourselves of some of the important concepts of GRPO algorithm:
+
+- Group Formation: The model generates multiple completions for each prompt.
+- Preference Learning: The model learns from a reward function that compares groups of completions.
+- Training Configuration: The model uses a configuration to control the training process.
+
+What do we need to do to implement GRPO?
+
+- Define a dataset of prompts.
+- Define a reward function that takes a list of completions and returns a list of rewards.
+- Configure the training process with a GRPOConfig.
+- Train the model using the GRPOTrainer.
+
+Here's a minimal example to get started with GRPO training:
+
+```python
+from trl import GRPOTrainer, GRPOConfig
+from datasets import load_dataset
+
+# 1. Load your dataset
+dataset = load_dataset("your_dataset", split="train")
+
+
+# 2. Define a simple reward function
+def reward_func(completions, **kwargs):
+    """Example: Reward longer completions"""
+    return [float(len(completion)) for completion in completions]
+
+
+# 3. Configure training
+training_args = GRPOConfig(
+    output_dir="output",
+    num_train_epochs=3,
+    per_device_train_batch_size=4,
+    gradient_accumulation_steps=2,
+    logging_steps=10,
+)
+
+# 4. Initialize and train
+trainer = GRPOTrainer(
+    model="your_model",  # e.g. "Qwen/Qwen2-0.5B-Instruct"
+    args=training_args,
+    train_dataset=dataset,
+    reward_funcs=reward_func,
+)
+trainer.train()
+```
+
+## Key Components
+
+### 1. Dataset Format
+
+Your dataset should contain prompts that the model will respond to. The GRPO trainer will generate multiple completions for each prompt and use the reward function to compare them.
+
+### 2. Reward Function
+
+The reward function is crucial - it determines how the model learns. Here are two practical examples:
+
+```python
+# Example 1: Reward based on completion length
+def reward_length(completions, **kwargs):
+    return [float(len(completion)) for completion in completions]
+
+
+# Example 2: Reward based on matching a pattern
+import re
+
+
+def reward_format(completions, **kwargs):
+    pattern = r"^<think>.*?</think><answer>.*?</answer>$"
+    return [1.0 if re.match(pattern, c) else 0.0 for c in completions]
+```
+
+### 3. Training Configuration
+
+Key parameters to consider in `GRPOConfig`:
+
+```python
+training_args = GRPOConfig(
+    # Essential parameters
+    output_dir="output",
+    num_train_epochs=3,
+    num_generation=4,  # Number of completions to generate for each prompt
+    per_device_train_batch_size=4,  # We want to get all generations in one device batch
+    # Optional but useful
+    gradient_accumulation_steps=2,
+    learning_rate=1e-5,
+    logging_steps=10,
+    # GRPO specific (optional)
+    use_vllm=True,  # Speed up generation
+)
+```
+
+The `num_generation` parameter is particularly important for GRPO as it defines the group size - how many different completions the model will generate for each prompt. This is a key differentiator from other RL methods:
+
+- Too small (e.g., 2-3): May not provide enough diversity for meaningful comparisons
+- Recommended (4-16): Provides good balance between diversity and computational efficiency
+- Larger values: May improve learning but significantly increases computational cost
+
+The group size should be chosen based on your computational resources and the complexity of your task. For simple tasks, smaller groups (4-8) may be sufficient, while more complex reasoning tasks might benefit from larger groups (8-16).
+
+## Tips for Success
+
+1. **Memory Management**: Adjust `per_device_train_batch_size` and `gradient_accumulation_steps` based on your GPU memory.
+2. **Speed**: Enable `use_vllm=True` for faster generation if your model is supported.
+3. **Monitoring**: Watch the logged metrics during training:
+   - `reward`: Average reward across completions
+   - `reward_std`: Standard deviation within reward groups
+   - `kl`: KL divergence from reference model
+
+## Reward Function Design
+
+The DeepSeek R1 paper demonstrates several effective approaches to reward function design that you can adapt for your own GRPO implementation:
+
+### 1. Length-Based Rewards
+
+One of the easiest rewards to implement is a length-based reward. You can reward longer completions:
+
+```python
+def reward_len(completions, **kwargs):
+    ideal_length = 20
+    return [-abs(ideal_length - len(completion)) for completion in completions]
+```
+
+This reward function penalizes completions that are too short or too long, encouraging the model to generate completions that are close to the ideal length of 20 tokens.
+
+<!-- # TODO: update links when PR is merged -->
+
+<iframe 
+    src="https://marimo.app/gh/huggingface/notebooks/main/e?entrypoint=course%2Fen%2Fchapter13%2Fgrpo_length.py&embed=true&show-chrome=false"
+    title="Marimo Notebook"
+    width="100%"
+    height="800px"
+    frameBorder="0"
+    allow="clipboard-write"
+></iframe>
+
+## 2. Rule-Based Rewards for Verifiable Tasks
+
+For tasks with objectively correct answers (like mathematics or coding), you can implement rule-based reward functions:
+
+```python
+def problem_reward(completions, answers, **kwargs):
+    """Reward function for math problems with verifiable answers
+    completions: list of completions to evaluate
+    answers: list of answers to the problems from the dataset
+    """
+
+    rewards = []
+    for completion, correct_answer in zip(completions, answers):
+        # Extract the answer from the completion
+        try:
+            # This is a simplified example - you'd need proper parsing
+            answer = extract_final_answer(completion)
+            # Binary reward: 1 for correct, 0 for incorrect
+            reward = 1.0 if answer == correct_answer else 0.0
+            rewards.append(reward)
+        except:
+            # If we can't parse an answer, give a low reward
+            rewards.append(0.0)
+
+    return rewards
+```
+
+<!-- # TODO: update links when PR is merged -->
+
+<iframe 
+    src="https://marimo.app/gh/huggingface/notebooks/main/e?entrypoint=course%2Fen%2Fchapter13%2Fgrpo_math.py&embed=true&show-chrome=false"
+    title="Marimo Notebook"
+    width="100%"
+    height="800px"
+    frameBorder="0"
+    allow="clipboard-write"
+></iframe>
+
+## 3. Format-Based Rewards
+
+You can also reward proper formatting, which was important in the DeepSeek R1 training:
+
+```python
+def format_reward(completions, **kwargs):
+    """Reward completions that follow the desired format"""
+    # Example: Check if the completion follows a think-then-answer format
+    pattern = r"<think>(.*?)</think>\s*<answer>(.*?)</answer>"
+
+    rewards = []
+    for completion in completions:
+        match = re.search(pattern, completion, re.DOTALL)
+        if match:
+            # Check if there's substantial content in both sections
+            think_content = match.group(1).strip()
+            answer_content = match.group(2).strip()
+
+            if len(think_content) > 20 and len(answer_content) > 0:
+                rewards.append(1.0)
+            else:
+                rewards.append(
+                    0.5
+                )  # Partial reward for correct format but limited content
+        else:
+            rewards.append(0.0)  # No reward for incorrect format
+
+    return rewards
+```
+
+<!-- # TODO: update links when PR is merged -->
+
+<iframe 
+    src="https://marimo.app/gh/huggingface/notebooks/main/e?entrypoint=course%2Fen%2Fchapter13%2Fgrpo_format.py&embed=true&show-chrome=false"
+    title="Marimo Notebook"
+    width="100%"
+    height="800px"
+    frameBorder="0"
+    allow="clipboard-write"
+></iframe>
+
+
+
+These examples demonstrate how you can implement reward functions inspired by the DeepSeek R1 training process, focusing on correctness, formatting, and combined signals.
+
+
+## That's it!
+
+In the next section, you will follow an exercise to implement GRPO in TRL.
+

--- a/chapters/en/chapter12/5.mdx
+++ b/chapters/en/chapter12/5.mdx
@@ -1,0 +1,236 @@
+<CourseFloatingBanner chapter={2}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/course/en/chapter12/grpo_finetune.ipynb"},
+]} />
+
+# Practical Exercise: Fine-tune a model with GRPO
+
+Now that you've seen the theory, let's put it into practice! In this exercise, you'll fine-tune a model with GRPO.
+
+<Tip>
+This exercise was written by LLM fine-tuning expert [@mlabonne](https://huggingface.co/mlabonne).
+</Tip>
+
+## Install dependencies
+
+First, let's install the dependencies for this exercise.
+
+```bash
+!pip install -qqq datasets==3.2.0 transformers==4.47.1 trl==0.14.0 peft==0.14.0 accelerate==1.2.1 bitsandbytes==0.45.2 wandb==0.19.7 --progress-bar off
+!pip install -qqq flash-attn --no-build-isolation --progress-bar off
+```
+
+Now we'll import the necessary libraries.
+
+```python
+import torch
+from datasets import load_dataset
+from peft import LoraConfig, get_peft_model
+from transformers import AutoModelForCausalLM, AutoTokenizer
+from trl import GRPOConfig, GRPOTrainer
+```
+
+## Import and log in to Weights & Biases
+
+Weights & Biases is a tool for logging and monitoring your experiments. We'll use it to log our fine-tuning process.
+
+```python
+import wandb
+
+wandb.login()
+```
+
+You can do this exercise without logging in to Weights & Biases, but it's recommended to do so to track your experiments and interpret the results.
+
+## Load the dataset
+
+Now, let's load the dataset. In this case, we'll use the [`mlabonne/smoltldr`](https://huggingface.co/datasets/mlabonne/smoltldr) dataset, which contains a list of short stories.
+
+```python
+dataset = load_dataset("mlabonne/smoltldr")
+print(dataset)
+```
+
+## Load model
+
+Now, let's load the model.
+
+For this exercise, we'll use the [`SmolLM2-135M`](hhttps://huggingface.co/HuggingFaceTB/SmolLM2-135M) model. 
+
+This is a small 135M parameter model that runs on limited hardware. This makes the model ideal for learning, but it's not the most powerful model out there. If you have access to more powerful hardware, you can try to fine-tune a larger model like [`SmolLM2-1.7B`](https://huggingface.co/HuggingFaceTB/SmolLM2-1.7B).
+
+```python
+model_id = "HuggingFaceTB/SmolLM-135M-Instruct"
+model = AutoModelForCausalLM.from_pretrained(
+    model_id,
+    torch_dtype="auto",
+    device_map="auto",
+    attn_implementation="flash_attention_2",
+)
+tokenizer = AutoTokenizer.from_pretrained(model_id)
+```
+
+## Load LoRA
+
+Now, let's load the LoRA configuration. We'll take advantage of LoRA to reduce the number of trainable parameters, and in turn the memory footprint we need to fine-tune the model.
+
+If you're not familiar with LoRA, you can read more about it in [Chapter 11](https://huggingface.co/learn/course/en/chapter11/3).
+
+```python
+# Load LoRA
+lora_config = LoraConfig(
+    task_type="CAUSAL_LM",
+    r=16,
+    lora_alpha=32,
+    target_modules="all-linear",
+)
+model = get_peft_model(model, lora_config)
+print(model.print_trainable_parameters())
+```
+
+```sh
+Total trainable parameters: 135M
+```
+
+## Define the reward function
+
+As mentioned in the previous section, GRPO can use any reward function to improve the model. In this case, we'll use a simple reward function that encourages the model to generate text that is 50 tokens long.
+
+```python
+# Reward function
+ideal_length = 50
+
+
+def reward_len(completions, **kwargs):
+    return [-abs(ideal_length - len(completion)) for completion in completions]
+```
+
+## Define the training arguments
+
+Now, let's define the training arguments. We'll use the `GRPOConfig` class to define the training arguments in a typical `transformers` style.
+
+If this is the first time you're defining training arguments, you can check the [TrainingArguments](https://huggingface.co/docs/transformers/en/main_classes/trainer#trainingarguments) class for more information, or [Chapter 2](https://huggingface.co/learn/course/en/chapter2/1) for a detailed introduction.
+
+```python
+# Training arguments
+training_args = GRPOConfig(
+    output_dir="GRPO",
+    learning_rate=2e-5,
+    per_device_train_batch_size=8,
+    gradient_accumulation_steps=2,
+    max_prompt_length=512,
+    max_completion_length=96,
+    num_generations=8,
+    optim="adamw_8bit",
+    num_train_epochs=1,
+    bf16=True,
+    report_to=["wandb"],
+    remove_unused_columns=False,
+    logging_steps=1,
+)
+```
+
+Now, we can initialize the trainer with model, dataset, and training arguments and start training.
+
+```python
+# Trainer
+trainer = GRPOTrainer(
+    model=model,
+    reward_funcs=[reward_len],
+    args=training_args,
+    train_dataset=dataset["train"],
+)
+
+# Train model
+wandb.init(project="GRPO")
+trainer.train()
+```
+
+Training takes around 1 hour on a single A10G GPU which is available on Google Colab or via Hugging Face Spaces.
+
+## Push the model to the Hub during training
+
+If we set the `push_to_hub` argument to `True` and the `model_id` argument to a valid model name, the model will be pushed to the Hugging Face Hub whilst we're training. This is useful if you want to start vibe testing the model straight away!
+
+## Interpret training results
+
+`GRPOTrainer` logs the reward from your reward function, the loss, and a range of other metrics.
+
+We will focus on the reward from the reward function and the loss.
+
+As you can see, the reward from the reward function moves closer to 0 as the model learns. This is a good sign that the model is learning to generate text of the correct length.
+
+![Reward from reward function](https://huggingface.co/reasoning-course/images/resolve/main/grpo/13.png)
+
+<!-- @qgallouedec @mlabonne could you review this section please!? -->
+You might notice that the loss starts at zero and then increases during training, which may seem counterintuitive. This behavior is expected in GRPO and is directly related to the mathematical formulation of the algorithm. The loss in GRPO is proportional to the KL divergence (the cap relative to original policy) . As training progresses, the model learns to generate text that better matches the reward function, causing it to diverge more from its initial policy. This increasing divergence is reflected in the rising loss value, which actually indicates that the model is successfully adapting to optimize for the reward function.
+
+![Loss](https://huggingface.co/reasoning-course/images/resolve/main/grpo/14.png)
+
+## Save and publish the model
+
+Let's share the model with the community!
+
+```python
+merged_model = trainer.model.merge_and_unload()
+merged_model.push_to_hub(
+    "SmolGRPO-135M", private=False, tags=["GRPO", "Reasoning-Course"]
+)
+```
+
+## Generate text
+
+🎉 You've successfully fine-tuned a model with GRPO! Now, let's generate some text with the model.
+
+First, we'll define a really long document!
+
+```python
+prompt = """
+# A long document about the Cat
+
+The cat (Felis catus), also referred to as the domestic cat or house cat, is a small 
+domesticated carnivorous mammal. It is the only domesticated species of the family Felidae.
+Advances in archaeology and genetics have shown that the domestication of the cat occurred
+in the Near East around 7500 BC. It is commonly kept as a pet and farm cat, but also ranges
+freely as a feral cat avoiding human contact. It is valued by humans for companionship and
+its ability to kill vermin. Its retractable claws are adapted to killing small prey species
+such as mice and rats. It has a strong, flexible body, quick reflexes, and sharp teeth,
+and its night vision and sense of smell are well developed. It is a social species,
+but a solitary hunter and a crepuscular predator. Cat communication includes
+vocalizations—including meowing, purring, trilling, hissing, growling, and grunting—as
+well as body language. It can hear sounds too faint or too high in frequency for human ears,
+such as those made by small mammals. It secretes and perceives pheromones.
+"""
+
+messages = [
+    {"role": "user", "content": prompt},
+]
+```
+
+Now, we can generate text with the model.
+
+```python
+# Generate text
+from transformers import pipeline
+
+generator = pipeline("text-generation", model="SmolGRPO-135M")
+
+## Or use the model and tokenizer we defined earlier
+# generator = pipeline("text-generation", model=model, tokenizer=tokenizer)
+
+generate_kwargs = {
+    "max_new_tokens": 256,
+    "do_sample": True,
+    "temperature": 0.5,
+    "min_p": 0.1,
+}
+
+generated_text = generator(messages, generate_kwargs=generate_kwargs)
+
+print(generated_text)
+```
+
+# Conclusion
+
+In this chapter, we've seen how to fine-tune a model with GRPO. We've also seen how to interpret the training results and generate text with the model.

--- a/chapters/en/chapter12/6.mdx
+++ b/chapters/en/chapter12/6.mdx
@@ -1,0 +1,19 @@
+# Coming soon...
+
+This chapter is being run as a live cohort now! If you've finished the material so far, here's what to expect:
+
+## Course Schedule
+
+| Date | Unit |
+|------|------|
+| March 7th, 2025 | No-Code Exam and Certification |
+| March 14th, 2025 | Next Practical Exercise |
+| March 21st, 2025 | Interactive code review |
+| | Unsloth Exercise on fine-tuning a model with GRPO |
+| | More written material on building reasoning models |
+| | Live sessions on building Open R1 |
+| | Code Exam and Certification |
+
+## Staying Up to Date
+
+If you want to follow the course, follow the [The Reasoning Course](https://huggingface.co/reasoning-course) and join the [Discord community](https://discord.gg/F3vZujJH)!


### PR DESCRIPTION
* add basic introduction for students

* page on the basics of RL

* add page on grpo and the deep seek paper

* add grpo in trl page

* add coming soon page

* add ungraded quizzes on rl and r1

* update toc

* format code snippets

* fix images in rl page

* fix and make correct grpo section in rl page (2.mx)

* fix preference data mistake

* fix use of 'preference data' in grpo paper walkthrough

* improve dpo and ppo comparison in RL page (2.mdx)

* respond to feedback on TRL page

* add pseudo code and limitations to the GRPO paper page

* expand grpo comparison in RL page

* add examples of dummy reward functions to TRL page

* add length function examples to TRL page

* format code snippets

* Fix all GRPO acronyms

* remove mention of preference datasets

* Apply suggestions from code review

Co-authored-by: Quentin Gallouédec <45557362+qgallouedec@users.noreply.github.com>

* respond to reviews in RL page

* remove unclear paragraph in paper page

* [DEMO] add interactive examples for GRPO reward functions (#800)

* add marimo example of length based reward function with a slider

* move demo into TRL page

* experiment with marimo outside of prose

* update TOC with marimo example

* use marimo table for representation

* remove more snippet returns

* try with simple strings

* drop styling from marimo box

* try pure iframe component

* try without return values

* fall back to hello world marimo example

* try snippet after marimo

* define marimo in python script

* add real marimo example

* add real marimo example with length reward

* hide code and headers for tidyness

* add markdown for explanaition

* add markdown for explanaition

* move markdown up

* fix missing slider

* add notebooks to real locations

* remove experimentation page

* use correct urls and add todos

* update all image links due to hub org rename

* fix query params in notebook urls

* reorder images to match prose

* add notebook exercise

Co-authored-by: Maxime Labonne <labonne.maxime@gmail.com>

* update the toc

* chang images in exercise

* give clearer definition of what students will learn

* add inference providers example

* add reference to open r1 implementation of GRPO

* add section on pushing model to the hub during training.

* update marimo examples

* improve inference section in exercise

* move from chapter 13 to chapter12

* update coming soon section with future releases

* use a table for unit releases

* switch round r1 demo for iframe and link

* make the marimo boxes longer

* add maxime's name to the unit.

* use released version of marimo notebooks

---------

Co-authored-by: Quentin Gallouédec <45557362+qgallouedec@users.noreply.github.com>
Co-authored-by: Maxime Labonne <labonne.maxime@gmail.com>