### PR TITLE
Fix code block formatting issue in Chapter 3, Section 2

### DIFF
--- a/chapters/zh-CN/chapter3/2.mdx
+++ b/chapters/zh-CN/chapter3/2.mdx
@@ -394,8 +394,6 @@ samples = {k: v for k, v in samples.items() if k not in ["idx", "sentence1", "se
 不出所料，我们得到了不同长度的样本，从 32 到 67。动态填充意味着这个 batch 都应该填充到长度为 67，这是这个 batch 中的最大长度。如果没有动态填充，所有的样本都必须填充到整个数据集中的最大长度，或者模型可以接受的最大长度。让我们再次检查 `data_collator` 是否正确地动态填充了这批样本：
 
 ```py:
-
-```py
 batch = data_collator(samples)
 {k: v.shape for k, v in batch.items()}
 ```


### PR DESCRIPTION
This pull request fixes a Markdown formatting issue in Chapter 3, Section 2 of the Hugging Face course.

- The Python code block was not properly displayed due to incorrect Markdown syntax.
- The code block is now correctly formatted and renders properly in the documentation.

Thank you for maintaining this excellent course!


本 PR 修复了 Hugging Face 课程第 3 章第 2 节中的 Markdown 格式错误。

- 原文中的 Python 代码块由于 Markdown 语法错误，无法正常显示。
- 现已修复，代码块可以正确显示，文档排版更清晰。

感谢您维护这么优秀的课程！

![image](https://github.com/user-attachments/assets/b9639e8a-a720-4d8f-bd70-79505fe6db86)
