### PR TITLE
Fix DRL course link in 2.mdx

### DIFF
--- a/chapters/en/chapter12/2.mdx
+++ b/chapters/en/chapter12/2.mdx
@@ -5,7 +5,7 @@ Welcome to the first page!
 We're going to start our journey into the exciting world of Reinforcement Learning (RL) and discover how it's revolutionizing the way we train Language Models like the ones you might use every day.
 
 <Tip>
-In this chapter, we are focusing on reinforcement learning for language models. However, reinforcement learning is a broad field with many applications beyond language models. If you're interested in learning more about reinforcement learning, you should check out the [Deep Reinforcement Learning course](https://huggingface.co/courses/deep-rl-course/en/unit1/introduction).
+In this chapter, we are focusing on reinforcement learning for language models. However, reinforcement learning is a broad field with many applications beyond language models. If you're interested in learning more about reinforcement learning, you should check out the <a href="https://huggingface.co/learn/deep-rl-course/unit1/introduction">Deep Reinforcement Learning course</a>.
 </Tip>
 
 This page will give you a friendly and clear introduction to RL, even if you've never encountered it before. We'll break down the core ideas and see why RL is becoming so important in the field of Large Language Models (LLMs).


### PR DESCRIPTION
This should fix the DRL course link (visually but also the URL).

By the way, congrats on the new course! 