### PR TITLE
Moved the 3 categories of models to where they are quoted

### DIFF
--- a/chapters/en/chapter1/4.mdx
+++ b/chapters/en/chapter1/4.mdx
@@ -36,6 +36,9 @@ The [Transformer architecture](https://arxiv.org/abs/1706.03762) was introduced 
 
 - **January 2022**: [InstructGPT](https://huggingface.co/papers/2203.02155), a version of GPT-3 that was trained to follow instructions better
 This list is far from comprehensive, and is just meant to highlight a few of the different kinds of Transformer models. Broadly, they can be grouped into three categories:
+  - GPT-like (also called _auto-regressive_ Transformer models)
+  - BERT-like (also called _auto-encoding_ Transformer models) 
+  - T5-like (also called _sequence-to-sequence_ Transformer models)
 
 - **January 2023**: [Llama](https://huggingface.co/papers/2302.13971), a large language model that is able to generate text in a variety of languages.
 
@@ -44,10 +47,6 @@ This list is far from comprehensive, and is just meant to highlight a few of the
 - **May 2024**: [Gemma 2](https://huggingface.co/papers/2408.00118), a family of lightweight, state-of-the-art open models ranging from 2B to 27B parameters that incorporate interleaved local-global attentions and group-query attention, with smaller models trained using knowledge distillation to deliver performance competitive with models 2-3 times larger.
 
 - **November 2024**: [SmolLM2](https://huggingface.co/papers/2502.02737), a state-of-the-art small language model (135 million to 1.7 billion parameters) that achieves impressive performance despite its compact size, and unlocking new possibilities for mobile and edge devices.
-
-- GPT-like (also called _auto-regressive_ Transformer models)
-- BERT-like (also called _auto-encoding_ Transformer models) 
-- T5-like (also called _sequence-to-sequence_ Transformer models)
 
 We will dive into these families in more depth later on.
 


### PR DESCRIPTION
The bullet talking about the Jan 22 release mentions three categories of models (BERT, GPT, T5), but they are only mentioned later.