### PR TITLE
Update 2.mdx - Convert Arrow columns to list before tokenization

### DIFF
--- a/chapters/en/chapter3/2.mdx
+++ b/chapters/en/chapter3/2.mdx
@@ -129,8 +129,8 @@ from transformers import AutoTokenizer
 
 checkpoint = "bert-base-uncased"
 tokenizer = AutoTokenizer.from_pretrained(checkpoint)
-tokenized_sentences_1 = tokenizer(raw_datasets["train"]["sentence1"])
-tokenized_sentences_2 = tokenizer(raw_datasets["train"]["sentence2"])
+tokenized_sentences_1 = tokenizer(list(raw_datasets["train"]["sentence1"]))
+tokenized_sentences_2 = tokenizer(list(raw_datasets["train"]["sentence2"]))
 ```
 
 <Tip>


### PR DESCRIPTION
The Transformers tokenizer expects a string or a Python list/sequence of strings. Arrow Column objects (from datasets) are not directly supported and raise ValueError Wrapping the column with list(...) materializes a list of plain Python strings so the tokenizer accepts them.