### PR TITLE
Update 3.mdx

### DIFF
--- a/chapters/es/chapter3/3.mdx
+++ b/chapters/es/chapter3/3.mdx
@@ -147,7 +147,7 @@ def compute_metrics(eval_preds):
 Y para ver cómo se utiliza para informar de las métricas al final de cada época, así es como definimos un nuevo `Trainer` con nuestra función `compute_metrics()`:
 
 ```py
-training_args = TrainingArguments("test-trainer", evaluation_strategy="epoch")
+training_args = TrainingArguments("test-trainer", eval_strategy="epoch")
 model = AutoModelForSequenceClassification.from_pretrained(checkpoint, num_labels=2)
 
 trainer = Trainer(


### PR DESCRIPTION
Hubo un cambio en este codigo "training_args = TrainingArguments("test-trainer", evaluation_strategy="epoch")"
el parametro de "evaluation_strategy" paso a "eval_strategy"