### PR TITLE
Update 3.mdx

### DIFF
--- a/chapters/en/chapter2/3.mdx
+++ b/chapters/en/chapter2/3.mdx
@@ -46,12 +46,12 @@ This will save two files to your disk:
 ```
 ls directory_on_my_computer
 
-config.json pytorch_model.bin
+config.json model.safetensos
 ```
 
 If you look inside the *config.json* file, you'll see all the necessary attributes needed to build the model architecture. This file also contains some metadata, such as where the checkpoint originated and what 🤗 Transformers version you were using when you last saved the checkpoint.
 
-The *pytorch_model.bin* file is known as the state dictionary; it contains all your model's weights. The two files work together: the configuration file is needed to know about the model architecture, while the model weights are the parameters of the model.
+The *model.safetensos* file is known as the state dictionary; it contains all your model's weights. The two files work together: the configuration file is needed to know about the model architecture, while the model weights are the parameters of the model.
 
 To reuse a saved model, use the `from_pretrained()` method again:
 


### PR DESCRIPTION
"pytorch_model.bin" is replaced with "model.safetensors"