### PR TITLE
Update 4.mdx

### DIFF
--- a/chapters/en/chapter1/4.mdx
+++ b/chapters/en/chapter1/4.mdx
@@ -35,7 +35,7 @@ The [Transformer architecture](https://arxiv.org/abs/1706.03762) was introduced 
 - **May 2020**, [GPT-3](https://huggingface.co/papers/2005.14165), an even bigger version of GPT-2 that is able to perform well on a variety of tasks without the need for fine-tuning (called _zero-shot learning_)
 
 - **January 2022**: [InstructGPT](https://huggingface.co/papers/2203.02155), a version of GPT-3 that was trained to follow instructions better
-This list is far from comprehensive, and is just meant to highlight a few of the different kinds of Transformer models. Broadly, they can be grouped into three categories:
+This list is far from comprehensive, and is just meant to highlight a few of the different kinds of Transformer models.
 
 - **January 2023**: [Llama](https://huggingface.co/papers/2302.13971), a large language model that is able to generate text in a variety of languages.
 
@@ -145,7 +145,7 @@ The model is primarily composed of two blocks:
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter1/transformers_blocks-dark.svg" alt="Architecture of a Transformers models">
 </div>
 
-Each of these parts can be used independently, depending on the task: 
+Each of these parts can be used independently, depending on the task. Broadly, they can be grouped into three categories:: 
 
 * **Encoder-only models**: Good for tasks that require understanding of the input, such as sentence classification and named entity recognition.
 * **Decoder-only models**: Good for generative tasks such as text generation.


### PR DESCRIPTION
'Broadly, they can be grouped into three categories:' was mistakenly in the InstructGPT point. Added it to the correct place above categories of transformer models. Line 148