### PR TITLE
typo fix in class distribution computing.

### DIFF
--- a/chapters/en/chapter5/3.mdx
+++ b/chapters/en/chapter5/3.mdx
@@ -535,7 +535,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```


### PR DESCRIPTION
fixed the typo in the class distribution computing in dataframe part. renamed columns should be "condition" and "frequency" instead of "frequency" and "count"