### PR TITLE
Update 3.mdx

### DIFF
--- a/chapters/en/chapter2/3.mdx
+++ b/chapters/en/chapter2/3.mdx
@@ -277,10 +277,16 @@ encoded_sequences = [
 ]
 ```
 
-This is a list of encoded sequences: a list of lists. Tensors only accept rectangular shapes (think matrices). This "array" is already of rectangular shape, so converting it to a tensor is easy:
+This is a list of encoded sequences: a list of lists. Tensors only accept rectangular shapes.  
+Because these lists have different lengths, we can **pad** the shorter ones with zeros so they all have the same size:
 
 ```py
 import torch
+
+encoded_sequences = [
+    [101, 1045, 1005, 2310, 2042, 3403, 2005, 1037, 17662, 12172, 2607, 2026, 2878, 2166, 1012, 102],
+    [101, 1045, 5223, 2023, 2061, 2172, 999, 102, 0, 0, 0, 0, 0, 0, 0, 0],
+]
 
 model_inputs = torch.tensor(encoded_sequences)
 ```


### PR DESCRIPTION
The current text says the list of encoded sequences is “already of rectangular shape,” but the example actually contains lists of different lengths (16 and 8 tokens). This means the array is not rectangular and cannot be directly converted to a tensor without padding.
<img width="1055" height="903" alt="image" src="https://github.com/user-attachments/assets/9bddd8b4-94ec-45fe-9aff-9d6e47a030ad" />
<img width="1031" height="350" alt="image" src="https://github.com/user-attachments/assets/62390535-d79a-41e3-9d35-cb6745f3f6b2" />
