### PR TITLE
Fix broken link to Deep RL course introduction in English and Romanian versions

### DIFF
--- a/chapters/en/chapter12/2.mdx
+++ b/chapters/en/chapter12/2.mdx
@@ -6,7 +6,7 @@ We're going to start our journey into the exciting world of Reinforcement Learni
 
 <Tip>
 
-In this chapter, we are focusing on reinforcement learning for language models. However, reinforcement learning is a broad field with many applications beyond language models. If you're interested in learning more about reinforcement learning, you should check out the [Deep Reinforcement Learning course](https://huggingface.co/courses/deep-rl-course/en/unit1/introduction).
+In this chapter, we are focusing on reinforcement learning for language models. However, reinforcement learning is a broad field with many applications beyond language models. If you're interested in learning more about reinforcement learning, you should check out the [Deep Reinforcement Learning course](https://huggingface.co/learn/deep-rl-course/en/unit1/introduction).
 
 </Tip>
 

--- a/chapters/rum/chapter12/2.mdx
+++ b/chapters/rum/chapter12/2.mdx
@@ -6,7 +6,7 @@ Vom începe călătoria noastră în lumea captivantă a Învățării prin Înt
 
 <Tip>
 
-În acest capitol, ne concentrăm pe învățarea prin întărire pentru modelele de limbaj. Cu toate acestea, învățarea prin întărire este un domeniu larg cu multe aplicații dincolo de modelele de limbaj. Dacă ești interesat să înveți mai multe despre învățarea prin întărire, ar trebui să consulți [Cursul de Învățare prin Întărire Profundă](https://huggingface.co/courses/deep-rl-course/en/unit1/introduction).
+În acest capitol, ne concentrăm pe învățarea prin întărire pentru modelele de limbaj. Cu toate acestea, învățarea prin întărire este un domeniu larg cu multe aplicații dincolo de modelele de limbaj. Dacă ești interesat să înveți mai multe despre învățarea prin întărire, ar trebui să consulți [Cursul de Învățare prin Întărire Profundă](https://huggingface.co/learn/deep-rl-course/en/unit1/introduction).
 
 </Tip>
 


### PR DESCRIPTION
This PR replaces the outdated URL:

https://huggingface.co/courses/deep-rl-course/en/unit1/introduction  
(which returns a 404)

with the correct, working link:

https://huggingface.co/learn/deep-rl-course/en/unit1/introduction

The fix was applied in both the English and Romanian versions of the course.
