### PR TITLE
fix typo in SmolLM2-135M model link

### DIFF
--- a/chapters/en/chapter12/5.mdx
+++ b/chapters/en/chapter12/5.mdx
@@ -58,7 +58,7 @@ print(dataset)
 
 Now, let's load the model.
 
-For this exercise, we'll use the [`SmolLM2-135M`](hhttps://huggingface.co/HuggingFaceTB/SmolLM2-135M) model. 
+For this exercise, we'll use the [`SmolLM2-135M`](https://huggingface.co/HuggingFaceTB/SmolLM2-135M) model. 
 
 This is a small 135M parameter model that runs on limited hardware. This makes the model ideal for learning, but it's not the most powerful model out there. If you have access to more powerful hardware, you can try to fine-tune a larger model like [`SmolLM2-1.7B`](https://huggingface.co/HuggingFaceTB/SmolLM2-1.7B).
 


### PR DESCRIPTION
This pull request includes a small typo correction in the `chapters/en/chapter12/5.mdx` file. The change fixes a typo in the URL link for the `SmolLM2-135M` model.

* [`chapters/en/chapter12/5.mdx`](diffhunk://#diff-b2b8fe41af7e5083b450f9d4f5da8941c6da5b9f76d933fbda18df56b2eea69eL61-R61): Corrected the URL link for the `SmolLM2-135M` model by removing an extra 'h' character.