### PR TITLE
fix: replace set_format('torch') with with_format('torch') to avoid N…

### DIFF
--- a/chapters/en/chapter3/4.mdx
+++ b/chapters/en/chapter3/4.mdx
@@ -47,7 +47,7 @@ Our `tokenized_datasets` has one method for each of those steps:
 ```py
 tokenized_datasets = tokenized_datasets.remove_columns(["sentence1", "sentence2", "idx"])
 tokenized_datasets = tokenized_datasets.rename_column("label", "labels")
-tokenized_datasets.set_format("torch")
+tokenized_datasets.with_format("torch")
 tokenized_datasets["train"].column_names
 ```
 


### PR DESCRIPTION
The use of set_format("torch") on Hugging Face datasets can sometimes result in a TypeError: 'NoneType' object is not callable because set_format mutates the dataset in place and may return None. A safer alternative is to use with_format("torch"), which creates a formatted view of the dataset without mutating the original, preventing this error.