### PR TITLE
Fix typo: Unigram section link

### DIFF
--- a/chapters/en/chapter6/4.mdx
+++ b/chapters/en/chapter6/4.mdx
@@ -104,7 +104,7 @@ Now that we've seen a little of how some different tokenizers process text, we c
 
 ## SentencePiece[[sentencepiece]]
 
-[SentencePiece](https://github.com/google/sentencepiece) is a tokenization algorithm for the preprocessing of text that you can use with any of the models we will see in the next three sections. It considers the text as a sequence of Unicode characters, and replaces spaces with a special character, `▁`. Used in conjunction with the Unigram algorithm (see [section 7](/course/chapter7/7)), it doesn't even require a pre-tokenization step, which is very useful for languages where the space character is not used (like Chinese or Japanese).
+[SentencePiece](https://github.com/google/sentencepiece) is a tokenization algorithm for the preprocessing of text that you can use with any of the models we will see in the next three sections. It considers the text as a sequence of Unicode characters, and replaces spaces with a special character, `▁`. Used in conjunction with the Unigram algorithm (see [section 7](/course/chapter6/7)), it doesn't even require a pre-tokenization step, which is very useful for languages where the space character is not used (like Chinese or Japanese).
 
 The other main feature of SentencePiece is *reversible tokenization*: since there is no special treatment of spaces, decoding the tokens is done simply by concatenating them and replacing the `_`s with spaces -- this results in the normalized text. As we saw earlier, the BERT tokenizer removes repeating spaces, so its tokenization is not reversible.
 


### PR DESCRIPTION
# What does this PR do?

Small typo in docs where the link to the Unigram algorithm from discussion on pre-tokenization (SentencePiece specifically).

~~Fixes #1736~~

> EDIT: Realized I might've opened the issue in the wrong repo 😅. Here's the link to that issue for reference: https://github.com/huggingface/hub-docs/issues/1736
> I won't open a new issue to reduce confusion.

## Before submitting

- [x] This PR fixes a typo or improves the docs (you can dismiss the other checks if that's the case).