### PR TITLE
Update Chapter 2 3.mdx

### DIFF
--- a/chapters/en/chapter2/3.mdx
+++ b/chapters/en/chapter2/3.mdx
@@ -277,7 +277,14 @@ encoded_sequences = [
 ]
 ```
 
-This is a list of encoded sequences: a list of lists. Tensors only accept rectangular shapes (think matrices). This "array" is already of rectangular shape, so converting it to a tensor is easy:
+This is a list of encoded sequences: a list of lists. Tensors only accept rectangular shapes (think matrices). As `encoded_sequences` is not rectangular, we need to make it so.
+
+```py
+max_length = len(encoded_sequences[0])
+encoded_sequences[1].extend([0] * (max_length-len(encoded_sequences[1])))
+```
+
+This "array" is now of rectangular shape, so converting it to a tensor is easy:
 
 ```py
 import torch


### PR DESCRIPTION
Issue #982: Incorrect content in Chapter 2 3.mdx: Why is all of this necessary? Made encoded_sequences rectangular before converting to tensors.