### PR TITLE
Update 4.mdx

### DIFF
--- a/chapters/en/chapter12/4.mdx
+++ b/chapters/en/chapter12/4.mdx
@@ -5,7 +5,7 @@ In this page, we'll learn how to implement Group Relative Policy Optimization (G
 We'll explore the core concepts of GRPO as they are embodied in TRL's GRPOTrainer, using snippets from the official TRL documentation to guide us.
 
 <Tip>
-This chapter is aimed at TRL beginners. If you are already familiar with TRL, you might want to also check out the [Open R1 implementation](https://github.com/huggingface/open-r1/blob/main/src/open_r1/grpo.py) of GRPO.
+This chapter is aimed at TRL beginners. If you are already familiar with TRL, you might want to also check out the <a href="https://github.com/huggingface/open-r1/blob/main/src/open_r1/grpo.py">Open R1 implementation</a> of GRPO.
 </Tip>
 
 First, let's remind ourselves of some of the important concepts of GRPO algorithm:


### PR DESCRIPTION
fixed grpo.py link with href since previously it didn't work with tip tag