### PR TITLE
Fix inconsistency: learning rate change was described as decrease but increased

### DIFF
--- a/chapters/en/chapter3/5.mdx
+++ b/chapters/en/chapter3/5.mdx
@@ -268,8 +268,8 @@ from transformers import TrainingArguments
 
 training_args = TrainingArguments(
     output_dir="./results",
-    -learning_rate=1e-5,
-    +learning_rate=1e-4,
+    -learning_rate=1e-4,
+    +learning_rate=1e-5,
     -per_device_train_batch_size=16,
     +per_device_train_batch_size=32,
 )


### PR DESCRIPTION
### Description
This PR fixes a mismatch between the comment and the actual code behavior in the example.

The text says the learning rate is being lowered, but the code increases it from `1e-5` to `1e-4`. I've corrected the value to reflect a decreased learning rate, as stated.

### Why This Change Is Necessary
Accurate documentation and examples are crucial for new users learning how to fine-tune models. This helps avoid confusion and potential training issues.

### Type of Change
- [x] Bug fix / doc fix
