### PR TITLE
Updated Discord links and nits in Chapter 12

### DIFF
--- a/chapters/en/chapter12/1.mdx
+++ b/chapters/en/chapter12/1.mdx
@@ -12,9 +12,9 @@ LLMs have shown excellent performance on many generative tasks. However, up unti
 
 Open R1 is a project that aims to make LLMs reason on complex problems. It does this by using reinforcement learning to encourage LLMs to 'think' and reason. 
 
-In simple terms, the model is train to generate thoughts as well as outputs, and to structure these thoughts and outputs so that they can be handled separately by the user. 
+In simple terms, the model is trained to generate thoughts as well as outputs, and to structure these thoughts and outputs so that they can be handled separately by the user. 
 
-Let's take a look at an example. A we gave ourself the task of solving the following problem, we might think like this:
+Let's take a look at an example. As we gave ourself the task of solving the following problem, we might think like this:
 
 ```sh
 Problem: "I have 3 apples and 2 oranges. How many pieces of fruit do I have in total?"
@@ -79,14 +79,14 @@ Don't worry if you're missing some of these – we'll explain key concepts as we
 
 <Tip>
 
-If you don't have all the prerequisites, check out this [course](chapter1/1.mdx) from units 1 to 11
+If you don't have all the prerequisites, check out this [course](/course/chapter1/1) from units 1 to 11
 
 </Tip>
 
 ## How to Use This Chapter
 
 1. **Read Sequentially**: The sections build on each other, so it's best to read them in order
-2. **Share Notes**: Write down key concepts and questions and discuss them with in the community in [Discord](https://discord.gg/F3vZujJH)
+2. **Share Notes**: Write down key concepts and questions and discuss them within the community in [Discord](https://discord.gg/UrrTSsSyjb)
 3. **Try the Code**: When we get to practical examples, try them yourself
 4. **Join the Community**: Use the resources we provide to connect with other learners
 

--- a/chapters/en/chapter12/6.mdx
+++ b/chapters/en/chapter12/6.mdx
@@ -16,4 +16,4 @@ This chapter is being run as a live cohort now! If you've finished the material 
 
 ## Staying Up to Date
 
-If you want to follow the course, follow the [The Reasoning Course](https://huggingface.co/reasoning-course) and join the [Discord community](https://discord.gg/F3vZujJH)!
+If you want to follow the course, follow the [The Reasoning Course](https://huggingface.co/reasoning-course) and join the [Discord community](https://discord.gg/UrrTSsSyjb)!


### PR DESCRIPTION
Discord link is invalid so I've updated it using the one from [agents-course's README](https://github.com/huggingface/agents-course).

@burtenshaw 

![image](https://github.com/user-attachments/assets/a509998a-5047-4ebd-856a-531822345b45)
