### PR TITLE
Fix: Corrected terminology in documentation

### DIFF
--- a/chapters/en/chapter1/3.mdx
+++ b/chapters/en/chapter1/3.mdx
@@ -59,7 +59,7 @@ classifier(
  {'label': 'NEGATIVE', 'score': 0.9994558095932007}]
 ```
 
-By default, this pipeline selects a particular pretrained model that has been fine-tuned for sentiment analysis in English. The model is downloaded and cached when you create the `classifier` object. If you rerun the command, the cached model will be used instead and there is no need to download the model again.
+By default, this pipeline selects a particular pretrained model that has been fine-tuned for sentiment analysis in English. The model is downloaded and cached when you create the `classifier` instance. If you rerun the command, the cached model will be used instead and there is no need to download the model again.
 
 There are three main steps involved when you pass some text to a pipeline:
 


### PR DESCRIPTION
Updated the documentation to clarify that the model is downloaded and cached when creating the classifier instance, not the classifier object.