### PR TITLE
Mistake with Trainer constructor - Chapter 7

### DIFF
--- a/chapters/en/chapter7/2.mdx
+++ b/chapters/en/chapter7/2.mdx
@@ -739,7 +739,7 @@ trainer = Trainer(
     eval_dataset=tokenized_datasets["validation"],
     data_collator=data_collator,
     compute_metrics=compute_metrics,
-    tokenizer=tokenizer,
+    processing_class=tokenizer,
 )
 trainer.train()
 ```


### PR DESCRIPTION
Switch to processing_class; tokenizer parameter deprecated in Trainer constructor