### PR TITLE
fix typo: zh-CN chapter1-3 "eature" -> "feature"

### DIFF
--- a/chapters/zh-CN/chapter1/3.mdx
+++ b/chapters/zh-CN/chapter1/3.mdx
@@ -71,7 +71,7 @@ classifier(
 
 目前 [可用的一些pipeline](https://huggingface.co/transformers/main_classes/pipelines) 有：
 
-* `eature-extraction` （获取文本的向量表示）
+* `feature-extraction` （获取文本的向量表示）
 * `fill-mask` （完形填空）
 * `ner` （命名实体识别）
 * `question-answering` （问答）


### PR DESCRIPTION
This PR just fixes a tiny typo in the chapters/zh-CN/chapter1/3.mdx file.