### PR TITLE
Update 3.mdx change parameter 'source' in gr.Audio() to 'sources'

### DIFF
--- a/chapters/en/chapter9/3.mdx
+++ b/chapters/en/chapter9/3.mdx
@@ -64,7 +64,7 @@ def reverse_audio(audio):
     return reversed_audio
 
 
-mic = gr.Audio(source="microphone", type="numpy", label="Speak here...")
+mic = gr.Audio(sources="microphone", type="numpy", label="Speak here...")
 gr.Interface(reverse_audio, mic, "audio").launch()
 ```
 


### PR DESCRIPTION
I met error when i run the original colab, and i checked the source code, found the parameter name is 'sources' but not 'source'