### PR TITLE
[RENAME] rename nlp course to LLM course

### DIFF
--- a/chapters/en/_toctree.yml
+++ b/chapters/en/_toctree.yml
@@ -8,7 +8,7 @@
   - local: chapter1/1
     title: Introduction
   - local: chapter1/2
-    title: Natural Language Processing
+    title: Natural Language Processing and Large Language Models
   - local: chapter1/3
     title: Transformers, what can they do?
   - local: chapter1/4
@@ -143,7 +143,7 @@
   - local: chapter7/7
     title: Question answering
   - local: chapter7/8
-    title: Mastering NLP
+    title: Mastering LLMs
   - local: chapter7/9
     title: End-of-chapter quiz
     quiz: 7
@@ -255,8 +255,3 @@
     title: Part 2 release event
   - local: events/3
     title: Gradio Blocks party
-
-- title: TEST EXTERNAL
-  sections:
-  - href: https://huggingface.co/docs/transformers/index
-    title: 🤗 Transformers documentation

--- a/chapters/en/_toctree.yml
+++ b/chapters/en/_toctree.yml
@@ -126,7 +126,7 @@
     title: End-of-chapter quiz
     quiz: 6
 
-- title: 7. Main NLP tasks
+- title: 7. Classical NLP tasks
   sections:
   - local: chapter7/1
     title: Introduction
@@ -255,3 +255,8 @@
     title: Part 2 release event
   - local: events/3
     title: Gradio Blocks party
+
+- title: TEST EXTERNAL
+  sections:
+  - external: https://huggingface.co/docs/transformers/index
+    title: 🤗 Transformers documentation

--- a/chapters/en/_toctree.yml
+++ b/chapters/en/_toctree.yml
@@ -258,5 +258,5 @@
 
 - title: TEST EXTERNAL
   sections:
-  - external: https://huggingface.co/docs/transformers/index
+  - href: https://huggingface.co/docs/transformers/index
     title: 🤗 Transformers documentation

--- a/chapters/en/chapter1/1.mdx
+++ b/chapters/en/chapter1/1.mdx
@@ -9,8 +9,17 @@
 
 <Youtube id="00GKzGyWFEs" />
 
-This course will teach you about natural language processing (NLP) using libraries from the [Hugging Face](https://huggingface.co/) ecosystem — [🤗 Transformers](https://github.com/huggingface/transformers), [🤗 Datasets](https://github.com/huggingface/datasets), [🤗 Tokenizers](https://github.com/huggingface/tokenizers), and [🤗 Accelerate](https://github.com/huggingface/accelerate) — as well as the [Hugging Face Hub](https://huggingface.co/models). It's completely free and without ads.
+This course will teach you about large language models (LLMs) and natural language processing (NLP) using libraries from the [Hugging Face](https://huggingface.co/) ecosystem — [🤗 Transformers](https://github.com/huggingface/transformers), [🤗 Datasets](https://github.com/huggingface/datasets), [🤗 Tokenizers](https://github.com/huggingface/tokenizers), and [🤗 Accelerate](https://github.com/huggingface/accelerate) — as well as the [Hugging Face Hub](https://huggingface.co/models). It's completely free and without ads.
 
+## Understanding NLP and LLMs[[understanding-nlp-and-llms]]
+
+While this course was originally focused on NLP (Natural Language Processing), it has evolved to emphasize Large Language Models (LLMs), which represent the latest advancement in the field. 
+
+**What's the difference?**
+- **NLP (Natural Language Processing)** is the broader field focused on enabling computers to understand, interpret, and generate human language. NLP encompasses many techniques and tasks such as sentiment analysis, named entity recognition, and machine translation.
+- **LLMs (Large Language Models)** are a powerful subset of NLP models characterized by their massive size, extensive training data, and ability to perform a wide range of language tasks with minimal task-specific training. Models like the Llama, GPT, or Claude series are examples of LLMs that have revolutionized what's possible in NLP.
+
+Throughout this course, you'll learn about both traditional NLP concepts and cutting-edge LLM techniques, as understanding the foundations of NLP is crucial for working effectively with LLMs.
 
 ## What to expect?[[what-to-expect]]
 
@@ -22,8 +31,9 @@ Here is a brief overview of the course:
 </div>
 
 - Chapters 1 to 4 provide an introduction to the main concepts of the 🤗 Transformers library. By the end of this part of the course, you will be familiar with how Transformer models work and will know how to use a model from the [Hugging Face Hub](https://huggingface.co/models), fine-tune it on a dataset, and share your results on the Hub!
-- Chapters 5 to 8 teach the basics of 🤗 Datasets and 🤗 Tokenizers before diving into classic NLP tasks. By the end of this part, you will be able to tackle the most common NLP problems by yourself.
+- Chapters 5 to 8 teach the basics of 🤗 Datasets and 🤗 Tokenizers before diving into classic NLP tasks and LLM techniques. By the end of this part, you will be able to tackle the most common language processing challenges by yourself.
 - Chapter 9 goes beyond NLP to cover how to build and share demos of your models on the 🤗 Hub. By the end of this part, you will be ready to showcase your 🤗 Transformers application to the world!
+- Chapters 10 to 12 dive into advanced LLM topics like fine-tuning, curating high-quality datasets, and building reasoning models.
 
 This course:
 
@@ -39,6 +49,8 @@ About the authors:
 
 [**Abubakar Abid**](https://huggingface.co/abidlabs) completed his PhD at Stanford in applied machine learning. During his PhD, he founded [Gradio](https://github.com/gradio-app/gradio), an open-source Python library that has been used to build over 600,000 machine learning demos. Gradio was acquired by Hugging Face, which is where Abubakar now serves as a machine learning team lead.
 
+[**Ben Burtenshaw**](https://huggingface.co/burtenshaw) is a Machine Learning Engineer at Hugging Face. He completed his PhD in Natural Language Processing at the University of Antwerp, where he applied Transformer models to generate children stories for the purpose of improving literacy skills. Since then, he has focused on educational materials and tools for the wider community.
+
 [**Matthew Carrigan**](https://huggingface.co/Rocketknight1) is a Machine Learning Engineer at Hugging Face. He lives in Dublin, Ireland and previously worked as an ML engineer at Parse.ly and before that as a post-doctoral researcher at Trinity College Dublin. He does not believe we're going to get to AGI by scaling existing architectures, but has high hopes for robot immortality regardless.
 
 [**Lysandre Debut**](https://huggingface.co/lysandre) is a Machine Learning Engineer at Hugging Face and has been working on the 🤗 Transformers library since the very early development stages. His aim is to make NLP accessible for everyone by developing tools with a very simple API.
@@ -51,9 +63,9 @@ About the authors:
 
 [**Lucile Saulnier**](https://huggingface.co/SaulLu) is a machine learning engineer at Hugging Face, developing and supporting the use of open source tools. She is also actively involved in many research projects in the field of Natural Language Processing such as collaborative training and BigScience.
 
-[**Lewis Tunstall**](https://huggingface.co/lewtun) is a machine learning engineer at Hugging Face, focused on developing open-source tools and making them accessible to the wider community. He is also a co-author of the O’Reilly book [Natural Language Processing with Transformers](https://www.oreilly.com/library/view/natural-language-processing/9781098136789/).
+[**Lewis Tunstall**](https://huggingface.co/lewtun) is a machine learning engineer at Hugging Face, focused on developing open-source tools and making them accessible to the wider community. He is also a co-author of the O'Reilly book [Natural Language Processing with Transformers](https://www.oreilly.com/library/view/natural-language-processing/9781098136789/).
 
-[**Leandro von Werra**](https://huggingface.co/lvwerra) is a machine learning engineer in the open-source team at Hugging Face and also a co-author of the O’Reilly book [Natural Language Processing with Transformers](https://www.oreilly.com/library/view/natural-language-processing/9781098136789/). He has several years of industry experience bringing NLP projects to production by working across the whole machine learning stack..
+[**Leandro von Werra**](https://huggingface.co/lvwerra) is a machine learning engineer in the open-source team at Hugging Face and also a co-author of the O'Reilly book [Natural Language Processing with Transformers](https://www.oreilly.com/library/view/natural-language-processing/9781098136789/). He has several years of industry experience bringing NLP projects to production by working across the whole machine learning stack..
 
 ## FAQ[[faq]]
 

--- a/chapters/en/chapter1/2.mdx
+++ b/chapters/en/chapter1/2.mdx
@@ -1,11 +1,11 @@
-# Natural Language Processing[[natural-language-processing]]
+# Natural Language Processing and Large Language Models[[natural-language-processing-and-large-language-models]]
 
 <CourseFloatingBanner
     chapter={1}
     classNames="absolute z-10 right-0 top-0"
 />
 
-Before jumping into Transformer models, let's do a quick overview of what natural language processing is and why we care about it.
+Before jumping into Transformer models, let's do a quick overview of what natural language processing is, how large language models have transformed the field, and why we care about it.
 
 ## What is NLP?[[what-is-nlp]]
 
@@ -21,6 +21,20 @@ The following is a list of common NLP tasks, with some examples of each:
 
 NLP isn't limited to written text though. It also tackles complex challenges in speech recognition and computer vision, such as generating a transcript of an audio sample or a description of an image.
 
-## Why is it challenging?[[why-is-it-challenging]]
+## The Rise of Large Language Models (LLMs)[[rise-of-llms]]
+
+In recent years, the field of NLP has been revolutionized by Large Language Models (LLMs). These models, which include architectures like GPT (Generative Pre-trained Transformer) and Llama, have transformed what's possible in language processing.
+
+LLMs are characterized by:
+- **Scale**: They contain millions or even billions of parameters
+- **General capabilities**: They can perform multiple tasks without task-specific training
+- **In-context learning**: They can learn from examples provided in the prompt
+- **Emergent abilities**: As these models grow in size, they demonstrate capabilities that weren't explicitly programmed or anticipated
+
+The advent of LLMs has shifted the paradigm from building specialized models for specific NLP tasks to using a single, large model that can be prompted or fine-tuned to address a wide range of language tasks. This has made sophisticated language processing more accessible while also introducing new challenges in areas like efficiency, ethics, and deployment.
+
+## Why is language processing challenging?[[why-is-it-challenging]]
 
 Computers don't process information in the same way as humans. For example, when we read the sentence "I am hungry," we can easily understand its meaning. Similarly, given two sentences such as "I am hungry" and "I am sad," we're able to easily determine how similar they are. For machine learning (ML) models, such tasks are more difficult. The text needs to be processed in a way that enables the model to learn from it. And because language is complex, we need to think carefully about how this processing must be done. There has been a lot of research done on how to represent text, and we will look at some methods in the next chapter.
+
+Even with the advances in LLMs, many fundamental challenges remain. These include understanding ambiguity, cultural context, sarcasm, and humor. LLMs address these challenges through massive training on diverse datasets, but still often fall short of human-level understanding in many complex scenarios.

--- a/chapters/en/chapter1/2.mdx
+++ b/chapters/en/chapter1/2.mdx
@@ -26,7 +26,7 @@ NLP isn't limited to written text though. It also tackles complex challenges in 
 In recent years, the field of NLP has been revolutionized by Large Language Models (LLMs). These models, which include architectures like GPT (Generative Pre-trained Transformer) and [Llama](https://huggingface.co/meta-llama), have transformed what's possible in language processing.
 
 LLMs are characterized by:
-- **Scale**: They contain millions or even billions of parameters
+- **Scale**: They contain millions, billions, or even hundreds of billions of parameters
 - **General capabilities**: They can perform multiple tasks without task-specific training
 - **In-context learning**: They can learn from examples provided in the prompt
 - **Emergent abilities**: As these models grow in size, they demonstrate capabilities that weren't explicitly programmed or anticipated

--- a/chapters/en/chapter1/2.mdx
+++ b/chapters/en/chapter1/2.mdx
@@ -23,7 +23,7 @@ NLP isn't limited to written text though. It also tackles complex challenges in 
 
 ## The Rise of Large Language Models (LLMs)[[rise-of-llms]]
 
-In recent years, the field of NLP has been revolutionized by Large Language Models (LLMs). These models, which include architectures like GPT (Generative Pre-trained Transformer) and Llama, have transformed what's possible in language processing.
+In recent years, the field of NLP has been revolutionized by Large Language Models (LLMs). These models, which include architectures like GPT (Generative Pre-trained Transformer) and [Llama](https://huggingface.co/meta-llama), have transformed what's possible in language processing.
 
 LLMs are characterized by:
 - **Scale**: They contain millions or even billions of parameters

--- a/chapters/en/chapter7/1.mdx
+++ b/chapters/en/chapter7/1.mdx
@@ -7,7 +7,7 @@
     classNames="absolute z-10 right-0 top-0"
 />
 
-In [Chapter 3](/course/chapter3), you saw how to fine-tune a model for text classification. In this chapter, we will tackle the following common NLP tasks:
+In [Chapter 3](/course/chapter3), you saw how to fine-tune a model for text classification. In this chapter, we will tackle the following common language tasks that are essential for working with both traditional NLP models and modern LLMs:
 
 - Token classification
 - Masked language modeling (like BERT)
@@ -15,6 +15,8 @@ In [Chapter 3](/course/chapter3), you saw how to fine-tune a model for text clas
 - Translation
 - Causal language modeling pretraining (like GPT-2)
 - Question answering
+
+These fundamental tasks form the foundation of how Large Language Models (LLMs) work and understanding them is crucial for effectively working with today's most advanced language models.
 
 {#if fw === 'pt'}
 

--- a/chapters/en/chapter7/8.mdx
+++ b/chapters/en/chapter7/8.mdx
@@ -1,22 +1,34 @@
-# Mastering NLP[[mastering-nlp]]
+# Mastering LLMs[[mastering-llms]]
 
 <CourseFloatingBanner
     chapter={7}
     classNames="absolute z-10 right-0 top-0"
 />
 
-If you've made it this far in the course, congratulations -- you now have all the knowledge and tools you need to tackle (almost) any NLP task with 🤗 Transformers and the Hugging Face ecosystem!
+If you've made it this far in the course, congratulations -- you now have all the knowledge and tools you need to tackle (almost) any language task with 🤗 Transformers and the Hugging Face ecosystem!
+
+## From NLP to LLMs
+
+While we've covered many traditional NLP tasks in this course, the field has been revolutionized by Large Language Models (LLMs). These models have dramatically expanded what's possible in language processing:
+
+- They can handle multiple tasks without task-specific fine-tuning
+- They excel at following instructions and adapting to different contexts
+- They can generate coherent, contextually appropriate text for various applications
+- They can perform reasoning and solve complex problems through techniques like chain-of-thought prompting
+
+The foundational NLP skills you've learned are still essential for working with LLMs effectively. Understanding tokenization, model architectures, fine-tuning approaches, and evaluation metrics provides the knowledge needed to leverage LLMs to their full potential.
 
 We have seen a lot of different data collators, so we made this little video to help you find which one to use for each task:
 
 <Youtube id="-RPeakdlHYo"/>
 
-After completing this lightning tour through the core NLP tasks, you should:
+After completing this lightning tour through the core language tasks, you should:
 
 * Know which architectures (encoder, decoder, or encoder-decoder) are best suited for each task
 * Understand the difference between pretraining and fine-tuning a language model
 * Know how to train Transformer models using either the `Trainer` API and distributed training features of 🤗 Accelerate or TensorFlow and Keras, depending on which track you've been following
 * Understand the meaning and limitations of metrics like ROUGE and BLEU for text generation tasks
 * Know how to interact with your fine-tuned models, both on the Hub and using the `pipeline` from 🤗 Transformers
+* Appreciate how LLMs build upon and extend traditional NLP techniques
 
-Despite all this knowledge, there will come a time when you'll either encounter a difficult bug in your code or have a question about how to solve a particular NLP problem. Fortunately, the Hugging Face community is here to help you! In the final chapter of this part of the course, we'll explore how you can debug your Transformer models and ask for help effectively.
+Despite all this knowledge, there will come a time when you'll either encounter a difficult bug in your code or have a question about how to solve a particular language processing problem. Fortunately, the Hugging Face community is here to help you! In the final chapter of this part of the course, we'll explore how you can debug your Transformer models and ask for help effectively.


### PR DESCRIPTION
This PR renames the course but it does not remove NLP. It is a minimal effort to integrate the course more with the current community. It does this in two ways:

- introduces llms and their difference to other nlp models
- uses the concept of 'classical nlp' to refer to model's like classifiers.

