### PR TITLE
Fix code error in chapter 5 section 3

### DIFF
--- a/chapters/en/chapter5/3.mdx
+++ b/chapters/en/chapter5/3.mdx
@@ -535,7 +535,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```

--- a/chapters/es/chapter5/3.mdx
+++ b/chapters/es/chapter5/3.mdx
@@ -533,7 +533,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```

--- a/chapters/fr/chapter5/3.mdx
+++ b/chapters/fr/chapter5/3.mdx
@@ -545,7 +545,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```

--- a/chapters/it/chapter5/3.mdx
+++ b/chapters/it/chapter5/3.mdx
@@ -534,7 +534,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```

--- a/chapters/pt/chapter5/3.mdx
+++ b/chapters/pt/chapter5/3.mdx
@@ -533,7 +533,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```

--- a/chapters/ru/chapter5/3.mdx
+++ b/chapters/ru/chapter5/3.mdx
@@ -536,7 +536,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```

--- a/chapters/vi/chapter5/3.mdx
+++ b/chapters/vi/chapter5/3.mdx
@@ -533,7 +533,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```

--- a/chapters/zh-CN/chapter5/3.mdx
+++ b/chapters/zh-CN/chapter5/3.mdx
@@ -533,7 +533,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```

--- a/chapters/zh-TW/chapter5/3.mdx
+++ b/chapters/zh-TW/chapter5/3.mdx
@@ -534,7 +534,7 @@ frequencies = (
     .value_counts()
     .to_frame()
     .reset_index()
-    .rename(columns={"index": "condition", "condition": "frequency"})
+    .rename(columns={"index": "condition", "count": "frequency"})
 )
 frequencies.head()
 ```


### PR DESCRIPTION
In [chapter 5 section 3](https://huggingface.co/learn/llm-course/chapter5/3#from-datasets-to-dataframes-and-back), the code for computing the class distribution with Pandas dataframe method chaining does not work as expected due to the incorrect key in column mapping for the `rename` method. 

This PR fixes the issue by changing the key `condition` to `count` in all available languages.  
