### PR TITLE
docs: Fix contradiction and misleading code in Chapter 2 Models section

### DIFF
--- a/chapters/en/chapter2/3.mdx
+++ b/chapters/en/chapter2/3.mdx
@@ -277,21 +277,11 @@ encoded_sequences = [
 ]
 ```
 
-This is a list of encoded sequences: a list of lists. Tensors only accept rectangular shapes (think matrices). This "array" is already of rectangular shape, so converting it to a tensor is easy:
+This is a list of encoded sequences: a list of lists. As you can see, the lengths of the tokenized outputs are different. Tensors require a "rectangular" shape (like a matrix), so you won't be able to convert this list of lists directly to a tensor. To resolve this, you need to use padding, as we saw earlier.
 
-```py
-import torch
+### Using the tensors as inputs to the model [[using-the-tensors-as-inputs-to-the-model]]
 
-model_inputs = torch.tensor(encoded_sequences)
-```
-
-### Using the tensors as inputs to the model[[using-the-tensors-as-inputs-to-the-model]]
-
-Making use of the tensors with the model is extremely simple — we just call the model with the inputs:
-
-```py
-output = model(model_inputs)
-```
+Making use of the tensors with the model is extremely simple...
 
 While the model accepts a lot of different arguments, only the input IDs are necessary. We'll explain what the other arguments do and when they are required later, 
 but first we need to take a closer look at the tokenizers that build the inputs that a Transformer model can understand.


### PR DESCRIPTION
Hi there!
I noticed a small but important error in the "Models" section of Chapter 2 of the course. This PR corrects it.
The Problem:
In the subsection "Why is all of this necessary?", the text demonstrates tokenizing two sentences that result in lists of different lengths. However, the following paragraph incorrectly states:
This "array" is already of rectangular shape, so converting it to a tensor is easy:

import torch
model_inputs = torch.tensor(encoded_sequences)

This is a contradiction, and the code snippet would fail, which could be confusing for learners.
The Solution:
I've updated the text to correctly identify that the lists are of different lengths and therefore require padding to be converted into a rectangular tensor. I also removed the erroneous code snippet.
This change makes the explanation clearer, more accurate, and reinforces the importance of the padding concept discussed just before this section.
Thanks for maintaining this wonderful course