### PR TITLE
Fix minor typos in 1.mdx

### DIFF
--- a/chapters/en/chapter12/1.mdx
+++ b/chapters/en/chapter12/1.mdx
@@ -12,9 +12,9 @@ LLMs have shown excellent performance on many generative tasks. However, up unti
 
 Open R1 is a project that aims to make LLMs reason on complex problems. It does this by using reinforcement learning to encourage LLMs to 'think' and reason. 
 
-In simple terms, the model is train to generate thoughts as well as outputs, and to structure these thoughts and outputs so that they can be handled separately by the user. 
+In simple terms, the model is trained to generate thoughts as well as outputs, and to structure these thoughts and outputs so that they can be handled separately by the user. 
 
-Let's take a look at an example. A we gave ourself the task of solving the following problem, we might think like this:
+Let's take a look at an example. As we gave ourself the task of solving the following problem, we might think like this:
 
 ```sh
 Problem: "I have 3 apples and 2 oranges. How many pieces of fruit do I have in total?"


### PR DESCRIPTION
Fix: Correct minor typos

1.  Replaced `train` with `trained`:

Old: "In simple terms, the model is train to generate thoughts..."
New: "In simple terms, the model is trained to generate thoughts..."

2. Replaced `A` with `As`:

Old: "A we gave ourself the task of solving the following problem..."
New: "As we gave ourself the task of solving the following problem..."