### PR TITLE
Fix link in 3.mdx

### DIFF
--- a/chapters/en/chapter12/3.mdx
+++ b/chapters/en/chapter12/3.mdx
@@ -11,7 +11,7 @@ In the next chapter, we will build on this knowledge and implement GRPO in pract
 The initial goal of the paper was to explore whether pure reinforcement learning could develop reasoning capabilities without supervised fine-tuning. 
 
 <Tip>
-Up until that point, all the popular LLMs required some supervised fine-tuning, which we explored in <a href="learn/nlp-course/en/chapter11/1">chapter 11</a>.
+Up until that point, all the popular LLMs required some supervised fine-tuning, which we explored in <a href="/learn/nlp-course/en/chapter11/1">chapter 11</a>.
 </Tip>
 
 ## The Breakthrough 'Aha' Moment

--- a/chapters/en/chapter12/3.mdx
+++ b/chapters/en/chapter12/3.mdx
@@ -10,7 +10,9 @@ In the next chapter, we will build on this knowledge and implement GRPO in pract
 
 The initial goal of the paper was to explore whether pure reinforcement learning could develop reasoning capabilities without supervised fine-tuning. 
 
-> **Tip:** Up until that point, all the popular LLMs required some supervised fine-tuning, which we explored in [chapter 11](learn/nlp-course/en/chapter11/1).
+<Tip>
+Up until that point, all the popular LLMs required some supervised fine-tuning, which we explored in <a href="learn/nlp-course/en/chapter11/1">chapter 11</a>.
+</Tip>
 
 ## The Breakthrough 'Aha' Moment
 

--- a/chapters/en/chapter12/3.mdx
+++ b/chapters/en/chapter12/3.mdx
@@ -10,9 +10,7 @@ In the next chapter, we will build on this knowledge and implement GRPO in pract
 
 The initial goal of the paper was to explore whether pure reinforcement learning could develop reasoning capabilities without supervised fine-tuning. 
 
-<Tip>
-Up until that point, all the popular LLMs required some supervised fine-tuning, which we explored in [chapter 11](/chapters/en/chapter11/1).
-</Tip>
+> **Tip:** Up until that point, all the popular LLMs required some supervised fine-tuning, which we explored in [chapter 11](learn/nlp-course/en/chapter11/1).
 
 ## The Breakthrough 'Aha' Moment
 


### PR DESCRIPTION
Fixes the course link to chapter 11, and uses a href for the link link to hopefully fix the link being shown as plaintext on live server.