### PR TITLE
Defining model and tokenizer before using them

### DIFF
--- a/chapters/en/chapter11/3.mdx
+++ b/chapters/en/chapter11/3.mdx
@@ -111,6 +111,15 @@ device = "cuda" if torch.cuda.is_available() else "cpu"
 # Load dataset
 dataset = load_dataset("HuggingFaceTB/smoltalk", "all")
 
+# Configure model and tokenizer
+model_name = "HuggingFaceTB/SmolLM2-135M"
+model = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=model_name).to(
+    device
+)
+tokenizer = AutoTokenizer.from_pretrained(pretrained_model_name_or_path=model_name)
+# Setup chat template
+model, tokenizer = setup_chat_format(model=model, tokenizer=tokenizer)
+
 # Configure trainer
 training_args = SFTConfig(
     output_dir="./sft_output",


### PR DESCRIPTION
While these are defined in the previous section 11.2, for someone copying the code to run onto their notebooks, this would fail.