### PR TITLE
Update 5.mdx: Added generation_strategies guide missing link

### DIFF
--- a/chapters/en/chapter1/5.mdx
+++ b/chapters/en/chapter1/5.mdx
@@ -84,7 +84,7 @@ GPT-2's pretraining objective is based entirely on [causal language modeling](ht
 Ready to try your hand at text generation? Check out our complete [causal language modeling guide](https://huggingface.co/docs/transformers/tasks/language_modeling#causal-language-modeling) to learn how to finetune DistilGPT-2 and use it for inference!
 
 <Tip>
-For more information about text generation, check out the [text generation strategies](generation_strategies) guide!
+For more information about text generation, check out the [text generation strategies](https://huggingface.co/docs/transformers/generation_strategies#generation-strategies) guide!
 </Tip>
 
 ### Text classification


### PR DESCRIPTION
Added the missing link for the `generation_strategies` guide.