### PR TITLE
Chapter 11 - Chat Templates - Qwen Model Issue & Messages Addition

### DIFF
--- a/chapters/en/chapter11/2.mdx
+++ b/chapters/en/chapter11/2.mdx
@@ -94,12 +94,14 @@ from transformers import AutoTokenizer
 
 # These will use different templates automatically
 mistral_tokenizer = AutoTokenizer.from_pretrained("mistralai/Mistral-7B-Instruct-v0.1")
-qwen_tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen-7B-Chat")
+qwen_tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-VL-7B-Instruct")
 smol_tokenizer = AutoTokenizer.from_pretrained("HuggingFaceTB/SmolLM2-135M-Instruct")
 
 messages = [
     {"role": "system", "content": "You are a helpful assistant."},
     {"role": "user", "content": "Hello!"},
+    {"role": "assistant", "content": "Hi! How can I help you today?"},
+    {"role": "user", "content": "What's the weather?"},
 ]
 
 # Each will format according to its model's template

--- a/chapters/en/chapter11/2.mdx
+++ b/chapters/en/chapter11/2.mdx
@@ -129,9 +129,9 @@ What's the weather?<|im_start|>assistant
 Mistral template:
 
 ```sh
-<s>[INST] You are a helpful assistant. [/INST]
-Hi! How can I help you today?</s>
-[INST] Hello! [/INST]
+<s> [INST] You are a helpful assistant.
+
+Hello! [/INST] Hi! How can I help you today?</s> [INST] What's the weather? [/INST]
 ```
 
 </details>


### PR DESCRIPTION
Hi,

Looking at the code snippet to format messages I encounter the following error with `transformers==4.49.0` : 
```
Cannot use chat template functions because tokenizer.chat_template is not set and no template argument was passed! For information about writing templates and setting the tokenizer.chat_template attribute, please see the documentation at https://huggingface.co/docs/transformers/main/en/chat_templating
```

It is due to the `Qwen/Qwen-7B-Chat` model. Looking at the model in [HF](https://huggingface.co/Qwen/Qwen-7B-Chat/tree/main) I did not find any chat template configuration. 

This PR suggests to use `Qwen/Qwen2.5-VL-7B-Instruct` instead which has a `chat_template` in its tokenizer config (can be found [here](https://huggingface.co/Qwen/Qwen2.5-VL-7B-Instruct/blob/main/tokenizer_config.json#L197)).

Furthermore looking at the expected output : 
```
<|im_start|>system
You are a helpful assistant.<|im_end|>
<|im_start|>user
Hello!<|im_end|>
<|im_start|>assistant
Hi! How can I help you today?<|im_end|>
<|im_start|>user
What's the weather?<|im_start|>assistant
```
messages from `assistant` and response from `user` can be added in the `messages` variables : 
```
{"role": "assistant", "content": "Hi! How can I help you today?"},
{"role": "user", "content": "What's the weather?"},
```

Lastly, the output from the Mistral tokenizer is not correct. Messages from `system` and `user` are concatenated in the `[INST]` tag :

<img width="762" alt="image" src="https://github.com/user-attachments/assets/3f9416ab-70c3-4901-8b07-15e9ba21ea8f" />
