### PR TITLE
feat(my): Add Myanmar translation for Chapter 7 and per-chapter Glossary

### DIFF
--- a/chapters/my/_toctree.yml
+++ b/chapters/my/_toctree.yml
@@ -131,27 +131,27 @@
     title: အခန်း (၆) ဆိုင်ရာ မေးခွန်းများ
     quiz: 6
 
-# - title: 7. Classical NLP tasks
-#   sections:
-#   - local: chapter7/1
-#     title: Introduction
-#   - local: chapter7/2
-#     title: Token classification
-#   - local: chapter7/3
-#     title: Fine-tuning a masked language model
-#   - local: chapter7/4
-#     title: Translation
-#   - local: chapter7/5
-#     title: Summarization
-#   - local: chapter7/6
-#     title: Training a causal language model from scratch
-#   - local: chapter7/7
-#     title: Question answering
-#   - local: chapter7/8
-#     title: Mastering LLMs
-#   - local: chapter7/9
-#     title: End-of-chapter quiz
-#     quiz: 7
+- title: 7. Classical NLP Tasks များ
+  sections:
+  - local: chapter7/1
+    title: နိဒါန်း
+  - local: chapter7/2
+    title: Token Classification
+  - local: chapter7/3
+    title: Masked Language Model တစ်ခုကို Fine-tuning လုပ်ခြင်း
+  - local: chapter7/4
+    title: ဘာသာပြန်ခြင်း
+  - local: chapter7/5
+    title: အနှစ်ချုပ်ဖော်ပြခြင်း
+  - local: chapter7/6
+    title: Causal Language Model တစ်ခုကို အစကနေ Train လုပ်ခြင်း
+  - local: chapter7/7
+    title: မေးခွန်းဖြေဆိုခြင်း
+  - local: chapter7/8
+    title: LLM များကို ကျွမ်းကျင်ခြင်း
+  - local: chapter7/9
+    title: အခန်း (၇) ဆိုင်ရာ မေးခွန်းများ
+    quiz: 7
 
 # - title: 8. How to ask for help
 #   sections:

--- a/chapters/my/chapter7/1.mdx
+++ b/chapters/my/chapter7/1.mdx
@@ -1,0 +1,61 @@
+<FrameworkSwitchCourse {fw} />
+
+# နိဒါန်း[[introduction]]
+
+<CourseFloatingBanner
+    chapter={7}
+    classNames="absolute z-10 right-0 top-0"
+/>
+
+[Chapter 3](/course/chapter3) မှာ သင်ဟာ text classification အတွက် model တစ်ခုကို fine-tune လုပ်နည်းကို တွေ့ခဲ့ရပါတယ်။ ဒီအခန်းမှာတော့၊ traditional NLP models တွေနဲ့ modern LLMs တွေ နှစ်ခုလုံးနဲ့ အလုပ်လုပ်ဖို့အတွက် မရှိမဖြစ်လိုအပ်တဲ့ အောက်ပါ common language tasks တွေကို ကျွန်တော်တို့ ကိုင်တွယ်ဖြေရှင်းသွားမှာပါ။ 
+
+- Token classification
+- Masked language modeling (BERT ကဲ့သို့)
+- အနှစ်ချုပ်ဖော်ပြခြင်း (Summarization)
+- ဘာသာပြန်ခြင်း (Translation)
+- Causal language modeling pretraining (GPT-2 ကဲ့သို့)
+- မေးခွန်းဖြေဆိုခြင်း (Question answering)
+
+ဒီအခြေခံ tasks တွေက Large Language Models (LLMs) တွေ ဘယ်လိုအလုပ်လုပ်တယ်ဆိုတာရဲ့ အခြေခံအုတ်မြစ်တွေကို ဖွဲ့စည်းထားပြီး၊ ဒါတွေကို နားလည်ထားခြင်းက ဒီနေ့ခေတ်ရဲ့ အဆင့်မြင့်ဆုံး language models တွေနဲ့ ထိထိရောက်ရောက် အလုပ်လုပ်ဖို့အတွက် အရေးကြီးပါတယ်။
+
+{#if fw === 'pt'}
+
+ဒါတွေကို လုပ်ဆောင်ဖို့အတွက်၊ [Chapter 3](/course/chapter3) မှာ သင်သင်ယူခဲ့တဲ့ `Trainer` API နဲ့ 🤗 Accelerate library အကြောင်း၊ [Chapter 5](/course/chapter5) မှာ 🤗 Datasets library အကြောင်း၊ ပြီးတော့ [Chapter 6](/course/chapter6) မှာ 🤗 Tokenizers library အကြောင်း သင်သင်ယူခဲ့တဲ့ အရာအားလုံးကို အကျိုးယူဖို့ လိုအပ်ပါလိမ့်မယ်။ [Chapter 4](/course/chapter4) မှာ လုပ်ခဲ့သလို ကျွန်တော်တို့ရဲ့ ရလဒ်တွေကို Model Hub ကိုလည်း upload လုပ်သွားမှာဖြစ်တဲ့အတွက်၊ ဒါဟာ အရာအားလုံး ပေါင်းစပ်လာမယ့် အခန်းပါပဲ!
+
+အပိုင်းတစ်ခုစီကို သီးခြားစီ ဖတ်ရှုနိုင်ပြီး `Trainer` API ဒါမှမဟုတ် သင်ကိုယ်တိုင်ရဲ့ training loop ကို 🤗 Accelerate အသုံးပြုပြီး model တစ်ခုကို ဘယ်လို train လုပ်ရမယ်ဆိုတာ ပြသပေးပါလိမ့်မယ်။ အပိုင်းနှစ်ခုထဲက စိတ်ဝင်စားရာ တစ်ခုကို ကျော်သွားပြီး အဲဒီတစ်ခုတည်းကိုပဲ အာရုံစိုက်နိုင်ပါတယ်။ `Trainer` API က model ကို fine-tuning လုပ်တာ ဒါမှမဟုတ် နောက်ကွယ်မှာ ဘာတွေဖြစ်နေလဲဆိုတာကို စိုးရိမ်စရာမလိုဘဲ train လုပ်တာအတွက် အကောင်းဆုံးဖြစ်ပြီး၊ `Accelerate` နဲ့ training loop ကတော့ သင်လိုချင်တဲ့ အစိတ်အပိုင်းတိုင်းကို ပိုမိုလွယ်ကူစွာ customize လုပ်နိုင်စေပါလိမ့်မယ်။
+
+{:else}
+
+ဒါတွေကို လုပ်ဆောင်ဖို့အတွက်၊ [Chapter 3](/course/chapter3) မှာ Keras API နဲ့ models တွေကို train လုပ်တာအကြောင်း သင်သင်ယူခဲ့တဲ့ အရာအားလုံး၊ [Chapter 5](/course/chapter5) မှာ 🤗 Datasets library အကြောင်း၊ ပြီးတော့ [Chapter 6](/course/chapter6) မှာ 🤗 Tokenizers library အကြောင်း သင်သင်ယူခဲ့တဲ့ အရာအားလုံးကို အကျိုးယူဖို့ လိုအပ်ပါလိမ့်မယ်။ [Chapter 4](/course/chapter4) မှာ လုပ်ခဲ့သလို ကျွန်တော်တို့ရဲ့ ရလဒ်တွေကို Model Hub ကိုလည်း upload လုပ်သွားမှာဖြစ်တဲ့အတွက်၊ ဒါဟာ အရာအားလုံး ပေါင်းစပ်လာမယ့် အခန်းပါပဲ!
+
+အပိုင်းတစ်ခုစီကို သီးခြားစီ ဖတ်ရှုနိုင်ပါတယ်။
+
+{/if}
+
+> [!TIP]
+> အကယ်၍ သင်သည် အပိုင်းများကို အစီအစဉ်အတိုင်း ဖတ်ပါက၊ ၎င်းတို့တွင် ကုတ်ဒ်နှင့် စာသားများ အတန်အသင့် တူညီနေသည်ကို သတိပြုမိပါလိမ့်မည်။ ထပ်ခါတလဲလဲ ဖော်ပြခြင်းမှာ သင်စိတ်ဝင်စားသော မည်သည့်လုပ်ငန်းအတွက်မဆို (သို့မဟုတ် နောက်မှ ပြန်လာရန်) အပြည့်အစုံသော လုပ်ဆောင်နိုင်သည့် ဥပမာတစ်ခုကို တွေ့ရှိနိုင်စေရန် ရည်ရွယ်ပါသည်။
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **Fine-tune**: ကြိုတင်လေ့ကျင့်ထားပြီးသား (pre-trained) မော်ဒယ်တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (specific task) အတွက် အနည်းငယ်သော ဒေတာနဲ့ ထပ်မံလေ့ကျင့်ပေးခြင်းကို ဆိုလိုပါတယ်။
+*   **Text Classification**: စာသားကို သတ်မှတ်ထားသော အမျိုးအစားများထဲသို့ ခွဲခြားသတ်မှတ်ခြင်းနှင့် သက်ဆိုင်သော ပြဿနာ။
+*   **Traditional NLP Models**: Neural Networks များ မပေါ်မီက အသုံးပြုခဲ့သော Natural Language Processing (NLP) models များ (ဥပမာ- rule-based systems, statistical models)။
+*   **Modern LLMs (Large Language Models)**: Transformer Architecture ပေါ်တွင် အခြေခံပြီး ဒေတာအမြောက်အမြားဖြင့် လေ့ကျင့်ထားသော ခေတ်မီဘာသာစကားမော်ဒယ်ကြီးများ။
+*   **Token Classification**: စာသား sequence တစ်ခုအတွင်းရှိ token တစ်ခုစီကို အမျိုးအစားခွဲခြားသတ်မှတ်ခြင်း လုပ်ငန်း (ဥပမာ- Named Entity Recognition)။
+*   **Masked Language Modeling (MLM)**: စာကြောင်းတစ်ခုထဲမှ စကားလုံးအချို့ကို ဝှက်ထားပြီး ၎င်းတို့ကို ခန့်မှန်းစေခြင်းဖြင့် model ကို လေ့ကျင့်သော task (BERT ကဲ့သို့)။
+*   **Summarization**: ရှည်လျားသော စာသားတစ်ခု၏ အနှစ်ချုပ်ကို ထုတ်လုပ်ခြင်း။
+*   **Translation**: ဘာသာစကားတစ်ခုမှ အခြားဘာသာစကားတစ်ခုသို့ စာသားများကို ဘာသာပြန်ခြင်း။
+*   **Causal Language Modeling Pretraining**: စာကြောင်းတစ်ခု၏ နောက်ဆက်တွဲ token (စကားလုံး) ကို ခန့်မှန်းခြင်းဖြင့် model ကို လေ့ကျင့်သော task (GPT-2 ကဲ့သို့)။
+*   **Question Answering**: ပေးထားသော စာသားတစ်ခုမှ မေးခွန်းတစ်ခု၏ အဖြေကို ရှာဖွေခြင်း။
+*   **Tasks**: Artificial Intelligence (AI) သို့မဟုတ် Machine Learning (ML) မော်ဒယ်တစ်ခုက လုပ်ဆောင်ရန် ဒီဇိုင်းထုတ်ထားသော သီးခြားအလုပ်။
+*   **Large Language Models (LLMs)**: လူသားဘာသာစကားကို နားလည်ပြီး ထုတ်လုပ်ပေးနိုင်တဲ့ အလွန်ကြီးမားတဲ့ Artificial Intelligence (AI) မော်ဒယ်တွေ ဖြစ်ပါတယ်။
+*   **`Trainer` API**: Hugging Face Transformers library မှ model များကို ထိရောက်စွာ လေ့ကျင့်ရန်အတွက် ဒီဇိုင်းထုတ်ထားသော မြင့်မားသောအဆင့် API။
+*   **🤗 Accelerate Library**: Hugging Face က ထုတ်လုပ်ထားတဲ့ library တစ်ခုဖြစ်ပြီး PyTorch code တွေကို မတူညီတဲ့ training environment (ဥပမာ - GPU အများအပြား၊ distributed training) တွေမှာ အလွယ်တကူ run နိုင်အောင် ကူညီပေးပါတယ်။
+*   **🤗 Datasets Library**: Hugging Face က ထုတ်လုပ်ထားတဲ့ library တစ်ခုဖြစ်ပြီး AI မော်ဒယ်တွေ လေ့ကျင့်ဖို့အတွက် ဒေတာအစုအဝေး (datasets) တွေကို လွယ်လွယ်ကူကူ ဝင်ရောက်ရယူ၊ စီမံခန့်ခွဲပြီး အသုံးပြုနိုင်စေပါတယ်။
+*   **🤗 Tokenizers Library**: Rust ဘာသာနဲ့ ရေးသားထားတဲ့ Hugging Face library တစ်ခုဖြစ်ပြီး မြန်ဆန်ထိရောက်တဲ့ tokenization ကို လုပ်ဆောင်ပေးသည်။
+*   **Model Hub**: Hugging Face Hub ကို ရည်ညွှန်းပြီး AI မော်ဒယ်များ ရှာဖွေ၊ မျှဝေ၊ အသုံးပြုနိုင်သော ဗဟို platform။
+*   **Upload Results**: လေ့ကျင့်ထားသော model ၏ ရလဒ်များ သို့မဟုတ် model files များကို Hugging Face Hub သို့ တင်ခြင်း။
+*   **Training Loop**: model တစ်ခုကို လေ့ကျင့်ရန်အတွက် iterations များစွာဖြင့် လုပ်ဆောင်သော အဓိက code အပိုင်း။
+*   **Customize**: မိမိနှစ်သက်ရာ သို့မဟုတ် လိုအပ်ချက်များအတိုင်း ပြင်ဆင်ခြင်း။
+*   **Keras API**: TensorFlow library တွင် ပါဝင်သော မြင့်မားသောအဆင့် (high-level) API တစ်ခုဖြစ်ပြီး deep learning models များကို လွယ်ကူလျင်မြန်စွာ တည်ဆောက်ရန် အသုံးပြုသည်။
+*   **Prose**: ပုံမှန်စာသား သို့မဟုတ် စကားပြေ။

--- a/chapters/my/chapter7/2.mdx
+++ b/chapters/my/chapter7/2.mdx
@@ -1,0 +1,1140 @@
+<FrameworkSwitchCourse {fw} />
+
+# Token Classification[[token-classification]]
+
+{#if fw === 'pt'}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section2_pt.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section2_pt.ipynb"},
+]} />
+
+{:else}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section2_tf.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section2_tf.ipynb"},
+]} />
+
+{/if}
+
+ကျွန်တော်တို့ လေ့လာမယ့် ပထမဆုံး application ကတော့ token classification ဖြစ်ပါတယ်။ ဒီ generic task က "စာကြောင်းတစ်ကြောင်းရှိ token တစ်ခုစီကို label တစ်ခု သတ်မှတ်ခြင်း" အဖြစ် ဖော်ပြနိုင်တဲ့ ပြဿနာအားလုံးကို ဖော်ပြပါတယ်၊ ဥပမာ...
+
+-   **Named entity recognition (NER)**: စာကြောင်းတစ်ခုထဲက entities တွေ (ဥပမာ - လူပုဂ္ဂိုလ်၊ နေရာဒေသ၊ အဖွဲ့အစည်း) ကို ရှာဖွေပါ။ ဒါကို entity တစ်ခုစီအတွက် class တစ်ခုစီနဲ့ "no entity" အတွက် class တစ်ခုစီထားပြီး token တစ်ခုစီကို label တစ်ခု သတ်မှတ်ခြင်းအဖြစ် ဖော်ပြနိုင်ပါတယ်။
+-   **Part-of-speech tagging (POS)**: စာကြောင်းတစ်ခုစီရှိ စကားလုံးတစ်လုံးစီကို သီးခြား part of speech တစ်ခု (ဥပမာ - noun, verb, adjective စသည်) နှင့် သက်ဆိုင်ကြောင်း မှတ်သားပါ။
+-   **Chunking**: တူညီတဲ့ entity ထဲမှာ ပါဝင်တဲ့ tokens တွေကို ရှာဖွေပါ။ ဒီ task (POS ဒါမှမဟုတ် NER နဲ့ ပေါင်းစပ်နိုင်ပါတယ်) ကို chunk တစ်ခုရဲ့အစမှာ ရှိတဲ့ tokens တွေအတွက် label တစ်ခု (ပုံမှန်အားဖြင့် `B-`)၊ chunk အတွင်းမှာရှိတဲ့ tokens တွေအတွက် တခြား label တစ်ခု (ပုံမှန်အားဖြင့် `I-`)၊ ပြီးတော့ ဘယ် chunk နဲ့မှ မသက်ဆိုင်တဲ့ tokens တွေအတွက် တတိယ label တစ်ခု (ပုံမှန်အားဖြင့် `O`) သတ်မှတ်ခြင်းအဖြစ် ဖော်ပြနိုင်ပါတယ်။
+
+<Youtube id="wVHdVlPScxA"/>
+
+ဟုတ်ပါတယ်။ token classification problem အမျိုးအစားများစွာ ရှိပါသေးတယ်၊ ဒါတွေက ကိုယ်စားပြုတဲ့ ဥပမာအနည်းငယ်မျှသာ ဖြစ်ပါတယ်။ ဒီအပိုင်းမှာ၊ ကျွန်တော်တို့ဟာ NER task တစ်ခုပေါ်မှာ model (BERT) တစ်ခုကို fine-tune လုပ်သွားမှာဖြစ်ပြီး၊ အဲဒါက အခုလို predictions တွေကို တွက်ချက်နိုင်ပါလိမ့်မယ်-
+
+<iframe src="https://course-demos-bert-finetuned-ner.hf.space" frameBorder="0" height="350" title="Gradio app" class="block dark:hidden container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
+
+<a class="flex justify-center" href="/huggingface-course/bert-finetuned-ner">
+<img class="block dark:hidden lg:w-3/5" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/model-eval-bert-finetuned-ner.png" alt="One-hot encoded labels for question answering."/>
+<img class="hidden dark:block lg:w-3/5" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/model-eval-bert-finetuned-ner-dark.png" alt="One-hot encoded labels for question answering."/>
+</a>
+
+ကျွန်တော်တို့ train လုပ်ပြီး Hub ကို upload လုပ်မယ့် model ကို [ဒီနေရာမှာ](https://huggingface.co/huggingface-course/bert-finetuned-ner?text=My+name+is+Sylvain+and+I+work+at+Hugging+Face+in+Brooklyn) ရှာပြီး ၎င်းရဲ့ predictions တွေကို ထပ်မံစစ်ဆေးနိုင်ပါတယ်။
+
+## ဒေတာကို ပြင်ဆင်ခြင်း[[preparing-the-data]]
+
+ပထမဆုံးအနေနဲ့၊ ကျွန်တော်တို့မှာ token classification အတွက် သင့်လျော်တဲ့ dataset တစ်ခု လိုအပ်ပါတယ်။ ဒီအပိုင်းမှာ ကျွန်တော်တို့ [CoNLL-2003 dataset](https://huggingface.co/datasets/conll2003) ကို အသုံးပြုပါမယ်။ ဒါက Reuters က သတင်းများ ပါဝင်ပါတယ်။
+
+> [!TIP]
+> 💡 သင့် dataset က သက်ဆိုင်ရာ labels တွေနဲ့အတူ စကားလုံးတွေအဖြစ် ပိုင်းခြားထားတဲ့ texts တွေနဲ့ ဖွဲ့စည်းထားသရွေ့၊ ဒီနေရာမှာ ဖော်ပြထားတဲ့ data processing procedures တွေကို သင့်ကိုယ်ပိုင် dataset နဲ့ လိုက်လျောညီထွေဖြစ်အောင် ပြုလုပ်နိုင်ပါလိမ့်မယ်။ သင့်ကိုယ်ပိုင် custom data ကို `Dataset` ထဲမှာ ဘယ်လို load လုပ်ရမလဲဆိုတာ ပြန်လည်လေ့လာဖို့ လိုအပ်ရင် [Chapter 5](/course/chapter5) ကို ပြန်ကြည့်ပါ။
+
+### CoNLL-2003 Dataset[[the-conll-2003-dataset]]
+
+CoNLL-2003 dataset ကို load လုပ်ဖို့၊ 🤗 Datasets library ကနေ `load_dataset()` method ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။
+
+```py
+from datasets import load_dataset
+
+raw_datasets = load_dataset("conll2003")
+```
+
+ဒါက dataset ကို download လုပ်ပြီး cache လုပ်ပါလိမ့်မယ်၊ [Chapter 3](/course/chapter3) မှာ GLUE MRPC dataset အတွက် ကျွန်တော်တို့ တွေ့ခဲ့ရသလိုပါပဲ။ ဒီ object ကို စစ်ဆေးကြည့်ခြင်းက ရှိနေတဲ့ columns တွေနဲ့ training, validation, test sets တွေကြားက split ကို ပြသပါတယ်။
+
+```py
+raw_datasets
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['chunk_tags', 'id', 'ner_tags', 'pos_tags', 'tokens'],
+        num_rows: 14041
+    })
+    validation: Dataset({
+        features: ['chunk_tags', 'id', 'ner_tags', 'pos_tags', 'tokens'],
+        num_rows: 3250
+    })
+    test: Dataset({
+        features: ['chunk_tags', 'id', 'ner_tags', 'pos_tags', 'tokens'],
+        num_rows: 3453
+    })
+})
+```
+
+အထူးသဖြင့်၊ dataset မှာ ကျွန်တော်တို့ အစောပိုင်းက ဖော်ပြခဲ့တဲ့ tasks သုံးခု (NER, POS, chunking) အတွက် labels တွေ ပါဝင်တာကို မြင်နိုင်ပါတယ်။ တခြား datasets တွေနဲ့ အဓိက ကွာခြားချက်ကတော့ input texts တွေဟာ sentences သို့မဟုတ် documents တွေအဖြစ် မဟုတ်ဘဲ words list တွေအဖြစ် တင်ပြထားခြင်းပါပဲ (နောက်ဆုံး column ကို `tokens` လို့ခေါ်ပေမယ့်၊ subword tokenization အတွက် tokenizer ကို ထပ်မံဖြတ်သန်းဖို့ လိုအပ်နေသေးတဲ့ pre-tokenized inputs တွေဖြစ်တဲ့အတွက် ၎င်းမှာ words တွေ ပါဝင်ပါတယ်)။
+
+training set ရဲ့ ပထမဆုံး element ကို ကြည့်ရအောင်...
+
+```py
+raw_datasets["train"][0]["tokens"]
+```
+
+```python out
+['EU', 'rejects', 'German', 'call', 'to', 'boycott', 'British', 'lamb', '.']
+```
+
+ကျွန်တော်တို့ named entity recognition ကို လုပ်ဆောင်ချင်တာဖြစ်လို့၊ NER tags တွေကို ကြည့်ပါမယ်။
+
+```py
+raw_datasets["train"][0]["ner_tags"]
+```
+
+```python out
+[3, 0, 7, 0, 0, 0, 7, 0, 0]
+```
+
+ဒါတွေက training အတွက် အဆင်သင့်ဖြစ်နေတဲ့ integers တွေအဖြစ် labels တွေပါ၊ ဒါပေမယ့် data ကို စစ်ဆေးကြည့်ချင်တဲ့အခါ အသုံးဝင်မှာ မဟုတ်ပါဘူး။ text classification အတွက်လိုပဲ၊ အဲဒီ integers တွေနဲ့ label names တွေကြားက ဆက်စပ်မှုကို ကျွန်တော်တို့ရဲ့ dataset ရဲ့ `features` attribute ကို ကြည့်ခြင်းဖြင့် ဝင်ရောက်ကြည့်ရှုနိုင်ပါတယ်။
+
+```py
+ner_feature = raw_datasets["train"].features["ner_tags"]
+ner_feature
+```
+
+```python out
+Sequence(feature=ClassLabel(num_classes=9, names=['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC', 'B-MISC', 'I-MISC'], names_file=None, id=None), length=-1, id=None)
+```
+
+ဒါကြောင့် ဒီ column မှာ `ClassLabel`s တွေရဲ့ sequences တွေဖြစ်တဲ့ elements တွေ ပါဝင်ပါတယ်။ sequence ရဲ့ elements အမျိုးအစားက ဒီ `ner_feature` ရဲ့ `feature` attribute ထဲမှာ ရှိပြီး၊ names list ကို အဲဒီ `feature` ရဲ့ `names` attribute ကို ကြည့်ခြင်းဖြင့် ဝင်ရောက်ကြည့်ရှုနိုင်ပါတယ်။
+
+```py
+label_names = ner_feature.feature.names
+label_names
+```
+
+```python out
+['O', 'B-PER', 'I-PER', 'B-ORG', 'I-ORG', 'B-LOC', 'I-LOC', 'B-MISC', 'I-MISC']
+```
+
+[Chapter 6](/course/chapter6/3) မှာ `token-classification` pipeline ကို နက်နက်နဲနဲ လေ့လာတုန်းက ဒီ labels တွေကို ကျွန်တော်တို့ မြင်တွေ့ခဲ့ရပြီးပါပြီ၊ ဒါပေမယ့် လျင်မြန်စွာ ပြန်လည်လေ့လာဖို့-
+
+-   `O` က စကားလုံးဟာ ဘယ် entity နဲ့မှ မသက်ဆိုင်ဘူးလို့ ဆိုလိုပါတယ်။
+-   `B-PER`/`I-PER` က စကားလုံးဟာ *person* entity တစ်ခုရဲ့အစ ဒါမှမဟုတ် အတွင်းမှာ ရှိတယ်လို့ ဆိုလိုပါတယ်။
+-   `B-ORG`/`I-ORG` က စကားလုံးဟာ *organization* entity တစ်ခုရဲ့အစ ဒါမှမဟုတ် အတွင်းမှာ ရှိတယ်လို့ ဆိုလိုပါတယ်။
+-   `B-LOC`/`I-LOC` က စကားလုံးဟာ *location* entity တစ်ခုရဲ့အစ ဒါမှမဟုတ် အတွင်းမှာ ရှိတယ်လို့ ဆိုလိုပါတယ်။
+-   `B-MISC`/`I-MISC` က စကားလုံးဟာ *miscellaneous* entity တစ်ခုရဲ့အစ ဒါမှမဟုတ် အတွင်းမှာ ရှိတယ်လို့ ဆိုလိုပါတယ်။
+
+အခု ကျွန်တော်တို့ အစောပိုင်းက တွေ့ခဲ့ရတဲ့ labels တွေကို decode လုပ်လိုက်ရင် အောက်ပါအတိုင်း ရပါတယ်။
+
+```python
+words = raw_datasets["train"][0]["tokens"]
+labels = raw_datasets["train"][0]["ner_tags"]
+line1 = ""
+line2 = ""
+for word, label in zip(words, labels):
+    full_label = label_names[label]
+    max_length = max(len(word), len(full_label))
+    line1 += word + " " * (max_length - len(word) + 1)
+    line2 += full_label + " " * (max_length - len(full_label) + 1)
+
+print(line1)
+print(line2)
+```
+
+```python out
+'EU    rejects German call to boycott British lamb .'
+'B-ORG O       B-MISC O    O  O       B-MISC  O    O'
+```
+
+ပြီးတော့ `B-` နဲ့ `I-` labels တွေ ရောနှောထားတဲ့ ဥပမာတစ်ခုအတွက်၊ training set ရဲ့ index 4 မှာရှိတဲ့ element ပေါ်မှာ အလားတူ code က ပေးတဲ့ ရလဒ်ကတော့...
+
+```python out
+'Germany \'s representative to the European Union \'s veterinary committee Werner Zwingmann said on Wednesday consumers should buy sheepmeat from countries other than Britain until the scientific advice was clearer .'
+'B-LOC   O  O              O  O   B-ORG    I-ORG O  O          O         B-PER  I-PER     O    O  O         O         O      O   O         O    O         O     O    B-LOC   O     O   O          O      O   O       O'
+```
+
+ကျွန်တော်တို့ မြင်ရတဲ့အတိုင်း၊ "European Union" နဲ့ "Werner Zwingmann" လို စကားလုံးနှစ်လုံးပါတဲ့ entities တွေက ပထမစကားလုံးအတွက် `B-` label နဲ့ ဒုတိယစကားလုံးအတွက် `I-` label ကို ရရှိပါတယ်။
+
+> [!TIP]
+> ✏️ **သင့်အလှည့်!** အဲဒီစာကြောင်းနှစ်ကြောင်းကို ၎င်းတို့ရဲ့ POS ဒါမှမဟုတ် chunking labels တွေနဲ့အတူ ပုံနှိပ်ထုတ်ဝေပါ။
+
+### ဒေတာများကို စီမံဆောင်ရွက်ခြင်း[[processing-the-data]]
+
+<Youtube id="iY2AZYdZAr0"/>
+
+ပုံမှန်အတိုင်းပါပဲ၊ ကျွန်တော်တို့ရဲ့ texts တွေကို model က နားလည်နိုင်ဖို့ token IDs တွေအဖြစ် ပြောင်းလဲဖို့ လိုအပ်ပါတယ်။ [Chapter 6](/course/chapter6/) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့အတိုင်း၊ token classification tasks တွေမှာ အဓိကကွာခြားချက်က pre-tokenized inputs တွေ ရှိနေခြင်းပါပဲ။ ကံကောင်းစွာနဲ့ပဲ၊ tokenizer API က ဒါကို အတော်လေး လွယ်ကူစွာ ကိုင်တွယ်နိုင်ပါတယ်၊ ကျွန်တော်တို့ `tokenizer` ကို special flag တစ်ခုနဲ့ သတိပေးဖို့ပဲ လိုပါတယ်။
+
+စတင်ဖို့အတွက်၊ ကျွန်တော်တို့ရဲ့ `tokenizer` object ကို ဖန်တီးရအောင်။ အရင်က ပြောခဲ့တဲ့အတိုင်း၊ ကျွန်တော်တို့ဟာ BERT pretrained model တစ်ခုကို အသုံးပြုမှာဖြစ်လို့၊ သက်ဆိုင်ရာ tokenizer ကို download လုပ်ပြီး cache လုပ်ခြင်းဖြင့် စတင်ပါမယ်။
+
+```python
+from transformers import AutoTokenizer
+
+model_checkpoint = "bert-base-cased"
+tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
+```
+
+သင် `model_checkpoint` ကို [Hub](https://huggingface.co/models) က သင်နှစ်သက်ရာ တခြား model တစ်ခုနဲ့၊ ဒါမှမဟုတ် pretrained model နဲ့ tokenizer တစ်ခုကို သိမ်းဆည်းထားတဲ့ local folder တစ်ခုနဲ့ အစားထိုးနိုင်ပါတယ်။ တစ်ခုတည်းသော ကန့်သတ်ချက်ကတော့ tokenizer ဟာ 🤗 Tokenizers library နဲ့ ထောက်ပံ့ထားရမှာဖြစ်ပြီး၊ ဒါကြောင့် "fast" version တစ်ခု ရရှိနိုင်ရပါမယ်။ fast version ပါဝင်တဲ့ architectures အားလုံးကို [ဒီဇယားကြီး](https://huggingface.co/transformers/#supported-frameworks) မှာ ကြည့်နိုင်ပြီး၊ သင်အသုံးပြုနေတဲ့ `tokenizer` object က 🤗 Tokenizers နဲ့ ထောက်ပံ့ထားခြင်းရှိမရှိ စစ်ဆေးဖို့အတွက် ၎င်းရဲ့ `is_fast` attribute ကို ကြည့်နိုင်ပါတယ်။
+
+```py
+tokenizer.is_fast
+```
+
+```python out
+True
+```
+
+pre-tokenized input တစ်ခုကို tokenize လုပ်ဖို့၊ ကျွန်တော်တို့ရဲ့ `tokenizer` ကို ပုံမှန်အတိုင်း အသုံးပြုပြီး `is_split_into_words=True` ကို ထပ်ထည့်ပေးရုံပါပဲ။
+
+```py
+inputs = tokenizer(raw_datasets["train"][0]["tokens"], is_split_into_words=True)
+inputs.tokens()
+```
+
+```python out
+['[CLS]', 'EU', 'rejects', 'German', 'call', 'to', 'boycott', 'British', 'la', '##mb', '.', '[SEP]']
+```
+
+ကျွန်တော်တို့ မြင်ရတဲ့အတိုင်း၊ tokenizer က model အသုံးပြုတဲ့ special tokens တွေ (`[CLS]` ကို အစမှာနဲ့ `[SEP]` ကို အဆုံးမှာ) ထည့်သွင်းပေးပြီး စကားလုံးအများစုကို မပြောင်းလဲဘဲ ထားခဲ့ပါတယ်။ သို့သော်လည်း၊ `lamb` ဆိုတဲ့ စကားလုံးကို subwords နှစ်ခုဖြစ်တဲ့ `la` နဲ့ `##mb` အဖြစ် tokenize လုပ်ခဲ့ပါတယ်။ ဒါက ကျွန်တော်တို့ရဲ့ inputs နဲ့ labels တွေကြား မကိုက်ညီမှုကို ဖြစ်ပေါ်စေပါတယ်။ labels စာရင်းမှာ elements ၉ ခုပဲ ရှိပေမယ့်၊ ကျွန်တော်တို့ရဲ့ input မှာ အခု tokens ၁၂ ခု ရှိနေပါတယ်။ special tokens တွေကို ထည့်သွင်းစဉ်းစားတာက လွယ်ပါတယ် (ဒါတွေက အစနဲ့ အဆုံးမှာ ရှိတယ်ဆိုတာ ကျွန်တော်တို့ သိပါတယ်)၊ ဒါပေမယ့် labels အားလုံးကို မှန်ကန်တဲ့ words တွေနဲ့ ချိန်ညှိဖို့လည်း သေချာစေဖို့ လိုပါတယ်။
+
+ကံကောင်းစွာနဲ့ပဲ၊ ကျွန်တော်တို့ fast tokenizer ကို အသုံးပြုနေတာကြောင့် 🤗 Tokenizers ရဲ့ စွမ်းအားတွေကို ရရှိထားပါတယ်၊ ဒါက token တစ်ခုစီကို ၎င်းရဲ့ သက်ဆိုင်ရာ word နဲ့ အလွယ်တကူ map လုပ်နိုင်တယ်လို့ ဆိုလိုပါတယ် ([Chapter 6](/course/chapter6/3) မှာ တွေ့ခဲ့ရတဲ့အတိုင်းပါပဲ)။
+
+```py
+inputs.word_ids()
+```
+
+```python out
+[None, 0, 1, 2, 3, 4, 5, 6, 7, 7, 8, None]
+```
+
+အနည်းငယ်လုပ်ဆောင်ခြင်းဖြင့်၊ ကျွန်တော်တို့ရဲ့ label list ကို tokens တွေနဲ့ ကိုက်ညီအောင် ချဲ့ထွင်နိုင်ပါတယ်။ ကျွန်တော်တို့ အသုံးပြုမယ့် ပထမဆုံး စည်းမျဉ်းကတော့ special tokens တွေက `-100` ဆိုတဲ့ label ကို ရရှိမှာ ဖြစ်ပါတယ်။ ဒါက default အားဖြင့် `-100` က ကျွန်တော်တို့ အသုံးပြုမယ့် loss function (cross entropy) မှာ လျစ်လျူရှုခံရတဲ့ index တစ်ခုဖြစ်လို့ပါ။ ပြီးတော့၊ token တစ်ခုစီဟာ ၎င်းပါဝင်တဲ့ word ရဲ့ အစက token နဲ့ တူညီတဲ့ label ကို ရရှိပါတယ်။ ဘာလို့လဲဆိုတော့ ၎င်းတို့ဟာ entity တစ်ခုတည်းရဲ့ အစိတ်အပိုင်းဖြစ်လို့ပါပဲ။ word အတွင်းမှာရှိပေမယ့် အစမှာမရှိတဲ့ tokens တွေအတွက်တော့ `B-` ကို `I-` နဲ့ အစားထိုးပါမယ် (ဘာလို့လဲဆိုတော့ token က entity ရဲ့ အစမဟုတ်လို့ပါ)။
+
+```python
+def align_labels_with_tokens(labels, word_ids):
+    new_labels = []
+    current_word = None
+    for word_id in word_ids:
+        if word_id != current_word:
+            # Start of a new word!
+            current_word = word_id
+            label = -100 if word_id is None else labels[word_id]
+            new_labels.append(label)
+        elif word_id is None:
+            # Special token
+            new_labels.append(-100)
+        else:
+            # Same word as previous token
+            label = labels[word_id]
+            # If the label is B-XXX we change it to I-XXX
+            if label % 2 == 1:
+                label += 1
+            new_labels.append(label)
+
+    return new_labels
+```
+
+ကျွန်တော်တို့ရဲ့ ပထမဆုံးစာကြောင်းပေါ်မှာ စမ်းကြည့်ရအောင်...
+
+```py
+labels = raw_datasets["train"][0]["ner_tags"]
+word_ids = inputs.word_ids()
+print(labels)
+print(align_labels_with_tokens(labels, word_ids))
+```
+
+```python out
+[3, 0, 7, 0, 0, 0, 7, 0, 0]
+[-100, 3, 0, 7, 0, 0, 0, 7, 0, 0, 0, -100]
+```
+
+ကျွန်တော်တို့ မြင်ရတဲ့အတိုင်း၊ ကျွန်တော်တို့ရဲ့ function က အစနဲ့ အဆုံးမှာရှိတဲ့ special tokens နှစ်ခုအတွက် `-100` ကို ထည့်သွင်းပေးခဲ့ပြီး၊ tokens နှစ်ခုအဖြစ် ပိုင်းခြားခံရတဲ့ ကျွန်တော်တို့ရဲ့ word အတွက် `0` အသစ်တစ်ခု ထည့်သွင်းပေးခဲ့ပါတယ်။
+
+> [!TIP]
+> ✏️ **သင့်အလှည့်!** သုတေသီအချို့က word တစ်ခုအတွက် label တစ်ခုတည်းကိုသာ သတ်မှတ်ပြီး၊ ပေးထားတဲ့ word ထဲက ကျန်ရှိတဲ့ subtokens တွေကို `-100` သတ်မှတ်ဖို့ ပိုနှစ်သက်ကြပါတယ်။ ဒါက subtokens များစွာအဖြစ် ပိုင်းခြားတဲ့ ရှည်လျားတဲ့ words တွေက loss ကို အလွန်အမင်း ထိခိုက်စေတာကို ရှောင်ရှားဖို့ပါပဲ။ ဒီစည်းမျဉ်းကို လိုက်နာပြီး input IDs တွေနဲ့ labels တွေကို ချိန်ညှိဖို့ အရင် function ကို ပြောင်းလဲပါ။
+
+ကျွန်တော်တို့ရဲ့ dataset တစ်ခုလုံးကို preprocess လုပ်ဖို့အတွက်၊ inputs အားလုံးကို tokenize လုပ်ပြီး labels အားလုံးပေါ်မှာ `align_labels_with_tokens()` ကို အသုံးပြုဖို့ လိုအပ်ပါတယ်။ ကျွန်တော်တို့ရဲ့ fast tokenizer ရဲ့ အမြန်နှုန်းကို အကျိုးယူဖို့အတွက်၊ texts များစွာကို တစ်ပြိုင်နက်တည်း tokenize လုပ်တာ အကောင်းဆုံးပါပဲ။ ဒါကြောင့် ကျွန်တော်တို့ဟာ examples list တစ်ခုကို process လုပ်မယ့် function တစ်ခုကို ရေးပြီး `Dataset.map()` method ကို `batched=True` option နဲ့ အသုံးပြုပါမယ်။ ကျွန်တော်တို့ရဲ့ ယခင်ဥပမာနဲ့ ကွာခြားတဲ့ တစ်ခုတည်းသောအရာကတော့ `word_ids()` function က tokenizer ရဲ့ inputs တွေက texts list (သို့မဟုတ် ကျွန်တော်တို့ရဲ့ ကိစ္စမှာ words list များ၏ list) တွေဖြစ်တဲ့အခါ၊ word IDs တွေရဲ့ index ကို ရယူဖို့ လိုအပ်တာကြောင့် ကျွန်တော်တို့ အဲဒါကိုလည်း ထည့်သွင်းထားပါတယ်။
+
+```py
+def tokenize_and_align_labels(examples):
+    tokenized_inputs = tokenizer(
+        examples["tokens"], truncation=True, is_split_into_words=True
+    )
+    all_labels = examples["ner_tags"]
+    new_labels = []
+    for i, labels in enumerate(all_labels):
+        word_ids = tokenized_inputs.word_ids(i)
+        new_labels.append(align_labels_with_tokens(labels, word_ids))
+
+    tokenized_inputs["labels"] = new_labels
+    return tokenized_inputs
+```
+
+ကျွန်တော်တို့ inputs တွေကို အခုထိ padding မလုပ်ရသေးဘူးဆိုတာ သတိပြုပါ။ ဒါကို နောက်မှ data collator နဲ့ batches တွေ ဖန်တီးတဲ့အခါ လုပ်ပါမယ်။
+
+အခုဆိုရင် ကျွန်တော်တို့ရဲ့ dataset ရဲ့ တခြား splits တွေပေါ်မှာ preprocessing အားလုံးကို တစ်ပြိုင်နက်တည်း အသုံးပြုနိုင်ပါပြီ။
+
+```py
+tokenized_datasets = raw_datasets.map(
+    tokenize_and_align_labels,
+    batched=True,
+    remove_columns=raw_datasets["train"].column_names,
+)
+```
+
+အခက်ခဲဆုံးအပိုင်းကို ကျွန်တော်တို့ လုပ်ဆောင်ခဲ့ပြီးပါပြီ။ Data ကို preprocess လုပ်ပြီးပြီဆိုတော့၊ တကယ်တမ်း training လုပ်တာက [Chapter 3](/course/chapter3) မှာ ကျွန်တော်တို့ လုပ်ခဲ့တာနဲ့ အတော်လေး ဆင်တူပါလိမ့်မယ်။
+
+{#if fw === 'pt'}
+
+## `Trainer` API ဖြင့် Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model-with-the-trainer-api]]
+
+`Trainer` ကို အသုံးပြုတဲ့ code က အရင်ကလိုပဲ ဖြစ်ပါလိမ့်မယ်။ ပြောင်းလဲမှုတွေကတော့ data ကို batch တစ်ခုအဖြစ် စုစည်းပုံနဲ့ metric computation function တွေပဲ ဖြစ်ပါတယ်။
+
+{:else}
+
+## Keras ဖြင့် Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model-with-keras]]
+
+Keras ကို အသုံးပြုတဲ့ code က အရင်ကနဲ့ အတော်လေး ဆင်တူပါလိမ့်မယ်။ ပြောင်းလဲမှုတွေကတော့ data ကို batch တစ်ခုအဖြစ် စုစည်းပုံနဲ့ metric computation function တွေပဲ ဖြစ်ပါတယ်။
+
+{/if}
+
+### Data Collation[[data-collation]]
+
+[Chapter 3](/course/chapter3) မှာလိုပဲ `DataCollatorWithPadding` ကို အသုံးပြုလို့ မရပါဘူး။ ဘာလို့လဲဆိုတော့ အဲဒါက inputs (input IDs, attention mask, token type IDs) တွေကိုပဲ padding လုပ်ပေးလို့ပါ။ ဒီနေရာမှာ ကျွန်တော်တို့ရဲ့ labels တွေကို inputs တွေအတိုင်း အရွယ်အစားတူညီအောင် padding လုပ်သင့်ပြီး၊ `-100` ကို value အဖြစ် အသုံးပြုသင့်ပါတယ်။ ဒါမှ သက်ဆိုင်ရာ predictions တွေကို loss computation မှာ လျစ်လျူရှုနိုင်မှာပါ။
+
+ဒါတွေအားလုံးကို [`DataCollatorForTokenClassification`](https://huggingface.co/transformers/main_classes/data_collator.html#datacollatorfortokenclassification) က လုပ်ဆောင်ပေးပါတယ်။ `DataCollatorWithPadding` လိုပဲ၊ ဒါက inputs တွေကို preprocess လုပ်ဖို့ အသုံးပြုတဲ့ `tokenizer` ကို ယူပါတယ်။
+
+{#if fw === 'pt'}
+
+```py
+from transformers import DataCollatorForTokenClassification
+
+data_collator = DataCollatorForTokenClassification(tokenizer=tokenizer)
+```
+
+{:else}
+
+```py
+from transformers import DataCollatorForTokenClassification
+
+data_collator = DataCollatorForTokenClassification(
+    tokenizer=tokenizer, return_tensors="tf"
+)
+```
+
+{/if}
+
+examples အနည်းငယ်ပေါ်မှာ ဒါကို စမ်းသပ်ဖို့အတွက်၊ ကျွန်တော်တို့ရဲ့ tokenized training set ကနေ examples list တစ်ခုပေါ်မှာ ခေါ်လိုက်ရုံပါပဲ။
+
+```py
+batch = data_collator([tokenized_datasets["train"][i] for i in range(2)])
+batch["labels"]
+```
+
+```python out
+tensor([[-100,    3,    0,    7,    0,    0,    0,    7,    0,    0,    0, -100],
+        [-100,    1,    2, -100, -100, -100, -100, -100, -100, -100, -100, -100]])
+```
+
+ကျွန်တော်တို့ရဲ့ dataset ထဲက ပထမဆုံးနဲ့ ဒုတိယ elements တွေအတွက် labels တွေနဲ့ နှိုင်းယှဉ်ကြည့်ရအောင်။
+
+```py
+for i in range(2):
+    print(tokenized_datasets["train"][i]["labels"])
+```
+
+```python out
+[-100, 3, 0, 7, 0, 0, 0, 7, 0, 0, 0, -100]
+[-100, 1, 2, -100]
+```
+
+{#if fw === 'pt'}
+
+ကျွန်တော်တို့ မြင်ရတဲ့အတိုင်း၊ ဒုတိယ label set ကို `-100` တွေကို အသုံးပြုပြီး ပထမဆုံး label set ရဲ့ အရှည်အထိ padding လုပ်ထားပါတယ်။
+
+{:else}
+
+ကျွန်တော်တို့ရဲ့ data collator က အဆင်သင့်ဖြစ်ပါပြီ။ အခု `to_tf_dataset()` method နဲ့ `tf.data.Dataset` တစ်ခု ဖန်တီးဖို့ အသုံးပြုရအောင်။ boilerplate code အနည်းငယ် လျှော့ချပြီး လုပ်ဆောင်ဖို့ `model.prepare_tf_dataset()` ကိုလည်း အသုံးပြုနိုင်ပါတယ်၊ ဒီအခန်းရဲ့ တခြားအပိုင်းတွေမှာ ဒါကို သင်မြင်ရပါလိမ့်မယ်။
+
+```py
+tf_train_dataset = tokenized_datasets["train"].to_tf_dataset(
+    columns=["attention_mask", "input_ids", "labels", "token_type_ids"],
+    collate_fn=data_collator,
+    shuffle=True,
+    batch_size=16,
+)
+
+tf_eval_dataset = tokenized_datasets["validation"].to_tf_dataset(
+    columns=["attention_mask", "input_ids", "labels", "token_type_ids"],
+    collate_fn=data_collator,
+    shuffle=False,
+    batch_size=16,
+)
+```
+
+နောက်တစ်ဆင့် - model ကိုယ်တိုင်ပါပဲ။
+
+{/if}
+
+{#if fw === 'tf'}
+
+### Model ကို သတ်မှတ်ခြင်း[[defining-the-model]]
+
+ကျွန်တော်တို့ token classification problem ပေါ်မှာ အလုပ်လုပ်နေတာကြောင့်၊ `TFAutoModelForTokenClassification` class ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။ ဒီ model ကို သတ်မှတ်တဲ့အခါ အဓိက မှတ်ထားရမယ့်အချက်ကတော့ ကျွန်တော်တို့မှာရှိတဲ့ labels အရေအတွက်အကြောင်း အချက်အလက်အချို့ကို ပေးပို့ဖို့ပါပဲ။ ဒီလိုလုပ်ဖို့ အလွယ်ကူဆုံးနည်းလမ်းကတော့ `num_labels` argument နဲ့ အဲဒီအရေအတွက်ကို ပေးဖို့ပါပဲ။ ဒါပေမယ့် ဒီအပိုင်းရဲ့ အစမှာ ကျွန်တော်တို့ မြင်တွေ့ခဲ့ရတဲ့ Inference widget ကဲ့သို့ ကောင်းမွန်တဲ့ widget တစ်ခု လိုချင်ရင်တော့ မှန်ကန်တဲ့ label correspondences တွေကို သတ်မှတ်တာက ပိုကောင်းပါတယ်။
+
+၎င်းတို့ကို `id2label` နဲ့ `label2id` ဆိုတဲ့ dictionaries နှစ်ခုဖြင့် သတ်မှတ်သင့်ပါတယ်။ ဒါတွေက ID ကနေ label သို့၊ label ကနေ ID သို့ mapping တွေ ပါဝင်ပါတယ်။
+
+```py
+id2label = {i: label for i, label in enumerate(label_names)}
+label2id = {v: k for k, v in id2label.items()}
+```
+
+အခုဆိုရင် ကျွန်တော်တို့ ဒါတွေကို `TFAutoModelForTokenClassification.from_pretrained()` method ကို ပေးလိုက်ရုံပါပဲ။ ဒါတွေက model ရဲ့ configuration မှာ သတ်မှတ်ခံရပြီး၊ ကောင်းမွန်စွာ သိမ်းဆည်းပြီး Hub ကို upload လုပ်ပါလိမ့်မယ်။
+
+```py
+from transformers import TFAutoModelForTokenClassification
+
+model = TFAutoModelForTokenClassification.from_pretrained(
+    model_checkpoint,
+    id2label=id2label,
+    label2id=label2id,
+)
+```
+
+[Chapter 3](/course/chapter3) မှာ ကျွန်တော်တို့ `TFAutoModelForSequenceClassification` ကို သတ်မှတ်ခဲ့တုန်းကလိုပဲ၊ model ကို ဖန်တီးတာက weights အချို့ (pretraining head က weights တွေ) ကို အသုံးမပြုခဲ့ဘူး၊ တခြား weights အချို့ (new token classification head က weights တွေ) ကို random အဖြစ် initialized လုပ်ခဲ့တယ်ဆိုတဲ့ warning တစ်ခုကို ထုတ်ပေးပြီး၊ ဒီ model ကို train လုပ်သင့်တယ်လို့ ဆိုပါတယ်။ ကျွန်တော်တို့ ခဏအတွင်းမှာ ဒါကို လုပ်ပါမယ်၊ ဒါပေမယ့် ပထမဆုံး ကျွန်တော်တို့ရဲ့ model မှာ မှန်ကန်တဲ့ labels အရေအတွက် ရှိမရှိ ထပ်မံစစ်ဆေးကြည့်ရအောင်။
+
+```python
+model.config.num_labels
+```
+
+```python out
+9
+```
+
+> [!WARNING]
+> ⚠️ သင့် model မှာ labels အရေအတွက် မှားနေတယ်ဆိုရင်၊ နောက်ပိုင်းမှာ `model.fit()` ကို ခေါ်တဲ့အခါ မရှင်းလင်းတဲ့ error တစ်ခု ရရှိပါလိမ့်မယ်။ ဒါက debug လုပ်ရတာ စိတ်အနှောင့်အယှက်ဖြစ်နိုင်တာကြောင့်၊ မျှော်လင့်ထားတဲ့ labels အရေအတွက် ရှိမရှိ သေချာစေဖို့ ဒီစစ်ဆေးမှုကို လုပ်ဖို့ သေချာလုပ်ပါ။
+
+### Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model]]
+
+ကျွန်တော်တို့ရဲ့ model ကို train လုပ်ဖို့ အခု အဆင်သင့်ဖြစ်ပါပြီ။ ပထမဆုံး လုပ်ရမယ့် အိမ်မှုကိစ္စလေး နည်းနည်းတော့ ကျန်ပါသေးတယ်၊ Hugging Face ကို login ဝင်ပြီး ကျွန်တော်တို့ရဲ့ training hyperparameters တွေကို သတ်မှတ်သင့်ပါတယ်။ သင် notebook မှာ အလုပ်လုပ်နေတယ်ဆိုရင်၊ ဒီအတွက် ကူညီပေးမယ့် convenience function တစ်ခု ရှိပါတယ်။
+
+```python
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+ဒါက သင်ရဲ့ Hugging Face login credentials တွေကို ထည့်သွင်းနိုင်မယ့် widget တစ်ခုကို ပြသပါလိမ့်မယ်။
+
+သင် notebook မှာ အလုပ်မလုပ်ဘူးဆိုရင်၊ သင့် terminal မှာ အောက်ပါစာကြောင်းကို ရိုက်ထည့်လိုက်ရုံပါပဲ။
+
+```bash
+huggingface-cli login
+```
+
+login ဝင်ပြီးနောက်၊ ကျွန်တော်တို့ model ကို compile လုပ်ဖို့ လိုအပ်တဲ့ အရာအားလုံးကို ပြင်ဆင်နိုင်ပါတယ်။ 🤗 Transformers က အဆင်ပြေတဲ့ `create_optimizer()` function တစ်ခုကို ပံ့ပိုးပေးပါတယ်။ ဒါက သင့် model ရဲ့ performance ကို built-in `Adam` optimizer နဲ့ နှိုင်းယှဉ်ရင် ပိုမိုကောင်းမွန်စေမယ့် weight decay နဲ့ learning rate decay အတွက် သင့်လျော်တဲ့ settings တွေနဲ့ `AdamW` optimizer တစ်ခုကို ပေးပါလိမ့်မယ်။
+
+```python
+from transformers import create_optimizer
+import tensorflow as tf
+
+# mixed-precision float16 နဲ့ train လုပ်ပါ
+# ဒါက အကျိုးမဖြစ်ထွန်းမယ့် GPU ကို အသုံးပြုနေရင် ဒီစာကြောင်းကို comment လုပ်ထားပါ
+tf.keras.mixed_precision.set_global_policy("mixed_float16")
+
+# training steps အရေအတွက်ကတော့ dataset ထဲက samples အရေအတွက်ကို batch size နဲ့ စားပြီးမှ
+# epochs စုစုပေါင်း အရေအတွက်နဲ့ မြှောက်တာပါ။ ဒီနေရာက tf_train_dataset က batched tf.data.Dataset
+# ဖြစ်ပြီး original Hugging Face Dataset မဟုတ်တာကြောင့်၊ ၎င်းရဲ့ len() က num_samples // batch_size
+# ဖြစ်နေပြီးသားပါ။
+num_epochs = 3
+num_train_steps = len(tf_train_dataset) * num_epochs
+
+optimizer, schedule = create_optimizer(
+    init_lr=2e-5,
+    num_warmup_steps=0,
+    num_train_steps=num_train_steps,
+    weight_decay_rate=0.01,
+)
+model.compile(optimizer=optimizer)
+```
+
+ကျွန်တော်တို့ `compile()` ကို `loss` argument ပေးစရာ မလိုဘူးဆိုတာလည်း သတိပြုပါ။ ဒါက models တွေက loss ကို အတွင်းပိုင်းမှာ တွက်ချက်နိုင်လို့ပါပဲ — သင် loss မပါဘဲ compile လုပ်ပြီး input dictionary ထဲမှာ labels တွေ ပေးခဲ့မယ်ဆိုရင် (ကျွန်တော်တို့ရဲ့ datasets တွေမှာ လုပ်ခဲ့သလိုပါပဲ)၊ model က အတွင်းပိုင်း loss ကို အသုံးပြုပြီး train လုပ်ပါလိမ့်မယ်။ ဒါက သင်ရွေးချယ်ထားတဲ့ task နဲ့ model type အတွက် သင့်လျော်ပါလိမ့်မယ်။
+
+နောက်ဆုံးအနေနဲ့၊ training လုပ်နေစဉ်အတွင်း ကျွန်တော်တို့ရဲ့ model ကို Hub ကို upload လုပ်ဖို့ `PushToHubCallback` တစ်ခုကို သတ်မှတ်ပြီး၊ အဲဒီ callback နဲ့ model ကို fit လုပ်ပါမယ်။
+
+```python
+from transformers.keras_callbacks import PushToHubCallback
+
+callback = PushToHubCallback(output_dir="bert-finetuned-ner", tokenizer=tokenizer)
+
+model.fit(
+    tf_train_dataset,
+    validation_data=tf_eval_dataset,
+    callbacks=[callback],
+    epochs=num_epochs,
+)
+```
+
+`hub_model_id` argument နဲ့ သင် push လုပ်ချင်တဲ့ repository ရဲ့ နာမည်အပြည့်အစုံကို သတ်မှတ်နိုင်ပါတယ် (အထူးသဖြင့်၊ organization တစ်ခုသို့ push လုပ်ဖို့အတွက် ဒီ argument ကို အသုံးပြုရပါလိမ့်မယ်)။ ဥပမာအားဖြင့်၊ ကျွန်တော်တို့ model ကို [`huggingface-course` organization](https://huggingface.co/huggingface-course) ကို push လုပ်ခဲ့တုန်းက၊ `hub_model_id="huggingface-course/bert-finetuned-ner"` ကို ထပ်ထည့်ခဲ့ပါတယ်။ default အားဖြင့်၊ အသုံးပြုတဲ့ repository က သင့် namespace ထဲမှာရှိပြီး သင်သတ်မှတ်ထားတဲ့ output directory နာမည်အတိုင်း ဖြစ်ပါလိမ့်မယ်၊ ဥပမာ `"cool_huggingface_user/bert-finetuned-ner"`။
+
+> [!TIP]
+> 💡 သင်အသုံးပြုနေတဲ့ output directory က ရှိပြီးသားဆိုရင်၊ ဒါက သင် push လုပ်ချင်တဲ့ repository ရဲ့ local clone တစ်ခု ဖြစ်ဖို့ လိုအပ်ပါတယ်။ မဟုတ်ဘူးဆိုရင်၊ `model.fit()` ကို ခေါ်တဲ့အခါ error တစ်ခု ရရှိမှာဖြစ်ပြီး နာမည်အသစ်တစ်ခု သတ်မှတ်ဖို့ လိုပါလိမ့်မယ်။
+
+training ဖြစ်နေစဉ်မှာ၊ model ကို သိမ်းဆည်းတဲ့အခါတိုင်း (ဒီနေရာမှာတော့ epoch တိုင်း) ဒါကို နောက်ကွယ်မှာ Hub ကို upload လုပ်ပါတယ်ဆိုတာ သတိပြုပါ။ ဒီနည်းနဲ့၊ လိုအပ်ရင် တခြား machine တစ်ခုပေါ်မှာ သင်ရဲ့ training ကို ပြန်လည်စတင်နိုင်ပါလိမ့်မယ်။
+
+ဒီအဆင့်မှာ၊ Model Hub ပေါ်က inference widget ကို အသုံးပြုပြီး သင့် model ကို စမ်းသပ်ကာ သင့်သူငယ်ချင်းတွေနဲ့ မျှဝေနိုင်ပါတယ်။ သင်ဟာ token classification task တစ်ခုပေါ်မှာ model တစ်ခုကို အောင်မြင်စွာ fine-tune လုပ်ခဲ့ပြီးပါပြီ — ဂုဏ်ယူပါတယ်! ဒါပေမယ့် ကျွန်တော်တို့ရဲ့ model က တကယ်ဘယ်လောက် ကောင်းလဲ။ သိရှိဖို့ metrics အချို့ကို အကဲဖြတ်သင့်ပါတယ်။
+
+{/if}
+
+### Metrics[[metrics]]
+
+{#if fw === 'pt'}
+
+`Trainer` က epoch တိုင်း metric တစ်ခုကို တွက်ချက်ဖို့အတွက်၊ predictions နဲ့ labels array တွေကို ယူပြီး metric names နဲ့ values ပါဝင်တဲ့ dictionary တစ်ခုကို ပြန်ပေးမယ့် `compute_metrics()` function တစ်ခုကို ကျွန်တော်တို့ သတ်မှတ်ဖို့ လိုအပ်ပါလိမ့်မယ်။
+
+token classification prediction ကို အကဲဖြတ်ဖို့ အသုံးပြုတဲ့ traditional framework ကတော့ [*seqeval*](https://github.com/chakki-works/seqeval) ဖြစ်ပါတယ်။ ဒီ metric ကို အသုံးပြုဖို့၊ ကျွန်တော်တို့ *seqeval* library ကို အရင်ဆုံး install လုပ်ဖို့ လိုအပ်ပါတယ်။
+
+```py
+!pip install seqeval
+```
+
+ဒါဆိုရင် [Chapter 3](/course/chapter3) မှာ လုပ်ခဲ့သလိုပဲ `evaluate.load()` function မှတစ်ဆင့် load လုပ်နိုင်ပါပြီ။
+
+{:else}
+
+token classification prediction ကို အကဲဖြတ်ဖို့ အသုံးပြုတဲ့ traditional framework ကတော့ [*seqeval*](https://github.com/chakki-works/seqeval) ဖြစ်ပါတယ်။ ဒီ metric ကို အသုံးပြုဖို့၊ ကျွန်တော်တို့ *seqeval* library ကို အရင်ဆုံး install လုပ်ဖို့ လိုအပ်ပါတယ်။
+
+```py
+!pip install seqeval
+```
+
+ဒါဆိုရင် [Chapter 3](/course/chapter3) မှာ လုပ်ခဲ့သလိုပဲ `evaluate.load()` function မှတစ်ဆင့် load လုပ်နိုင်ပါပြီ။
+
+{/if}
+
+```py
+import evaluate
+
+metric = evaluate.load("seqeval")
+```
+
+ဒီ metric က standard accuracy လိုမျိုး အလုပ်မလုပ်ပါဘူး- ၎င်းက lists of labels တွေကို integers အဖြစ် မဟုတ်ဘဲ strings အဖြစ် ယူမှာဖြစ်လို့၊ metric ကို မပေးခင် predictions နဲ့ labels တွေကို အပြည့်အဝ decode လုပ်ဖို့ ကျွန်တော်တို့ လိုအပ်ပါလိမ့်မယ်။ ဒါက ဘယ်လိုအလုပ်လုပ်လဲဆိုတာ ကြည့်ရအောင်။ ပထမဆုံး၊ ကျွန်တော်တို့ရဲ့ ပထမဆုံး training example အတွက် labels တွေကို ရယူပါမယ်-
+
+```py
+labels = raw_datasets["train"][0]["ner_tags"]
+labels = [label_names[i] for i in labels]
+labels
+```
+
+```python out
+['B-ORG', 'O', 'B-MISC', 'O', 'O', 'O', 'B-MISC', 'O', 'O']
+```
+
+ဒါဆိုရင် index 2 မှာရှိတဲ့ value ကို ပြောင်းလဲခြင်းဖြင့် အဲဒီအတွက် fake predictions တွေကို ဖန်တီးနိုင်ပါတယ်။
+
+```py
+predictions = labels.copy()
+predictions[2] = "O"
+metric.compute(predictions=[predictions], references=[labels])
+```
+
+metric က predictions list တစ်ခု (တစ်ခုတည်းမဟုတ်) နဲ့ labels list တစ်ခုကို ယူတယ်ဆိုတာ သတိပြုပါ။ ဒီမှာ output ပါ...
+
+```python out
+{'MISC': {'precision': 1.0, 'recall': 0.5, 'f1': 0.67, 'number': 2},
+ 'ORG': {'precision': 1.0, 'recall': 1.0, 'f1': 1.0, 'number': 1},
+ 'overall_precision': 1.0,
+ 'overall_recall': 0.67,
+ 'overall_f1': 0.8,
+ 'overall_accuracy': 0.89}
+```
+
+{#if fw === 'pt'}
+
+ဒါက အချက်အလက်များစွာကို ပြန်လည်ပေးပို့နေပါတယ်။ ကျွန်တော်တို့ဟာ entity တစ်ခုစီအတွက် precision, recall, F1 score တွေအပြင် overall score တွေပါ ရရှိပါတယ်။ ကျွန်တော်တို့ရဲ့ metric computation အတွက် overall score ကိုပဲ ထားရှိပါမယ်၊ ဒါပေမယ့် သင် report လုပ်ချင်တဲ့ metrics အားလုံးကို ပြန်ပေးဖို့ `compute_metrics()` function ကို စိတ်ကြိုက်ပြင်ဆင်နိုင်ပါတယ်။
+
+ဒီ `compute_metrics()` function က ပထမဆုံး logits တွေကို predictions တွေအဖြစ် ပြောင်းလဲဖို့ argmax ကို ယူပါတယ် (ပုံမှန်အတိုင်းပါပဲ၊ logits နဲ့ probabilities တွေက အစဉ်လိုက် တူညီတာကြောင့် softmax ကို အသုံးပြုဖို့ မလိုအပ်ပါဘူး)။ ဒါဆိုရင် labels နဲ့ predictions နှစ်ခုလုံးကို integers ကနေ strings တွေအဖြစ် ပြောင်းလဲရပါမယ်။ label က `-100` ဖြစ်နေတဲ့ values အားလုံးကို ဖယ်ရှားပြီးမှ ရလဒ်တွေကို `metric.compute()` method ကို ပေးပို့ပါတယ်။
+
+```py
+import numpy as np
+
+
+def compute_metrics(eval_preds):
+    logits, labels = eval_preds
+    predictions = np.argmax(logits, axis=-1)
+
+    # လျစ်လျူရှုထားသော index (special tokens) များကို ဖယ်ရှားပြီး labels အဖြစ် ပြောင်းလဲပါ။
+    true_labels = [[label_names[l] for l in label if l != -100] for label in labels]
+    true_predictions = [
+        [label_names[p] for (p, l) in zip(prediction, label) if l != -100]
+        for prediction, label in zip(predictions, labels)
+    ]
+    all_metrics = metric.compute(predictions=true_predictions, references=true_labels)
+    return {
+        "precision": all_metrics["overall_precision"],
+        "recall": all_metrics["overall_recall"],
+        "f1": all_metrics["overall_f1"],
+        "accuracy": all_metrics["overall_accuracy"],
+    }
+```
+
+ဒါပြီးသွားပြီဆိုတော့၊ ကျွန်တော်တို့ `Trainer` ကို သတ်မှတ်ဖို့ နီးပါး အဆင်သင့်ဖြစ်ပါပြီ။ ကျွန်တော်တို့မှာ fine-tune လုပ်ဖို့ `model` တစ်ခုပဲ လိုအပ်ပါတော့တယ်။
+
+{:else}
+
+ဒါက အချက်အလက်များစွာကို ပြန်လည်ပေးပို့နေပါတယ်။ ကျွန်တော်တို့ဟာ entity တစ်ခုစီအတွက် precision, recall, F1 score တွေအပြင် overall score တွေပါ ရရှိပါတယ်။ အခု ကျွန်တော်တို့ရဲ့ model predictions တွေကို အသုံးပြုပြီး တကယ့် scores အချို့ကို တွက်ချက်ကြည့်ရင် ဘာဖြစ်မလဲ ကြည့်ရအောင်။
+
+TensorFlow က ကျွန်တော်တို့ရဲ့ predictions တွေကို တစ်ခုနဲ့တစ်ခု ပေါင်းစပ်တာကို မကြိုက်ပါဘူး။ ဘာလို့လဲဆိုတော့ ၎င်းတို့မှာ variable sequence lengths တွေ ရှိနေလို့ပါပဲ။ ဒါက ကျွန်တော်တို့ `model.predict()` ကို တိုက်ရိုက်အသုံးပြုလို့ မရဘူးလို့ ဆိုလိုပါတယ် — ဒါပေမယ့် ဒါက ကျွန်တော်တို့ကို တားဆီးနိုင်မှာ မဟုတ်ပါဘူး။ ကျွန်တော်တို့ predictions တွေကို batch တစ်ခုချင်းစီ ရယူပြီး တစ်ခုတည်းသော ကြီးမားတဲ့ list တစ်ခုအဖြစ် ပေါင်းစပ်သွားမှာဖြစ်ပြီး၊ masking/padding ကို ဖော်ပြတဲ့ `-100` tokens တွေကို ဖယ်ရှားပြီးမှ နောက်ဆုံးမှာ list ပေါ်မှာ metrics တွေကို တွက်ချက်ပါမယ်။
+
+```py
+import numpy as np
+
+all_predictions = []
+all_labels = []
+for batch in tf_eval_dataset:
+    logits = model.predict_on_batch(batch)["logits"]
+    labels = batch["labels"]
+    predictions = np.argmax(logits, axis=-1)
+    for prediction, label in zip(predictions, labels):
+        for predicted_idx, label_idx in zip(prediction, label):
+            if label_idx == -100:
+                continue
+            all_predictions.append(label_names[predicted_idx])
+            all_labels.append(label_names[label_idx])
+metric.compute(predictions=[all_predictions], references=[all_labels])
+```
+
+```python out
+{'LOC': {'precision': 0.91, 'recall': 0.92, 'f1': 0.91, 'number': 1668},
+ 'MISC': {'precision': 0.70, 'recall': 0.79, 'f1': 0.74, 'number': 702},
+ 'ORG': {'precision': 0.85, 'recall': 0.90, 'f1': 0.88, 'number': 1661},
+ 'PER': {'precision': 0.95, 'recall': 0.95, 'f1': 0.95, 'number': 1617},
+ 'overall_precision': 0.87,
+ 'overall_recall': 0.91,
+ 'overall_f1': 0.89,
+ 'overall_accuracy': 0.97}
+```
+
+သင့် model က ကျွန်တော်တို့ရဲ့ model နဲ့ နှိုင်းယှဉ်ရင် ဘယ်လိုစွမ်းဆောင်ခဲ့လဲ။ သင်အလားတူ numbers တွေ ရရှိခဲ့ရင်၊ သင့် training က အောင်မြင်ခဲ့ပါပြီ။
+
+{/if}
+
+{#if fw === 'pt'}
+
+### Model ကို သတ်မှတ်ခြင်း[[defining-the-model]]
+
+ကျွန်တော်တို့ token classification problem ပေါ်မှာ အလုပ်လုပ်နေတာကြောင့်၊ `AutoModelForTokenClassification` class ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။ ဒီ model ကို သတ်မှတ်တဲ့အခါ အဓိက မှတ်ထားရမယ့်အချက်ကတော့ ကျွန်တော်တို့မှာရှိတဲ့ labels အရေအတွက်အကြောင်း အချက်အလက်အချို့ကို ပေးပို့ဖို့ပါပဲ။ ဒီလိုလုပ်ဖို့ အလွယ်ကူဆုံးနည်းလမ်းကတော့ `num_labels` argument နဲ့ အဲဒီအရေအတွက်ကို ပေးဖို့ပါပဲ။ ဒါပေမယ့် ဒီအပိုင်းရဲ့ အစမှာ ကျွန်တော်တို့ မြင်တွေ့ခဲ့ရတဲ့ Inference widget ကဲ့သို့ ကောင်းမွန်တဲ့ widget တစ်ခု လိုချင်ရင်တော့ မှန်ကန်တဲ့ label correspondences တွေကို သတ်မှတ်တာက ပိုကောင်းပါတယ်။
+
+၎င်းတို့ကို `id2label` နဲ့ `label2id` ဆိုတဲ့ dictionaries နှစ်ခုဖြင့် သတ်မှတ်သင့်ပါတယ်။ ဒါတွေက ID ကနေ label သို့၊ label ကနေ ID သို့ mapping တွေ ပါဝင်ပါတယ်။
+
+```py
+id2label = {i: label for i, label in enumerate(label_names)}
+label2id = {v: k for k, v in id2label.items()}
+```
+
+အခုဆိုရင် ကျွန်တော်တို့ ဒါတွေကို `AutoModelForTokenClassification.from_pretrained()` method ကို ပေးလိုက်ရုံပါပဲ။ ဒါတွေက model ရဲ့ configuration မှာ သတ်မှတ်ခံရပြီး၊ ကောင်းမွန်စွာ သိမ်းဆည်းပြီး Hub ကို upload လုပ်ပါလိမ့်မယ်။
+
+```py
+from transformers import AutoModelForTokenClassification
+
+model = AutoModelForTokenClassification.from_pretrained(
+    model_checkpoint,
+    id2label=id2label,
+    label2id=label2id,
+)
+```
+
+[Chapter 3](/course/chapter3) မှာ ကျွန်တော်တို့ `AutoModelForSequenceClassification` ကို သတ်မှတ်ခဲ့တုန်းကလိုပဲ၊ model ကို ဖန်တီးတာက weights အချို့ (pretraining head က weights တွေ) ကို အသုံးမပြုခဲ့ဘူး၊ တခြား weights အချို့ (new token classification head က weights တွေ) ကို random အဖြစ် initialized လုပ်ခဲ့တယ်ဆိုတဲ့ warning တစ်ခုကို ထုတ်ပေးပြီး၊ ဒီ model ကို train လုပ်သင့်တယ်လို့ ဆိုပါတယ်။ ကျွန်တော်တို့ ခဏအတွင်းမှာ ဒါကို လုပ်ပါမယ်၊ ဒါပေမယ့် ပထမဆုံး ကျွန်တော်တို့ရဲ့ model မှာ မှန်ကန်တဲ့ labels အရေအတွက် ရှိမရှိ ထပ်မံစစ်ဆေးကြည့်ရအောင်။
+
+```python
+model.config.num_labels
+```
+
+```python out
+9
+```
+
+> [!WARNING]
+> ⚠️ သင့် model မှာ labels အရေအတွက် မှားနေတယ်ဆိုရင်၊ နောက်ပိုင်းမှာ `Trainer.train()` method ကို ခေါ်တဲ့အခါ မရှင်းလင်းတဲ့ error တစ်ခု ရရှိပါလိမ့်မယ် (ဥပမာ "CUDA error: device-side assert triggered" လိုမျိုး)။ ဒီလို error တွေအတွက် users တွေက report လုပ်တဲ့ bug တွေရဲ့ နံပါတ်တစ် အကြောင်းအရင်းဖြစ်တာကြောင့်၊ မျှော်လင့်ထားတဲ့ labels အရေအတွက် ရှိမရှိ သေချာစေဖို့ ဒီစစ်ဆေးမှုကို လုပ်ဖို့ သေချာလုပ်ပါ။
+
+### Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model]]
+
+ကျွန်တော်တို့ရဲ့ model ကို train လုပ်ဖို့ အခု အဆင်သင့်ဖြစ်ပါပြီ။ ကျွန်တော်တို့ `Trainer` ကို မသတ်မှတ်ခင် နောက်ဆုံးလုပ်ရမယ့် အလုပ်နှစ်ခုပဲ ကျန်ပါတော့တယ်၊ Hugging Face ကို login ဝင်ပြီး ကျွန်တော်တို့ရဲ့ training arguments တွေကို သတ်မှတ်ဖို့ပါပဲ။ သင် notebook မှာ အလုပ်လုပ်နေတယ်ဆိုရင်၊ ဒီအတွက် ကူညီပေးမယ့် convenience function တစ်ခု ရှိပါတယ်။
+
+```python
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+ဒါက သင်ရဲ့ Hugging Face login credentials တွေကို ထည့်သွင်းနိုင်မယ့် widget တစ်ခုကို ပြသပါလိမ့်မယ်။
+
+သင် notebook မှာ အလုပ်မလုပ်ဘူးဆိုရင်၊ သင့် terminal မှာ အောက်ပါစာကြောင်းကို ရိုက်ထည့်လိုက်ရုံပါပဲ။
+
+```bash
+huggingface-cli login
+```
+
+ဒါပြီးသွားတာနဲ့၊ ကျွန်တော်တို့ `TrainingArguments` တွေကို သတ်မှတ်နိုင်ပါပြီ။
+
+```python
+from transformers import TrainingArguments
+
+args = TrainingArguments(
+    "bert-finetuned-ner",
+    evaluation_strategy="epoch",
+    save_strategy="epoch",
+    learning_rate=2e-5,
+    num_train_epochs=3,
+    weight_decay=0.01,
+    push_to_hub=True,
+)
+```
+
+ဒါတွေအများစုကို သင်အရင်က မြင်ဖူးပြီးသားပါ၊ ကျွန်တော်တို့ hyperparameters အချို့ကို သတ်မှတ်ပါတယ် (learning rate, train လုပ်မယ့် epochs အရေအတွက်, weight decay လိုမျိုး)၊ ပြီးတော့ model ကို save လုပ်ပြီး epoch တိုင်းရဲ့အဆုံးမှာ evaluate လုပ်ချင်တယ်၊ ကျွန်တော်တို့ရဲ့ ရလဒ်တွေကို Model Hub ကို upload လုပ်ချင်တယ်ဆိုတာ ဖော်ပြဖို့ `push_to_hub=True` ကို သတ်မှတ်ပါတယ်။ သင် push လုပ်ချင်တဲ့ repository ရဲ့ နာမည်ကို `hub_model_id` argument နဲ့ သတ်မှတ်နိုင်တယ်ဆိုတာ သတိပြုပါ (အထူးသဖြင့်၊ organization တစ်ခုသို့ push လုပ်ဖို့အတွက် ဒီ argument ကို အသုံးပြုရပါလိမ့်မယ်)။ ဥပမာအားဖြင့်၊ ကျွန်တော်တို့ model ကို [`huggingface-course` organization](https://huggingface.co/huggingface-course) ကို push လုပ်ခဲ့တုန်းက၊ `TrainingArguments` မှာ `hub_model_id="huggingface-course/bert-finetuned-ner"` ကို ထပ်ထည့်ခဲ့ပါတယ်။ default အားဖြင့်၊ အသုံးပြုတဲ့ repository က သင့် namespace ထဲမှာရှိပြီး သင်သတ်မှတ်ထားတဲ့ output directory နာမည်အတိုင်း ဖြစ်ပါလိမ့်မယ်၊ ဒါကြောင့် ကျွန်တော်တို့ရဲ့ ကိစ္စမှာတော့ `"sgugger/bert-finetuned-ner"` ဖြစ်ပါလိမ့်မယ်။
+
+> [!TIP]
+> 💡 သင်အသုံးပြုနေတဲ့ output directory က ရှိပြီးသားဆိုရင်၊ ဒါက သင် push လုပ်ချင်တဲ့ repository ရဲ့ local clone တစ်ခု ဖြစ်ဖို့ လိုအပ်ပါတယ်။ မဟုတ်ဘူးဆိုရင်၊ သင့် `Trainer` ကို သတ်မှတ်တဲ့အခါ error တစ်ခု ရရှိမှာဖြစ်ပြီး နာမည်အသစ်တစ်ခု သတ်မှတ်ဖို့ လိုပါလိမ့်မယ်။
+
+နောက်ဆုံးအနေနဲ့၊ အရာအားလုံးကို `Trainer` ကို ပေးပြီး training ကို စတင်လိုက်ရုံပါပဲ။
+
+```python
+from transformers import Trainer
+
+trainer = Trainer(
+    model=model,
+    args=args,
+    train_dataset=tokenized_datasets["train"],
+    eval_dataset=tokenized_datasets["validation"],
+    data_collator=data_collator,
+    compute_metrics=compute_metrics,
+    processing_class=tokenizer,
+)
+trainer.train()
+```
+
+training ဖြစ်နေစဉ်မှာ၊ model ကို သိမ်းဆည်းတဲ့အခါတိုင်း (ဒီနေရာမှာတော့ epoch တိုင်း) ဒါကို နောက်ကွယ်မှာ Hub ကို upload လုပ်ပါတယ်ဆိုတာ သတိပြုပါ။ ဒီနည်းနဲ့၊ လိုအပ်ရင် တခြား machine တစ်ခုပေါ်မှာ သင်ရဲ့ training ကို ပြန်လည်စတင်နိုင်ပါလိမ့်မယ်။
+
+training ပြီးသွားတာနဲ့၊ model ရဲ့ နောက်ဆုံး version ကို upload လုပ်ဖို့ `push_to_hub()` method ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။
+
+```py
+trainer.push_to_hub(commit_message="Training complete")
+```
+
+ဒီ command က သင်အခုလေးတင် လုပ်ခဲ့တဲ့ commit ရဲ့ URL ကို ပြန်ပေးပါတယ်။ သင်စစ်ဆေးကြည့်ချင်တယ်ဆိုရင်ပေါ့။
+
+```python out
+'https://huggingface.co/sgugger/bert-finetuned-ner/commit/26ab21e5b1568f9afeccdaed2d8715f571d786ed'
+```
+
+`Trainer` က evaluation results အားလုံးပါဝင်တဲ့ model card တစ်ခုကိုလည်း ရေးဆွဲပြီး upload လုပ်ပါတယ်။ ဒီအဆင့်မှာ၊ Model Hub ပေါ်က inference widget ကို အသုံးပြုပြီး သင့် model ကို စမ်းသပ်ကာ သင့်သူငယ်ချင်းတွေနဲ့ မျှဝေနိုင်ပါတယ်။ သင်ဟာ token classification task တစ်ခုပေါ်မှာ model တစ်ခုကို အောင်မြင်စွာ fine-tune လုပ်ခဲ့ပြီးပါပြီ — ဂုဏ်ယူပါတယ်!
+
+သင် training loop ကို နက်နက်နဲနဲ လေ့လာချင်တယ်ဆိုရင်၊ အခု ကျွန်တော်တို့ 🤗 Accelerate ကို အသုံးပြုပြီး အလားတူ လုပ်ဆောင်ပုံကို ပြသပါမယ်။
+
+## Custom Training Loop တစ်ခု[[a-custom-training-loop]]
+
+အခုဆိုရင် အပြည့်အစုံ training loop ကို ကြည့်ရအောင်၊ ဒါမှ သင်လိုအပ်တဲ့ အစိတ်အပိုင်းတွေကို အလွယ်တကူ customize လုပ်နိုင်မှာပါ။ ဒါက [Chapter 3](/course/chapter3/4) မှာ ကျွန်တော်တို့ လုပ်ခဲ့တာနဲ့ အတော်လေး ဆင်တူပါလိမ့်မယ်။ evaluation အတွက် အပြောင်းအလဲ အနည်းငယ်ရှိပါမယ်။
+
+### Training အတွက် အရာအားလုံးကို ပြင်ဆင်ခြင်း[[preparing-everything-for-training]]
+
+ပထမဆုံး ကျွန်တော်တို့ datasets တွေကနေ `DataLoader`s တွေကို တည်ဆောက်ဖို့ လိုပါတယ်။ ကျွန်တော်တို့ရဲ့ `data_collator` ကို `collate_fn` အဖြစ် ပြန်လည်အသုံးပြုပြီး training set ကို shuffle လုပ်ပါမယ်၊ ဒါပေမယ့် validation set ကိုတော့ shuffle လုပ်မှာ မဟုတ်ပါဘူး။
+
+```py
+from torch.utils.data import DataLoader
+
+train_dataloader = DataLoader(
+    tokenized_datasets["train"],
+    shuffle=True,
+    collate_fn=data_collator,
+    batch_size=8,
+)
+eval_dataloader = DataLoader(
+    tokenized_datasets["validation"], collate_fn=data_collator, batch_size=8
+)
+```
+
+နောက်ဆုံးအနေနဲ့ ကျွန်တော်တို့ model ကို ပြန်လည် instantiate လုပ်ပါမယ်။ ဒါက အရင်က fine-tuning ကို ဆက်လုပ်တာ မဟုတ်ဘဲ BERT pretrained model ကနေ ပြန်စတာ သေချာစေဖို့ပါ။
+
+```py
+model = AutoModelForTokenClassification.from_pretrained(
+    model_checkpoint,
+    id2label=id2label,
+    label2id=label2id,
+)
+```
+
+ဒါဆိုရင် optimizer တစ်ခု လိုအပ်ပါလိမ့်မယ်။ `AdamW` ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။ ဒါက `Adam` နဲ့ ဆင်တူပေမယ့် weight decay ကို အသုံးပြုပုံမှာ ပြင်ဆင်ချက်တစ်ခု ပါဝင်ပါတယ်။
+
+```py
+from torch.optim import AdamW
+
+optimizer = AdamW(model.parameters(), lr=2e-5)
+```
+
+အဲဒီ objects တွေအားလုံး ရပြီဆိုတာနဲ့၊ ၎င်းတို့ကို `accelerator.prepare()` method ကို ပေးပို့နိုင်ပါပြီ။
+
+```py
+from accelerate import Accelerator
+
+accelerator = Accelerator()
+model, optimizer, train_dataloader, eval_dataloader = accelerator.prepare(
+    model, optimizer, train_dataloader, eval_dataloader
+)
+```
+
+> [!TIP]
+> 🚨 သင် TPU ပေါ်မှာ train လုပ်နေတယ်ဆိုရင်၊ အထက်ပါ cell ကနေ စတင်တဲ့ code အားလုံးကို သီးခြား training function တစ်ခုထဲသို့ ရွှေ့ဖို့ လိုပါလိမ့်မယ်။ အသေးစိတ်အချက်အလက်တွေအတွက် [Chapter 3](/course/chapter3) ကို ကြည့်ပါ။
+
+ကျွန်တော်တို့ `train_dataloader` ကို `accelerator.prepare()` ကို ပေးပို့ပြီးတာနဲ့၊ training steps အရေအတွက်ကို တွက်ချက်ဖို့ ၎င်းရဲ့ length ကို အသုံးပြုနိုင်ပါတယ်။ dataloader ကို ပြင်ဆင်ပြီးမှ ဒါကို အမြဲတမ်းလုပ်သင့်တယ်ဆိုတာ မှတ်ထားပါ၊ ဘာလို့လဲဆိုတော့ အဲဒီ method က ၎င်းရဲ့ length ကို ပြောင်းလဲမှာ ဖြစ်လို့ပါပဲ။ learning rate ကနေ 0 အထိ classic linear schedule ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။
+
+```py
+from transformers import get_scheduler
+
+num_train_epochs = 3
+num_update_steps_per_epoch = len(train_dataloader)
+num_training_steps = num_train_epochs * num_update_steps_per_epoch
+
+lr_scheduler = get_scheduler(
+    "linear",
+    optimizer=optimizer,
+    num_warmup_steps=0,
+    num_training_steps=num_training_steps,
+)
+```
+
+နောက်ဆုံးအနေနဲ့၊ ကျွန်တော်တို့ model ကို Hub ကို push လုပ်ဖို့အတွက်၊ working folder တစ်ခုထဲမှာ `Repository` object တစ်ခု ဖန်တီးဖို့ လိုအပ်ပါလိမ့်မယ်။ ပထမဆုံး Hugging Face ကို login ဝင်ပါ၊ အကယ်၍ သင် login မဝင်ရသေးဘူးဆိုရင်ပေါ့။ ကျွန်တော်တို့ model ကို ပေးချင်တဲ့ model ID ကနေ repository name ကို ကျွန်တော်တို့ သတ်မှတ်ပါမယ် (သင်နှစ်သက်ရာ `repo_name` ကို အစားထိုးနိုင်ပါတယ်၊ ၎င်းမှာ သင့် username ပါဝင်ဖို့ပဲ လိုအပ်ပါတယ်၊ ဒါက `get_full_repo_name()` function က လုပ်ဆောင်တာပါ)။
+
+```py
+from huggingface_hub import Repository, get_full_repo_name
+
+model_name = "bert-finetuned-ner-accelerate"
+repo_name = get_full_repo_name(model_name)
+repo_name
+```
+
+```python out
+'sgugger/bert-finetuned-ner-accelerate'
+```
+
+ဒါဆိုရင် အဲဒီ repository ကို local folder တစ်ခုထဲမှာ clone လုပ်နိုင်ပါတယ်။ အဲဒါက ရှိပြီးသားဆိုရင်၊ ဒီ local folder က ကျွန်တော်တို့ အလုပ်လုပ်နေတဲ့ repository ရဲ့ ရှိပြီးသား clone တစ်ခု ဖြစ်ရပါမယ်။
+
+```py
+output_dir = "bert-finetuned-ner-accelerate"
+repo = Repository(output_dir, clone_from=repo_name)
+```
+
+အခုဆိုရင် `output_dir` ထဲမှာ ကျွန်တော်တို့ သိမ်းဆည်းထားတဲ့ ဘယ်အရာကိုမဆို `repo.push_to_hub()` method ကို ခေါ်ခြင်းဖြင့် upload လုပ်နိုင်ပါပြီ။ ဒါက epoch တစ်ခုစီရဲ့အဆုံးမှာ intermediate models တွေကို upload လုပ်ဖို့ ကူညီပါလိမ့်မယ်။
+
+### Training Loop[[training-loop]]
+
+အခုဆိုရင် အပြည့်အစုံ training loop ကို ရေးဖို့ အဆင်သင့်ဖြစ်ပါပြီ။ ၎င်းရဲ့ evaluation အပိုင်းကို ရိုးရှင်းစေဖို့၊ predictions နဲ့ labels တွေကို ကျွန်တော်တို့ရဲ့ `metric` object က မျှော်လင့်ထားတဲ့အတိုင်း strings list တွေအဖြစ် ပြောင်းလဲပေးတဲ့ `postprocess()` function ကို ကျွန်တော်တို့ သတ်မှတ်ပါတယ်။
+
+```py
+def postprocess(predictions, labels):
+    predictions = predictions.detach().cpu().clone().numpy()
+    labels = labels.detach().cpu().clone().numpy()
+
+    # လျစ်လျူရှုထားသော index (special tokens) များကို ဖယ်ရှားပြီး labels အဖြစ် ပြောင်းလဲပါ
+    true_labels = [[label_names[l] for l in label if l != -100] for label in labels]
+    true_predictions = [
+        [label_names[p] for (p, l) in zip(prediction, label) if l != -100]
+        for prediction, label in zip(predictions, labels)
+    ]
+    return true_labels, true_predictions
+```
+
+ဒါဆိုရင် training loop ကို ရေးနိုင်ပါပြီ။ training ဘယ်လိုသွားလဲဆိုတာကို လိုက်နာဖို့ progress bar တစ်ခု သတ်မှတ်ပြီးနောက်၊ loop မှာ အပိုင်းသုံးပိုင်း ရှိပါတယ်။
+
+-   Training ကိုယ်တိုင်၊ ဒါက `train_dataloader` ပေါ်မှာ classic iteration၊ model ကို forward pass လုပ်ခြင်း၊ ပြီးတော့ backward pass နဲ့ optimizer step တို့ ဖြစ်ပါတယ်။
+-   Evaluation မှာ၊ batch ပေါ်မှာ ကျွန်တော်တို့ရဲ့ model ရဲ့ outputs တွေကို ရပြီးနောက် ထူးခြားချက်တစ်ခု ရှိပါတယ်၊ processes နှစ်ခုက inputs တွေနဲ့ labels တွေကို မတူညီတဲ့ shapes တွေအထိ padding လုပ်ထားနိုင်တာကြောင့်၊ `gather()` method ကို မခေါ်ခင် predictions နဲ့ labels တွေကို တူညီတဲ့ shape ဖြစ်စေဖို့ `accelerator.pad_across_processes()` ကို အသုံးပြုဖို့ လိုပါတယ်။ ဒါကို မလုပ်ဘူးဆိုရင်၊ evaluation က error ဖြစ်သွားမှာ ဒါမှမဟုတ် ထာဝရ ရပ်တန့်နေမှာပါ။ ပြီးရင် ရလဒ်တွေကို `metric.add_batch()` ကို ပေးပို့ပြီး evaluation loop ပြီးသွားတာနဲ့ `metric.compute()` ကို ခေါ်ပါတယ်။
+-   Saving နဲ့ uploading မှာ၊ ကျွန်တော်တို့ model နဲ့ tokenizer ကို အရင်သိမ်းဆည်းပြီးမှ၊ `repo.push_to_hub()` ကို ခေါ်ပါတယ်။ 🤗 Hub library ကို asynchronous process မှာ push လုပ်ဖို့ ပြောဖို့ `blocking=False` argument ကို ကျွန်တော်တို့ အသုံးပြုတယ်ဆိုတာ သတိပြုပါ။ ဒီနည်းနဲ့၊ training က ပုံမှန်အတိုင်း ဆက်လက်လုပ်ဆောင်ပြီး ဒီ (ရှည်လျားတဲ့) instruction က နောက်ကွယ်မှာ execute ဖြစ်ပါတယ်။
+
+ဒီမှာ training loop အတွက် အပြည့်အစုံ code ပါ။
+
+```py
+from tqdm.auto import tqdm
+import torch
+
+progress_bar = tqdm(range(num_training_steps))
+
+for epoch in range(num_train_epochs):
+    # Training
+    model.train()
+    for batch in train_dataloader:
+        outputs = model(**batch)
+        loss = outputs.loss
+        accelerator.backward(loss)
+
+        optimizer.step()
+        lr_scheduler.step()
+        optimizer.zero_grad()
+        progress_bar.update(1)
+
+    # Evaluation
+    model.eval()
+    for batch in eval_dataloader:
+        with torch.no_grad():
+            outputs = model(**batch)
+
+        predictions = outputs.logits.argmax(dim=-1)
+        labels = batch["labels"]
+
+        # predictions နဲ့ labels တွေကို gather လုပ်ဖို့ padding လုပ်ဖို့ လိုအပ်ပါတယ်
+        predictions = accelerator.pad_across_processes(predictions, dim=1, pad_index=-100)
+        labels = accelerator.pad_across_processes(labels, dim=1, pad_index=-100)
+
+        predictions_gathered = accelerator.gather(predictions)
+        labels_gathered = accelerator.gather(labels)
+
+        true_predictions, true_labels = postprocess(predictions_gathered, labels_gathered)
+        metric.add_batch(predictions=true_predictions, references=true_labels)
+
+    results = metric.compute()
+    print(
+        f"epoch {epoch}:",
+        {
+            key: results[f"overall_{key}"]
+            for key in ["precision", "recall", "f1", "accuracy"]
+        },
+    )
+
+    # သိမ်းဆည်းပြီး upload လုပ်ပါ
+    accelerator.wait_for_everyone()
+    unwrapped_model = accelerator.unwrap_model(model)
+    unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)
+    if accelerator.is_main_process:
+        tokenizer.save_pretrained(output_dir)
+        repo.push_to_hub(
+            commit_message=f"Training in progress epoch {epoch}", blocking=False
+        )
+```
+
+ဒါက 🤗 Accelerate နဲ့ save လုပ်ထားတဲ့ model ကို သင်ပထမဆုံးအကြိမ် မြင်ဖူးတာဆိုရင်၊ ဒါနဲ့ပတ်သက်တဲ့ code သုံးကြောင်းကို စစ်ဆေးဖို့ ခဏရပ်ရအောင်-
+
+```py
+accelerator.wait_for_everyone()
+unwrapped_model = accelerator.unwrap_model(model)
+unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)
+```
+
+ပထမဆုံးစာကြောင်းက ရှင်းပါတယ်။ ဒါက processes အားလုံးကို ဆက်မလုပ်ခင် ဒီအဆင့်မှာ ရှိနေဖို့ စောင့်ဆိုင်းခိုင်းတာပါ။ ဒါက save မလုပ်ခင် process တိုင်းမှာ model တူတူ ရှိနေဖို့ သေချာစေတာပါ။ ဒါဆိုရင် ကျွန်တော်တို့ သတ်မှတ်ခဲ့တဲ့ base model ဖြစ်တဲ့ `unwrapped_model` ကို ယူလိုက်ပါတယ်။ `accelerator.prepare()` method က distributed training မှာ အလုပ်လုပ်အောင် model ကို ပြောင်းလဲတာကြောင့်၊ ၎င်းမှာ `save_pretrained()` method ရှိတော့မှာ မဟုတ်ပါဘူး၊ `accelerator.unwrap_model()` method က အဲဒီအဆင့်ကို ပယ်ဖျက်လိုက်တာပါ။ နောက်ဆုံးအနေနဲ့၊ ကျွန်တော်တို့ `save_pretrained()` ကို ခေါ်ပေမယ့် `torch.save()` အစား `accelerator.save()` ကို အသုံးပြုဖို့ အဲဒီ method ကို ပြောပါတယ်။
+
+ဒါပြီးသွားတာနဲ့၊ သင် `Trainer` နဲ့ train လုပ်ထားတဲ့ model နဲ့ အတော်လေးဆင်တူတဲ့ ရလဒ်တွေကို ထုတ်ပေးမယ့် model တစ်ခု ရရှိသင့်ပါတယ်။ ဒီ code ကို အသုံးပြုပြီး ကျွန်တော်တို့ train လုပ်ခဲ့တဲ့ model ကို [*huggingface-course/bert-finetuned-ner-accelerate*](https://huggingface.co/huggingface-course/bert-finetuned-ner-accelerate) မှာ စစ်ဆေးနိုင်ပါတယ်။ training loop မှာ ဘယ်လို tweak တွေကိုမဆို စမ်းသပ်ကြည့်ချင်တယ်ဆိုရင်၊ အပေါ်မှာ ပြသထားတဲ့ code ကို တိုက်ရိုက် ပြင်ဆင်ခြင်းဖြင့် အကောင်အထည်ဖော်နိုင်ပါတယ်!
+
+{/if}
+
+## Fine-tuned Model ကို အသုံးပြုခြင်း[[using-the-fine-tuned-model]]
+
+ကျွန်တော်တို့ fine-tune လုပ်ခဲ့တဲ့ model ကို Model Hub ပေါ်မှာ inference widget နဲ့ ဘယ်လိုအသုံးပြုရမယ်ဆိုတာကို သင်ပြပြီးသားပါ။ ၎င်းကို `pipeline` ထဲမှာ locally အသုံးပြုဖို့အတွက်၊ သင့်လျော်တဲ့ model identifier ကို သတ်မှတ်ပေးရုံပါပဲ။
+
+```py
+from transformers import pipeline
+
+# ဒါကို သင်ရဲ့ကိုယ်ပိုင် checkpoint နဲ့ အစားထိုးပါ
+model_checkpoint = "huggingface-course/bert-finetuned-ner"
+token_classifier = pipeline(
+    "token-classification", model=model_checkpoint, aggregation_strategy="simple"
+)
+token_classifier("My name is Sylvain and I work at Hugging Face in Brooklyn.")
+```
+
+```python out
+[{'entity_group': 'PER', 'score': 0.9988506, 'word': 'Sylvain', 'start': 11, 'end': 18},
+ {'entity_group': 'ORG', 'score': 0.9647625, 'word': 'Hugging Face', 'start': 33, 'end': 45},
+ {'entity_group': 'LOC', 'score': 0.9986118, 'word': 'Brooklyn', 'start': 49, 'end': 57}]
+```
+
+ကောင်းပါပြီ! ကျွန်တော်တို့ရဲ့ model က ဒီ pipeline အတွက် default model လိုပဲ ကောင်းကောင်း အလုပ်လုပ်နေပါတယ်။
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **Token Classification**: စာသား sequence တစ်ခုအတွင်းရှိ token တစ်ခုစီကို အမျိုးအစားခွဲခြားသတ်မှတ်ခြင်း လုပ်ငန်း (ဥပမာ- Named Entity Recognition)။
+*   **Named Entity Recognition (NER)**: စာသားတစ်ခုထဲက entities တွေ (ဥပမာ- လူပုဂ္ဂိုလ်၊ နေရာဒေသ၊ အဖွဲ့အစည်း) ကို ရှာဖွေဖော်ထုတ်ခြင်း။
+*   **Entity**: စာသားထဲတွင် အရေးကြီးသော အရာဝတ္ထု သို့မဟုတ် သဘောတရား (ဥပမာ- လူအမည်၊ အဖွဲ့အစည်းအမည်)။
+*   **Part-of-Speech Tagging (POS)**: စာကြောင်းတစ်ခုစီရှိ စကားလုံးတစ်လုံးစီကို သီးခြား part of speech တစ်ခု (ဥပမာ- noun, verb, adjective) နှင့် သက်ဆိုင်ကြောင်း မှတ်သားခြင်း။
+*   **Chunking**: တူညီသော entity ထဲတွင် ပါဝင်သော tokens များကို စုစည်းခြင်း။
+*   **`B-` (Beginning)**: Chunk သို့မဟုတ် entity တစ်ခု၏အစကို ဖော်ပြသော label။
+*   **`I-` (Inside)**: Chunk သို့မဟုတ် entity တစ်ခု၏ အတွင်းပိုင်းကို ဖော်ပြသော label။
+*   **`O` (Outside)**: Chunk သို့မဟုတ် entity တစ်ခုနှင့် မသက်ဆိုင်သော token ကို ဖော်ပြသော label။
+*   **Fine-tune**: ကြိုတင်လေ့ကျင့်ထားပြီးသား (pre-trained) မော်ဒယ်တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (specific task) အတွက် အနည်းငယ်သော ဒေတာနဲ့ ထပ်မံလေ့ကျင့်ပေးခြင်းကို ဆိုလိုပါတယ်။
+*   **BERT**: Google မှ ဖန်တီးခဲ့သော Bidirectional Encoder Representations from Transformers (BERT) model။
+*   **Predictions**: Machine Learning မော်ဒယ်တစ်ခုက input data ကို အခြေခံပြီး ခန့်မှန်းထုတ်ပေးသော ရလဒ်များ။
+*   **Model Hub (Hugging Face Hub)**: AI မော်ဒယ်တွေ၊ datasets တွေနဲ့ demo တွေကို အခြားသူတွေနဲ့ မျှဝေဖို့၊ ရှာဖွေဖို့နဲ့ ပြန်လည်အသုံးပြုဖို့အတွက် အွန်လိုင်း platform တစ်ခု ဖြစ်ပါတယ်။
+*   **`Gradio` App**: Gradio library ကို အသုံးပြု၍ Machine Learning model များအတွက် web-based demo များကို လွယ်ကူလျင်မြန်စွာ ဖန်တီးရန် app။
+*   **Pre-tokenized Inputs**: Tokenizer သို့ မပို့မီကတည်းက စကားလုံးများအဖြစ် ပိုင်းခြားထားပြီးဖြစ်သော စာသားများ။
+*   **`Dataset` (Hugging Face `Dataset`)**: Hugging Face Datasets library တွင် ဒေတာများကို ကိုယ်စားပြုသော class။
+*   **CoNLL-2003 Dataset**: Named Entity Recognition (NER) အတွက် အသုံးများသော dataset တစ်ခုဖြစ်ပြီး Reuters သတင်းများ ပါဝင်သည်။
+*   **News Stories (Reuters)**: Reuters သတင်းအေဂျင်စီမှ ထုတ်ဝေသော သတင်းများ။
+*   **`load_dataset()` Method**: Hugging Face Datasets library မှ dataset များကို download လုပ်ပြီး cache လုပ်ရန် အသုံးပြုသော method။
+*   **`DatasetDict` Object**: Training set, validation set, နှင့် test set ကဲ့သို့သော dataset အများအပြားကို dictionary ပုံစံဖြင့် သိမ်းဆည်းထားသော object။
+*   **`train` Split**: Model ကို လေ့ကျင့်ရန်အတွက် အသုံးပြုသော dataset အပိုင်း။
+*   **`validation` Split**: Training လုပ်နေစဉ် model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် အသုံးပြုသော dataset အပိုင်း။
+*   **`test` Split**: Model ၏ နောက်ဆုံး စွမ်းဆောင်ရည်ကို တိုင်းတာရန် အသုံးပြုသော dataset အပိုင်း။
+*   **`chunk_tags`**: Chunking task အတွက် labels များ။
+*   **`id`**: Dataset ရှိ example တစ်ခုစီ၏ ID။
+*   **`ner_tags`**: Named Entity Recognition (NER) task အတွက် labels များ။
+*   **`pos_tags`**: Part-of-speech (POS) tagging task အတွက် labels များ။
+*   **`tokens`**: စာသားကို စကားလုံးများအဖြစ် ပိုင်းခြားထားသော list။
+*   **Subword Tokenization**: စကားလုံးများကို သေးငယ်သော subword units (ဥပမာ- word pieces, byte-pair encodings) များအဖြစ် ပိုင်းခြားသော tokenization နည်းလမ်း။
+*   **Integers (Labels)**: Labels များကို ဂဏန်းတန်ဖိုးများအဖြစ် ကိုယ်စားပြုခြင်း။
+*   **`features` Attribute**: Dataset ၏ columns များ၏ အမျိုးအစားများနှင့် အချက်အလက်များကို ပြန်ပေးသော attribute။
+*   **`ClassLabel`**: Categorical labels များကို ကိုင်တွယ်ရန် 🤗 Datasets library မှ အသုံးပြုသော feature type။
+*   **`Sequence`**: 🤗 Datasets library တွင် sequences (list of values) များကို ကိုယ်စားပြုသော feature type။
+*   **`names` Attribute**: `ClassLabel` သို့မဟုတ် `Sequence` feature အတွင်းရှိ labels များ၏ နာမည်များကို ပြန်ပေးသော attribute။
+*   **Entity Spanning Two Words**: စကားလုံးနှစ်လုံးဖြင့် ဖွဲ့စည်းထားသော entity (ဥပမာ- "New York")။
+*   **`AutoTokenizer`**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး မော်ဒယ်အမည်ကို အသုံးပြုပြီး သက်ဆိုင်ရာ tokenizer ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **`model_checkpoint`**: pretrained model ၏ identifier (ဥပမာ- `"bert-base-cased"`)။
+*   **🤗 Tokenizers Library**: Rust ဘာသာနဲ့ ရေးသားထားတဲ့ Hugging Face library တစ်ခုဖြစ်ပြီး မြန်ဆန်ထိရောက်တဲ့ tokenization ကို လုပ်ဆောင်ပေးသည်။
+*   **`is_fast` Attribute**: tokenizer သည် fast (Rust-backed) version ဟုတ်မဟုတ် စစ်ဆေးသော attribute။
+*   **`is_split_into_words=True`**: `tokenizer()` function တွင် input text ကို စကားလုံးများအဖြစ် ပိုင်းခြားထားပြီးဖြစ်ကြောင်း ဖော်ပြသော argument။
+*   **Special Tokens**: Model (ဥပမာ- BERT) မှ အဓိပ္ပာယ်ရှိသော သို့မဟုတ် ဖွဲ့စည်းတည်ဆောက်ပုံဆိုင်ရာ ရည်ရွယ်ချက်များအတွက် အသုံးပြုသော token များ (ဥပမာ- `[CLS]`, `[SEP]`, `[PAD]`)။
+*   **`[CLS]` Token**: BERT model တွင် sequence ၏ အစကို ကိုယ်စားပြုသော special token။
+*   **`[SEP]` Token**: BERT model တွင် sentence တစ်ခု၏ အဆုံး သို့မဟုတ် sentence နှစ်ခုကြား ပိုင်းခြားရန် အသုံးပြုသော special token။
+*   **`##mb` (Subword Token)**: BERT tokenizer မှ ထုတ်လုပ်သော subword token တစ်ခု။ `##` က အရင် token ရဲ့ နောက်ဆက်တွဲဖြစ်ကြောင်း ဖော်ပြသည်။
+*   **Mismatch**: အရာနှစ်ခုကြား မကိုက်ညီမှု သို့မဟုတ် ကွာခြားမှု။
+*   **`word_ids()` Method**: fast tokenizer တွင် token တစ်ခုစီသည် မည်သည့်မူရင်း word နှင့် သက်ဆိုင်သည်ကို ပြန်ပေးသော method။
+*   **`-100` (Label)**: Loss function တွင် လျစ်လျူရှုရန်အတွက် သတ်မှတ်ထားသော label index။
+*   **Loss Function (Cross Entropy)**: Model ၏ ခန့်မှန်းချက်များနှင့် အမှန်တကယ် labels များကြား ကွာခြားမှုကို တိုင်းတာသော function။
+*   **Subtokens**: စကားလုံးများကို ပိုင်းခြားထားသော အစိတ်အပိုင်းများ။
+*   **`Dataset.map()` Method**: 🤗 Datasets library မှာ ပါဝင်တဲ့ method တစ်ခုဖြစ်ပြီး dataset ရဲ့ element တစ်ခုစီ ဒါမှမဟုတ် batch တစ်ခုစီပေါ်မှာ function တစ်ခုကို အသုံးပြုနိုင်စေသည်။
+*   **`batched=True`**: `map()` method မှာ အသုံးပြုသော argument တစ်ခုဖြစ်ပြီး function ကို dataset ရဲ့ element အများအပြားပေါ်မှာ တစ်ပြိုင်နက်တည်း အသုံးပြုစေသည်။
+*   **`truncation=True`**: tokenizer တွင် input sequence ကို model ၏ အများဆုံး input length အထိ ဖြတ်တောက်ရန် သတ်မှတ်ခြင်း။
+*   **`remove_columns` Argument**: `Dataset.map()` method တွင် ပြုပြင်ပြီးနောက် မလိုအပ်သော columns များကို dataset မှ ဖယ်ရှားရန် အသုံးပြုသော argument။
+*   **Padding**: sequence အရှည်များ ကွဲပြားသော inputs များကို တူညီသော အရှည်ဖြစ်စေရန် dummy values (ဥပမာ- 0 သို့မဟုတ် tokenizer ၏ pad token ID) များဖြင့် ဖြည့်ဆည်းခြင်း။
+*   **Data Collator**: `DataLoader` တစ်ခုမှာ အသုံးပြုတဲ့ function တစ်ခုဖြစ်ပြီး batch တစ်ခုအတွင်း samples တွေကို စုစည်းပေးသည်။
+*   **`Trainer` API**: Hugging Face Transformers library မှ model များကို ထိရောက်စွာ လေ့ကျင့်ရန်အတွက် ဒီဇိုင်းထုတ်ထားသော မြင့်မားသောအဆင့် API။
+*   **Keras**: TensorFlow library တွင် ပါဝင်သော မြင့်မားသောအဆင့် (high-level) API တစ်ခုဖြစ်ပြီး deep learning models များကို လွယ်ကူလျင်မြန်စွာ တည်ဆောက်ရန် အသုံးပြုသည်။
+*   **Data Collation**: Training အတွက် data samples များကို batch တစ်ခုအဖြစ် စုစည်းခြင်းလုပ်ငန်းစဉ်။
+*   **`DataCollatorWithPadding`**: Hugging Face Transformers library မှ ပံ့ပိုးပေးသော class တစ်ခုဖြစ်ပြီး dynamic padding ကို အသုံးပြု၍ batch တစ်ခုအတွင်း samples များကို စုစည်းပေးသည်။
+*   **`DataCollatorForTokenClassification`**: Token classification task အတွက် အထူးဒီဇိုင်းထုတ်ထားသော data collator တစ်ခုဖြစ်ပြီး inputs များနှင့် labels နှစ်ခုလုံးကို သင့်လျော်စွာ padding လုပ်ပေးသည်။
+*   **`return_tensors="tf"`**: TensorFlow tensors များကို ပြန်ပေးရန် သတ်မှတ်ခြင်း (TensorFlow framework အတွက်)။
+*   **Batch (Data Batch)**: Training သို့မဟုတ် evaluation အတွက် တစ်ပြိုင်နက်တည်း လုပ်ဆောင်သော data samples အုပ်စု။
+*   **PyTorch `tensor`**: PyTorch framework မှာ data များကို သိမ်းဆည်းရန် အသုံးပြုတဲ့ multi-dimensional array (tensor) တစ်ခု။
+*   **`tf.data.Dataset`**: TensorFlow တွင် data pipelines များကို တည်ဆောက်ရန် အသုံးပြုသော object။
+*   **`to_tf_dataset()` Method**: Hugging Face Dataset object ကို `tf.data.Dataset` object အဖြစ် ပြောင်းလဲပေးသော method (TensorFlow framework အတွက်)။
+*   **`model.prepare_tf_dataset()` Method**: TensorFlow တွင် `tf.data.Dataset` ကို ဖန်တီးရန်အတွက် ပိုမိုရိုးရှင်းသော method။
+*   **`shuffle=True/False`**: dataset ကို shuffle လုပ်ခြင်းရှိမရှိ သတ်မှတ်ခြင်း။
+*   **`batch_size`**: training လုပ်ငန်းစဉ်တစ်ခုစီတွင် model သို့ ပေးပို့သော input samples အရေအတွက်။
+*   **`TFAutoModelForTokenClassification`**: Hugging Face Transformers library မှ token classification အတွက် TensorFlow model ကို အလိုအလျောက် load လုပ်ပေးသော class။
+*   **`num_labels` Argument**: model configuration တွင် labels အရေအတွက်ကို သတ်မှတ်ရန် အသုံးပြုသော argument။
+*   **`id2label` Dictionary**: ID မှ label string သို့ mapping လုပ်သော dictionary။
+*   **`label2id` Dictionary**: Label string မှ ID သို့ mapping လုပ်သော dictionary။
+*   **`model.config`**: model ၏ configuration အချက်အလက်များကို သိမ်းဆည်းထားသော object။
+*   **`model.fit()` Method**: Keras model တွင် training လုပ်ငန်းစဉ်ကို စတင်ရန် အသုံးပြုသော method။
+*   **`TFAutoModelForSequenceClassification`**: Hugging Face Transformers library မှ sequence classification အတွက် TensorFlow model ကို အလိုအလျောက် load လုပ်ပေးသော class။
+*   **Pretraining Head**: pretrained model ၏ မူရင်း task (ဥပမာ- Masked Language Modeling) အတွက် output layer။
+*   **Token Classification Head**: token classification task အတွက် model တွင် ထပ်ထည့်ထားသော output layer။
+*   **Randomly Initialized**: weights များကို ကျပန်းတန်ဖိုးများဖြင့် စတင်သတ်မှတ်ခြင်း။
+*   **`huggingface_hub.notebook_login()`**: Jupyter/Colab Notebooks များတွင် Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော function။
+*   **Login Credentials**: အသုံးပြုသူအမည်နှင့် စကားဝှက်ကဲ့သို့သော authentication အချက်အလက်များ။
+*   **Widget**: Graphical User Interface (GUI) တွင် အသုံးပြုသူနှင့် အပြန်အလှန်တုံ့ပြန်နိုင်သော အစိတ်အပိုင်းများ။
+*   **`huggingface-cli login`**: Hugging Face CLI (Command Line Interface) မှ Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော command။
+*   **`create_optimizer()` Function**: Hugging Face Transformers မှ TensorFlow models များအတွက် `AdamW` optimizer ကို ဖန်တီးပေးသော utility function။
+*   **`AdamW` Optimizer**: Adam optimizer ၏ ပြုပြင်ထားသော ဗားရှင်းဖြစ်ပြီး weight decay ကို ပိုမိုထိရောက်စွာ ကိုင်တွယ်သည်။
+*   **`Adam` Optimizer**: Adaptive Moment Estimation (Adam) optimizer။
+*   **Weight Decay**: Model ၏ weights များကို သေးငယ်စေရန် training လုပ်နေစဉ်အတွင်း အသုံးပြုသော regularization နည်းလမ်း။
+*   **Learning Rate Decay**: Training လုပ်နေစဉ်အတွင်း learning rate ကို တဖြည်းဖြည်း လျှော့ချသည့် နည်းလမ်း။
+*   **Mixed-precision float16**: Model training တွင် float16 (half-precision) နှင့် float32 (full-precision) data types များကို ရောနှောအသုံးပြုခြင်းဖြင့် training မြန်နှုန်းကို တိုးမြှင့်ပြီး memory အသုံးပြုမှုကို လျှော့ချသည်။
+*   **`tf.keras.mixed_precision.set_global_policy("mixed_float16")`**: TensorFlow တွင် mixed-precision training ကို ဖွင့်ရန်။
+*   **`num_train_steps`**: training လုပ်ငန်းစဉ်တစ်ခုလုံး၏ စုစုပေါင်း training steps အရေအတွက်။
+*   **`init_lr`**: စတင် learning rate။
+*   **`num_warmup_steps`**: learning rate ကို တဖြည်းဖြည်း တိုးမြှင့်ပေးသည့် warmup steps အရေအတွက်။
+*   **`model.compile()` Method**: Keras model တွင် training လုပ်ရန်အတွက် optimizer, loss function နှင့် metrics များကို သတ်မှတ်ခြင်း။
+*   **`loss` Argument (in `compile()`)**: `compile()` method တွင် loss function ကို သတ်မှတ်ရန် အသုံးပြုသော argument။
+*   **`PushToHubCallback`**: Keras Trainer တွင် အသုံးပြုသော callback တစ်ခုဖြစ်ပြီး training လုပ်နေစဉ်အတွင်း models, tokenizers, configuration များနှင့် model card draft များကို Hub သို့ ပုံမှန် update လုပ်ရန်။
+*   **`output_dir`**: model files များကို သိမ်းဆည်းမည့် directory။
+*   **`validation_data`**: training လုပ်နေစဉ် model ကို အကဲဖြတ်ရန် အသုံးပြုမည့် validation dataset။
+*   **`callbacks`**: training လုပ်နေစဉ်အတွင်း သတ်မှတ်ထားသော အချိန်များတွင် လုပ်ဆောင်မည့် functions များ။
+*   **`epochs`**: model ကို training dataset တစ်ခုလုံးဖြင့် လေ့ကျင့်သည့် အကြိမ်အရေအတွက်။
+*   **`hub_model_id` Argument**: Hugging Face Hub တွင် repository ID ကို သတ်မှတ်ရန်။
+*   **Organization**: Hugging Face Hub ပေါ်ရှိ အဖွဲ့အစည်းအကောင့်။
+*   **Namespace**: Hugging Face Hub တွင် အသုံးပြုသူအမည် သို့မဟုတ် organization အမည်။
+*   **Local Clone**: Git repository ၏ ဒေသတွင်း ကွန်ပျူတာပေါ်ရှိ မိတ္တူ။
+*   **`model.fit()`**: Keras model တွင် training လုပ်ငန်းစဉ်ကို စတင်ရန် အသုံးပြုသော method။
+*   **Resume Training**: Training ကို ရပ်နားခဲ့သော နေရာမှ ပြန်လည်စတင်ခြင်း။
+*   **Inference Widget**: Model Hub ပေါ်တွင် model တစ်ခုကို interactive စမ်းသပ်နိုင်သည့် web UI အစိတ်အပိုင်း။
+*   **Metrics**: Model ၏ စွမ်းဆောင်ရည်ကို တိုင်းတာရန် အသုံးပြုသော တန်ဖိုးများ (ဥပမာ- accuracy, F1 score)။
+*   **`compute_metrics()` Function**: `Trainer` ကို အသုံးပြု၍ training လုပ်နေစဉ်အတွင်း metrics များကို တွက်ချက်ရန်အတွက် function။
+*   **`eval_preds`**: `compute_metrics()` function သို့ ပေးပို့သော predictions နှင့် labels။
+*   **`seqeval`**: token classification models များကို အကဲဖြတ်ရန်အတွက် အသုံးပြုသော Python library။
+*   **`evaluate.load()` Function**: Hugging Face Evaluate library မှ metric ကို load လုပ်ရန် အသုံးပြုသော function။
+*   **Precision**: True positives အရေအတွက်ကို True positives နှင့် False positives ပေါင်းလဒ်ဖြင့် စားခြင်း။ Model ၏ မှန်ကန်စွာ ခန့်မှန်းနိုင်မှု။
+*   **Recall**: True positives အရေအတွက်ကို True positives နှင့် False negatives ပေါင်းလဒ်ဖြင့် စားခြင်း။ Model က လိုအပ်သော အရာအားလုံးကို ဘယ်လောက်ဖော်ထုတ်နိုင်လဲ။
+*   **F1 Score**: Precision နှင့် Recall တို့၏ harmonic mean ကို တွက်ချက်သော metric။
+*   **`overall_precision`**: Overall precision score။
+*   **`overall_recall`**: Overall recall score။
+*   **`overall_f1`**: Overall F1 score။
+*   **`overall_accuracy`**: Overall accuracy score။
+*   **`np.argmax(logits, axis=-1)`**: Logits များမှ အများဆုံးတန်ဖိုးရှိသော index ကို ရယူခြင်းဖြင့် prediction ကို တွက်ချက်ခြင်း။
+*   **`logits`**: Model ၏ output layer မှ ထွက်ပေါ်လာသော raw, unnormalized scores များ။
+*   **`labels`**: အမှန်တကယ် label များ။
+*   **`true_labels`**: `-100` labels များကို ဖယ်ရှားပြီး label strings အဖြစ် ပြောင်းလဲထားသော အမှန်တကယ် labels များ။
+*   **`true_predictions`**: `-100` labels များကို ဖယ်ရှားပြီး label strings အဖြစ် ပြောင်းလဲထားသော predictions များ။
+*   **`all_metrics`**: `metric.compute()` မှ ပြန်ပေးသော metrics အားလုံးပါဝင်သည့် dictionary။
+*   **`model.predict_on_batch(batch)`**: TensorFlow model တွင် batch တစ်ခုပေါ်တွင် prediction များကို တွက်ချက်ရန်။
+*   **`tf_eval_dataset`**: TensorFlow evaluation dataset။
+*   **`AutoModelForTokenClassification`**: Hugging Face Transformers library မှ token classification အတွက် PyTorch model ကို အလိုအလျောက် load လုပ်ပေးသော class။
+*   **`TrainingArguments`**: `Trainer` ကို အသုံးပြု၍ training လုပ်ရန်အတွက် hyperparameters များနှင့် အခြား settings များကို သတ်မှတ်သော class။
+*   **`evaluation_strategy="epoch"`**: epoch တိုင်းပြီးဆုံးတိုင်း evaluation လုပ်ရန်။
+*   **`save_strategy="epoch"`**: epoch တိုင်းပြီးဆုံးတိုင်း model ကို save လုပ်ရန်။
+*   **`learning_rate`**: training လုပ်နေစဉ်အတွင်း model ၏ weights များကို မည်မျှပြောင်းလဲရမည်ကို ထိန်းချုပ်သော parameter။
+*   **`num_train_epochs`**: model ကို training dataset တစ်ခုလုံးဖြင့် လေ့ကျင့်သည့် အကြိမ်အရေအတွက်။
+*   **`weight_decay`**: Model ၏ weights များကို သေးငယ်စေရန် training လုပ်နေစဉ်အတွင်း အသုံးပြုသော regularization နည်းလမ်း။
+*   **`push_to_hub=True`**: training ပြီးဆုံးပြီးနောက် model ကို Hugging Face Hub သို့ upload လုပ်ရန်။
+*   **`trainer.train()`**: `Trainer` API ကို အသုံးပြု၍ training လုပ်ငန်းစဉ်ကို စတင်ရန်။
+*   **`trainer.push_to_hub()` Method**: `Trainer` မှ model ကို Hugging Face Hub သို့ commit message နှင့်အတူ upload လုပ်ရန်။
+*   **Commit Message**: Git commit တစ်ခုတွင် ပြောင်းလဲမှုများကို ဖော်ပြသော မက်ဆေ့ချ်။
+*   **`DataLoader`**: Dataset ကနေ data တွေကို batch အလိုက် load လုပ်ပေးတဲ့ PyTorch utility class။
+*   **`collate_fn`**: `DataLoader` တွင် batch တစ်ခုအတွင်း samples များကို စုစည်းပေးသော function။
+*   **`torch.optim.AdamW`**: PyTorch မှာ အသုံးပြုတဲ့ AdamW optimizer။
+*   **`model.parameters()`**: model ၏ လေ့ကျင့်နိုင်သော parameters (weights နှင့် biases) များကို ပြန်ပေးသော method။
+*   **`accelerator` (Hugging Face Accelerate)**: Distributed training နှင့် mixed-precision training ကို လွယ်ကူချောမွေ့စေသော object။
+*   **`accelerator.prepare()` Method**: models, optimizers, dataloaders များကို distributed training အတွက် ပြင်ဆင်ပေးသော method။
+*   **TPU (Tensor Processing Unit)**: Google မှ AI/ML workloads များအတွက် အထူးဒီဇိုင်းထုတ်ထားသော processor တစ်မျိုး။
+*   **Dedicated Training Function**: TPU training အတွက် လိုအပ်သော သီးခြား function။
+*   **Linear Schedule**: Learning rate ကို အစပိုင်းတွင် မြင့်မားစွာထားပြီး training လုပ်ငန်းစဉ်တစ်လျှောက် တဖြည်းဖြည်း လျှော့ချသည့် schedule။
+*   **`get_scheduler()` Function**: Hugging Face Transformers မှ learning rate schedulers များကို ဖန်တီးပေးသော function။
+*   **`num_update_steps_per_epoch`**: epoch တစ်ခုစီရှိ update steps အရေအတွက်။
+*   **`num_training_steps`**: training လုပ်ငန်းစဉ်တစ်ခုလုံး၏ စုစုပေါင်း training steps အရေအတွက်။
+*   **`lr_scheduler`**: learning rate ကို ထိန်းချုပ်ရန် အသုံးပြုသော object။
+*   **`Repository` Object**: `huggingface_hub` library မှ Git repository များကို ကိုင်တွယ်ရန်အတွက် object။
+*   **Working Folder**: project files များကို သိမ်းဆည်းထားသော folder။
+*   **`get_full_repo_name()` Function**: Hugging Face Hub တွင် repository အပြည့်အစုံနာမည်ကို ရယူရန် utility function။
+*   **`repo_name`**: repository ၏ အမည် (ဥပမာ- `"sgugger/my-awesome-model"`)။
+*   **`output_dir`**: model files များကို သိမ်းဆည်းမည့် directory။
+*   **`repo.push_to_hub()` Method**: `Repository` object မှ အပြောင်းအလဲများကို Hugging Face Hub သို့ push လုပ်ရန်။
+*   **Intermediate Models**: training လုပ်နေစဉ်အတွင်း သတ်မှတ်ထားသော အချိန်များတွင် သိမ်းဆည်းထားသော models များ။
+*   **`postprocess()` Function**: Predictions နှင့် labels များကို metric calculation အတွက် သင့်လျော်သော ပုံစံသို့ ပြောင်းလဲပေးသော function။
+*   **`predictions.detach().cpu().clone().numpy()`**: PyTorch tensor မှ gradient tracking ကို ဖယ်ရှားပြီး CPU သို့ ရွှေ့ကာ clone လုပ်၍ NumPy array အဖြစ် ပြောင်းလဲခြင်း။
+*   **`tqdm.auto.tqdm`**: Python တွင် loops များအတွက် progress bar ကို ပြသရန် utility။
+*   **`torch`**: PyTorch library။
+*   **`model.train()`**: PyTorch model ကို training mode သို့ ပြောင်းလဲခြင်း။
+*   **`model.eval()`**: PyTorch model ကို evaluation mode သို့ ပြောင်းလဲခြင်း။
+*   **`outputs = model(**batch)`**: model ၏ forward pass ကို batch data နှင့် လုပ်ဆောင်ခြင်း။
+*   **`loss = outputs.loss`**: model မှ တွက်ချက်ထားသော loss ကို ရယူခြင်း။
+*   **`accelerator.backward(loss)`**: Distributed training တွင် backpropagation ကို လုပ်ဆောင်ခြင်း။
+*   **`optimizer.step()`**: တွက်ချက်ထားသော gradients များကို အသုံးပြုပြီး model ၏ parameters များကို update လုပ်သော optimizer method။
+*   **`optimizer.zero_grad()`**: gradients များကို သုညသို့ ပြန်လည်သတ်မှတ်ခြင်း။
+*   **`torch.no_grad()`**: gradient တွက်ချက်မှုကို ပိတ်ထားရန် (evaluation mode တွင်)။
+*   **`outputs.logits.argmax(dim=-1)`**: model ၏ output logits များမှ အများဆုံးတန်ဖိုးရှိသော index (prediction) ကို ရယူခြင်း။
+*   **`accelerator.pad_across_processes()`**: Distributed training တွင် မတူညီသော processes များမှ tensors များကို တူညီသော shape အဖြစ် padding လုပ်ခြင်း။
+*   **`accelerator.gather()`**: Distributed training တွင် မတူညီသော processes များမှ tensors များကို စုစည်းခြင်း။
+*   **`metric.add_batch()`**: `evaluate` library ၏ metric object တွင် batch အလိုက် predictions နှင့် references များကို ထည့်သွင်းခြင်း။
+*   **`metric.compute()`**: `evaluate` library ၏ metric object တွင် metrics များကို တွက်ချက်ခြင်း။
+*   **`accelerator.wait_for_everyone()`**: Distributed training တွင် processes အားလုံး အဆင့်တစ်ခုတည်းတွင် ရှိနေစေရန် စောင့်ဆိုင်းခြင်း။
+*   **`accelerator.unwrap_model(model)`**: distributed training အတွက် `accelerator` မှ wrap လုပ်ထားသော model ကို မူရင်း model အဖြစ် ပြန်လည်ရယူခြင်း။
+*   **`unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)`**: model ကို `output_dir` သို့ သိမ်းဆည်းပြီး `accelerator.save()` ကို saving function အဖြစ် အသုံးပြုခြင်း။
+*   **`accelerator.is_main_process`**: လက်ရှိ process သည် main process ဟုတ်မဟုတ် စစ်ဆေးခြင်း။
+*   **`tokenizer.save_pretrained(output_dir)`**: tokenizer ကို `output_dir` သို့ သိမ်းဆည်းခြင်း။
+*   **`blocking=False`**: `push_to_hub()` method တွင် asynchronous (background) push လုပ်ငန်းစဉ်ကို ဖွင့်ရန်။
+*   **`torch.save()`**: PyTorch object များကို disk သို့ သိမ်းဆည်းရန် function။
+*   **`pipeline()` (Hugging Face Pipeline)**: `pipeline()` function ကို အသုံးပြုပြီး model တစ်ခုကို အလွယ်တကူ အသုံးပြုနိုင်သော abstraction။
+*   **`aggregation_strategy="simple"`**: token classification pipeline တွင် subword predictions များကို ပေါင်းစပ်ပုံ နည်းလမ်း။
+*   **Default Model**: pipeline အတွက် ကြိုတင်သတ်မှတ်ထားသော model။

--- a/chapters/my/chapter7/3.mdx
+++ b/chapters/my/chapter7/3.mdx
@@ -1,0 +1,1226 @@
+<FrameworkSwitchCourse {fw} />
+
+# Masked Language Model တစ်ခုကို Fine-tuning လုပ်ခြင်း[[fine-tuning-a-masked-language-model]]
+
+{#if fw === 'pt'}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section3_pt.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section3_pt.ipynb"},
+]} />
+
+{:else}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section3_tf.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section3_tf.ipynb"},
+]} />
+
+{/if}
+
+Transformer models တွေပါဝင်တဲ့ NLP applications အများအပြားအတွက်၊ သင်ဟာ Hugging Face Hub ကနေ pretrained model တစ်ခုကို ယူပြီး သင်ရဲ့ data ပေါ်မှာ လက်ရှိ task အတွက် တိုက်ရိုက် fine-tune လုပ်နိုင်ပါတယ်။ pretraining အတွက် အသုံးပြုခဲ့တဲ့ corpus က fine-tuning အတွက် အသုံးပြုခဲ့တဲ့ corpus နဲ့ သိပ်မကွာခြားဘူးဆိုရင်၊ transfer learning က များသောအားဖြင့် ကောင်းမွန်တဲ့ ရလဒ်တွေ ထုတ်ပေးပါလိမ့်မယ်။
+
+သို့သော်လည်း၊ task-specific head တစ်ခုကို train မလုပ်ခင်၊ သင်ရဲ့ data ပေါ်မှာ language models တွေကို အရင် fine-tune လုပ်ချင်တဲ့ ကိစ္စအချို့ရှိပါတယ်။ ဥပမာ၊ သင်၏ dataset မှာ ဥပဒေဆိုင်ရာ စာချုပ်တွေ ဒါမှမဟုတ် သိပ္ပံနည်းကျ ဆောင်းပါးတွေ ပါဝင်တယ်ဆိုရင်၊ BERT လို vanilla Transformer model တစ်ခုက သင်၏ corpus ထဲက domain-specific words တွေကို rare tokens တွေအဖြစ် သတ်မှတ်မှာဖြစ်ပြီး၊ ရလဒ်စွမ်းဆောင်ရည်က ကျေနပ်စရာ ကောင်းချင်မှ ကောင်းပါလိမ့်မယ်။ in-domain data ပေါ်မှာ language model ကို fine-tune လုပ်ခြင်းဖြင့် downstream tasks များစွာရဲ့ စွမ်းဆောင်ရည်ကို မြှင့်တင်နိုင်ပါတယ်၊ ဒါက သင်ဒီအဆင့်ကို တစ်ခါပဲ လုပ်ဖို့ လိုတယ်လို့ ဆိုလိုတာပါ။
+
+pretrained language model တစ်ခုကို in-domain data ပေါ်မှာ fine-tune လုပ်တဲ့ ဒီလုပ်ငန်းစဉ်ကို များသောအားဖြင့် _domain adaptation_ လို့ခေါ်ပါတယ်။ ဒါကို ၂၀၁၈ ခုနှစ်မှာ [ULMFiT](https://arxiv.org/abs/1801.06146) က လူသိများအောင် လုပ်ဆောင်ခဲ့ပါတယ်။ ULMFiT ဟာ NLP အတွက် transfer learning ကို တကယ်အလုပ်ဖြစ်စေခဲ့တဲ့ ပထမဆုံး neural architectures (LSTMs ပေါ် အခြေခံထားတာ) တွေထဲက တစ်ခုဖြစ်ပါတယ်။ ULMFiT နဲ့ domain adaptation ဥပမာကို အောက်ပါပုံမှာ ပြသထားပါတယ်၊ ဒီအပိုင်းမှာ ကျွန်တော်တို့ အဲဒါနဲ့ ဆင်တူတာတစ်ခု လုပ်ဆောင်ပါမယ်၊ ဒါပေမယ့် LSTM အစား Transformer နဲ့ပါ။
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/ulmfit.svg" alt="ULMFiT."/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/ulmfit-dark.svg" alt="ULMFiT."/>
+</div>
+
+ဒီအပိုင်းရဲ့ အဆုံးမှာ သင်ဟာ အောက်မှာ ပြသထားတဲ့အတိုင်း စာကြောင်းတွေကို autocomplete လုပ်နိုင်မယ့် [masked language model](https://huggingface.co/huggingface-course/distilbert-base-uncased-finetuned-imdb?text=This+is+a+great+%5BMASK%5D.) တစ်ခု Hub မှာ ရရှိပါလိမ့်မယ်။
+
+<iframe src="https://course-demos-distilbert-base-uncased-finetuned-imdb.hf.space" frameBorder="0" height="300" title="Gradio app" class="block dark:hidden container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
+
+စတင်လိုက်ရအောင်!
+
+<Youtube id="mqElG5QJWUg"/>
+
+> [!TIP]
+> 🙋 "masked language modeling" နဲ့ "pretrained model" ဆိုတဲ့ စကားလုံးတွေက သင့်အတွက် မရင်းနှီးဘူးဆိုရင်၊ [Chapter 1](/course/chapter1) ကို သွားကြည့်ပါ။ အဲဒီမှာ ဒီအဓိက သဘောတရားတွေအားလုံးကို ဗီဒီယိုတွေနဲ့တကွ ရှင်းပြထားပါတယ်။
+
+## Masked Language Modeling အတွက် Pretrained Model တစ်ခုကို ရွေးချယ်ခြင်း[[picking-a-pretrained-model-for-masked-language-modeling]]
+
+စတင်ဖို့အတွက်၊ masked language modeling အတွက် သင့်လျော်တဲ့ pretrained model တစ်ခုကို ရွေးချယ်ကြရအောင်။ အောက်ပါ screenshot မှာ ပြသထားတဲ့အတိုင်း၊ [Hugging Face Hub](https://huggingface.co/models?pipeline_tag=fill-mask&sort=downloads) မှာ "Fill-Mask" filter ကို အသုံးပြုပြီး candidates တွေကို ရှာဖွေနိုင်ပါတယ်။
+
+<div class="flex justify-center">
+<img src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/mlm-models.png" alt="Hub models." width="80%"/>
+</div>
+
+BERT နဲ့ RoBERTa family models တွေက အများဆုံး download လုပ်ထားကြပေမယ့်၊ ကျွန်တော်တို့က [DistilBERT](https://huggingface.co/distilbert-base-uncased) လို့ခေါ်တဲ့ model ကို အသုံးပြုပါမယ်။ ဒီ model က downstream performance မှာ အနည်းငယ်မျှသာ ဆုံးရှုံးမှုနဲ့ အများကြီး ပိုမြန်မြန် train လုပ်နိုင်ပါတယ်။ ဒီ model ကို _knowledge distillation_](https://en.wikipedia.org/wiki/Knowledge_distillation) လို့ခေါ်တဲ့ အထူးနည်းလမ်းတစ်ခု အသုံးပြုပြီး train လုပ်ခဲ့တာပါ။ အဲဒီမှာ BERT လို ကြီးမားတဲ့ "teacher model" ကို parameters အများကြီး နည်းပါးတဲ့ "student model" ရဲ့ training ကို လမ်းညွှန်ဖို့ အသုံးပြုခဲ့တာပါ။ knowledge distillation ရဲ့ အသေးစိတ်အချက်အလက်တွေကို ရှင်းပြတာက ဒီအပိုင်းမှာ အလွန်အကျွံ ဖြစ်သွားပါလိမ့်မယ်၊ ဒါပေမယ့် သင်စိတ်ဝင်စားတယ်ဆိုရင် [_Natural Language Processing with Transformers_](https://www.oreilly.com/library/view/natural-language-processing/9781098136789/) ( colloquially Transformers textbook လို့ သိကြပါတယ်) မှာ ဖတ်ရှုနိုင်ပါတယ်။
+
+{#if fw === 'pt'}
+
+`AutoModelForMaskedLM` class ကို အသုံးပြုပြီး DistilBERT ကို download လုပ်လိုက်ရအောင်...
+
+```python
+from transformers import AutoModelForMaskedLM
+
+model_checkpoint = "distilbert-base-uncased"
+model = AutoModelForMaskedLM.from_pretrained(model_checkpoint)
+```
+
+ဒီ model မှာ parameters ဘယ်လောက်ရှိတယ်ဆိုတာကို `num_parameters()` method ကို ခေါ်ခြင်းဖြင့် ကြည့်နိုင်ပါတယ်။
+
+```python
+distilbert_num_parameters = model.num_parameters() / 1_000_000
+print(f"'>>> DistilBERT number of parameters: {round(distilbert_num_parameters)}M'")
+print(f"'>>> BERT number of parameters: 110M'")
+```
+
+```python out
+'>>> DistilBERT number of parameters: 67M'
+'>>> BERT number of parameters: 110M'
+```
+
+{:else}
+
+`AutoModelForMaskedLM` class ကို အသုံးပြုပြီး DistilBERT ကို download လုပ်လိုက်ရအောင်...
+
+```python
+from transformers import TFAutoModelForMaskedLM
+
+model_checkpoint = "distilbert-base-uncased"
+model = TFAutoModelForMaskedLM.from_pretrained(model_checkpoint)
+```
+
+ဒီ model မှာ parameters ဘယ်လောက်ရှိတယ်ဆိုတာကို `summary()` method ကို ခေါ်ခြင်းဖြင့် ကြည့်နိုင်ပါတယ်။
+
+```python
+model.summary()
+```
+
+```python out
+Model: "tf_distil_bert_for_masked_lm"
+_________________________________________________________________
+Layer (type)                 Output Shape              Param #
+=================================================================
+distilbert (TFDistilBertMain multiple                  66362880
+_________________________________________________________________
+vocab_transform (Dense)      multiple                  590592
+_________________________________________________________________
+vocab_layer_norm (LayerNorma multiple                  1536
+_________________________________________________________________
+vocab_projector (TFDistilBer multiple                  23866170
+=================================================================
+Total params: 66,985,530
+Trainable params: 66,985,530
+Non-trainable params: 0
+_________________________________________________________________
+```
+
+{/if}
+
+parameters ၆၇ သန်းလောက်နဲ့ DistilBERT က BERT base model ထက် နှစ်ဆခန့် ပိုသေးငယ်ပြီး၊ ဒါက training speed ကို နှစ်ဆမြှင့်တင်ပေးနိုင်ပါတယ်။ ကောင်းပါပြီ! ဒီ model က text အပိုင်းအစလေးတစ်ခုကို ဘယ်လိုဖြည့်စွက်ပေးနိုင်မလဲဆိုတာ ကြည့်ရအောင်-
+
+```python
+text = "This is a great [MASK]."
+```
+
+လူသားတွေအနေနဲ့ `[MASK]` token အတွက် "day", "ride", ဒါမှမဟုတ် "painting" လို ဖြစ်နိုင်ခြေများစွာကို စဉ်းစားနိုင်ပါတယ်။ pretrained models တွေအတွက်ကတော့၊ ခန့်မှန်းချက်တွေဟာ model ကို train လုပ်ခဲ့တဲ့ corpus ပေါ်မှာ မူတည်ပါတယ်၊ ဘာလို့လဲဆိုတော့ model က data ထဲမှာရှိတဲ့ statistical patterns တွေကို ကောက်ယူတတ်အောင် သင်ယူထားလို့ပါပဲ။ BERT လိုပဲ၊ DistilBERT ကို [English Wikipedia](https://huggingface.co/datasets/wikipedia) နဲ့ [BookCorpus](https://huggingface.co/datasets/bookcorpus) datasets တွေပေါ်မှာ pretrained လုပ်ခဲ့တာကြောင့်၊ `[MASK]` အတွက် ခန့်မှန်းချက်တွေဟာ ဒီ domains တွေကို ထင်ဟပ်မယ်လို့ ကျွန်တော်တို့ မျှော်လင့်ပါတယ်။ mask ကို ခန့်မှန်းဖို့ DistilBERT ရဲ့ tokenizer က model အတွက် inputs တွေကို ထုတ်လုပ်ပေးဖို့ လိုအပ်တာကြောင့်၊ အဲဒါကို Hub ကနေ download လုပ်လိုက်ရအောင်။
+
+```python
+from transformers import AutoTokenizer
+
+tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
+```
+
+tokenizer နဲ့ model တစ်ခုရှိပြီဆိုတာနဲ့၊ ကျွန်တော်တို့ရဲ့ text ဥပမာကို model ကို ပေးပို့နိုင်ပြီး logits တွေကို ထုတ်ယူကာ ထိပ်တန်း ၅ ခုသော candidates တွေကို print ထုတ်နိုင်ပါတယ်။
+
+{#if fw === 'pt'}
+
+```python
+import torch
+
+inputs = tokenizer(text, return_tensors="pt")
+token_logits = model(**inputs).logits
+# [MASK] ၏ နေရာကို ရှာဖွေပြီး ၎င်း၏ logits များကို ထုတ်ယူပါ
+mask_token_index = torch.where(inputs["input_ids"] == tokenizer.mask_token_id)[1]
+mask_token_logits = token_logits[0, mask_token_index, :]
+# အမြင့်ဆုံး logits ရှိသော [MASK] candidates များကို ရွေးချယ်ပါ
+top_5_tokens = torch.topk(mask_token_logits, 5, dim=1).indices[0].tolist()
+
+for token in top_5_tokens:
+    print(f"'>>> {text.replace(tokenizer.mask_token, tokenizer.decode([token]))}'")
+```
+
+{:else}
+
+```python
+import numpy as np
+import tensorflow as tf
+
+inputs = tokenizer(text, return_tensors="np")
+token_logits = model(**inputs).logits
+# [MASK] ၏ နေရာကို ရှာဖွေပြီး ၎င်း၏ logits များကို ထုတ်ယူပါ
+mask_token_index = np.argwhere(inputs["input_ids"] == tokenizer.mask_token_id)[0, 1]
+mask_token_logits = token_logits[0, mask_token_index, :]
+# အမြင့်ဆုံး logits ရှိသော [MASK] candidates များကို ရွေးချယ်ပါ
+# အသေးဆုံး logits များ မဟုတ်ဘဲ အကြီးဆုံး logits များကို ရယူရန် argsort မလုပ်မီ array ကို negate လုပ်ပါ
+top_5_tokens = np.argsort(-mask_token_logits)[:5].tolist()
+
+for token in top_5_tokens:
+    print(f">>> {text.replace(tokenizer.mask_token, tokenizer.decode([token]))}")
+```
+
+{/if}
+
+```python out
+'>>> This is a great deal.'
+'>>> This is a great success.'
+'>>> This is a great adventure.'
+'>>> This is a great idea.'
+'>>> This is a great feat.'
+```
+
+outputs တွေကနေ model ရဲ့ ခန့်မှန်းချက်တွေက နေ့စဉ်သုံး စကားလုံးတွေကို ရည်ညွှန်းနေတာကို ကျွန်တော်တို့ မြင်နိုင်ပါတယ်။ ဒါဟာ English Wikipedia ရဲ့ အခြေခံကြောင့် အံ့သြစရာ မဟုတ်ပါဘူး။ ဒီ domain ကို နည်းနည်းပို niche ဖြစ်တဲ့ အရာတစ်ခုဆီ ဘယ်လိုပြောင်းမလဲဆိုတာ ကြည့်ရအောင် — အလွန်အမင်း အမြင်ကွဲလွဲနေတဲ့ ရုပ်ရှင် reviews တွေဆီကိုပါ။
+
+## Dataset[[the-dataset]]
+
+domain adaptation ကို ပြသဖို့၊ ကျွန်တော်တို့ဟာ နာမည်ကျော် [Large Movie Review Dataset](https://huggingface.co/datasets/imdb) (အတိုကောက် IMDb) ကို အသုံးပြုပါမယ်။ ဒါက sentiment analysis models တွေကို benchmark လုပ်ဖို့ မကြာခဏ အသုံးပြုတဲ့ ရုပ်ရှင် reviews corpus တစ်ခုပါ။ DistilBERT ကို ဒီ corpus ပေါ်မှာ fine-tune လုပ်ခြင်းဖြင့်၊ language model က ၎င်းရဲ့ vocabulary ကို pretrained လုပ်ခဲ့တဲ့ Wikipedia ရဲ့ factual data ကနေ movie reviews တွေရဲ့ ပိုပြီး subjective elements တွေဆီ လိုက်လျောညီထွေဖြစ်အောင် လုပ်မယ်လို့ ကျွန်တော်တို့ မျှော်လင့်ပါတယ်။ 🤗 Datasets ကနေ `load_dataset()` function နဲ့ data တွေကို Hugging Face Hub ကနေ ရယူနိုင်ပါတယ်။
+
+```python
+from datasets import load_dataset
+
+imdb_dataset = load_dataset("imdb")
+imdb_dataset
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['text', 'label'],
+        num_rows: 25000
+    })
+    test: Dataset({
+        features: ['text', 'label'],
+        num_rows: 25000
+    })
+    unsupervised: Dataset({
+        features: ['text', 'label'],
+        num_rows: 50000
+    })
+})
+```
+
+`train` နဲ့ `test` splits တွေမှာ review ပေါင်း ၂၅,၀၀၀ စီ ပါဝင်နေတာကို ကျွန်တော်တို့ တွေ့နိုင်ပြီး၊ `unsupervised` လို့ခေါ်တဲ့ label မပါတဲ့ split တစ်ခုမှာ reviews ၅၀,၀၀၀ ပါဝင်ပါတယ်။ ဘယ်လို text မျိုးနဲ့ အလုပ်လုပ်နေတယ်ဆိုတာ သိရအောင် samples အချို့ကို ကြည့်ရအောင်။ သင်တန်းရဲ့ ယခင်အခန်းတွေမှာ လုပ်ခဲ့သလိုပဲ၊ random sample တစ်ခု ဖန်တီးဖို့ `Dataset.shuffle()` နဲ့ `Dataset.select()` functions တွေကို ဆက်တိုက်အသုံးပြုပါမယ်။
+
+```python
+sample = imdb_dataset["train"].shuffle(seed=42).select(range(3))
+
+for row in sample:
+    print(f"\n'>>> Review: {row['text']}'")
+    print(f"'>>> Label: {row['label']}'")
+```
+
+```python out
+
+'>>> Review: This is your typical Priyadarshan movie--a bunch of loony characters out on some silly mission. His signature climax has the entire cast of the film coming together and fighting each other in some crazy moshpit over hidden money. Whether it is a winning lottery ticket in Malamaal Weekly, black money in Hera Pheri, "kodokoo" in Phir Hera Pheri, etc., etc., the director is becoming ridiculously predictable. Don\'t get me wrong; as clichéd and preposterous his movies may be, I usually end up enjoying the comedy. However, in most his previous movies there has actually been some good humor, (Hungama and Hera Pheri being noteworthy ones). Now, the hilarity of his films is fading as he is using the same formula over and over again.<br /><br />Songs are good. Tanushree Datta looks awesome. Rajpal Yadav is irritating, and Tusshar is not a whole lot better. Kunal Khemu is OK, and Sharman Joshi is the best.'
+'>>> Label: 0'
+
+'>>> Review: Okay, the story makes no sense, the characters lack any dimensionally, the best dialogue is ad-libs about the low quality of movie, the cinematography is dismal, and only editing saves a bit of the muddle, but Sam" Peckinpah directed the film. Somehow, his direction is not enough. For those who appreciate Peckinpah and his great work, this movie is a disappointment. Even a great cast cannot redeem the time the viewer wastes with this minimal effort.<br /><br />The proper response to the movie is the contempt that the director San Peckinpah, James Caan, Robert Duvall, Burt Young, Bo Hopkins, Arthur Hill, and even Gig Young bring to their work. Watch the great Peckinpah films. Skip this mess.'
+'>>> Label: 0'
+
+'>>> Review: I saw this movie at the theaters when I was about 6 or 7 years old. I loved it then, and have recently come to own a VHS version. <br /><br />My 4 and 6 year old children love this movie and have been asking again and again to watch it. <br /><br />I have enjoyed watching it again too. Though I have to admit it is not as good on a little TV.<br /><br />I do not have older children so I do not know what they would think of it. <br /><br />The songs are very cute. My daughter keeps singing them over and over.<br /><br />Hope this helps.'
+'>>> Label: 1'
+```
+
+ဟုတ်ပါတယ်၊ ဒါတွေက ရုပ်ရှင် reviews တွေ ဖြစ်ပါတယ်။ သင်အသက်ကြီးပြီဆိုရင် နောက်ဆုံး review ထဲက VHS version ပိုင်ဆိုင်မှုနဲ့ ပတ်သက်တဲ့ မှတ်ချက်ကိုတောင် နားလည်နိုင်ပါလိမ့်မယ် 😜! language modeling အတွက် labels တွေ မလိုအပ်ပေမယ့်၊ `0` က negative review ကို ရည်ညွှန်းပြီး `1` က positive review ကို ကိုယ်စားပြုတာကို ကျွန်တော်တို့ တွေ့မြင်နိုင်ပါတယ်။
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** `unsupervised` split ရဲ့ random sample တစ်ခုကို ဖန်တီးပြီး labels တွေဟာ `0` ဒါမှမဟုတ် `1` မဟုတ်ဘူးဆိုတာ စစ်ဆေးပါ။ ဒီလိုလုပ်ရင်း၊ `train` နဲ့ `test` splits တွေထဲက labels တွေဟာ တကယ်ပဲ `0` ဒါမှမဟုတ် `1` ဟုတ်မဟုတ် စစ်ဆေးကြည့်နိုင်ပါတယ် — ဒါက NLP practitioner တိုင်း project အသစ်တစ်ခုရဲ့ အစမှာ လုပ်ဆောင်သင့်တဲ့ အသုံးဝင်တဲ့ sanity check တစ်ခုပါ!
+
+data ကို အမြန်ကြည့်ပြီးပြီဆိုတော့၊ masked language modeling အတွက် ပြင်ဆင်တာကို ဆက်လုပ်ရအောင်။ [Chapter 3](/course/chapter3) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့ sequence classification tasks တွေနဲ့ နှိုင်းယှဉ်ရင်၊ လုပ်ဆောင်ရမယ့် ထပ်ဆောင်းအဆင့်အချို့ ရှိတာကို မြင်တွေ့ရပါလိမ့်မယ်။ စလိုက်ရအောင်!
+
+## Data ကို Preprocess လုပ်ခြင်း[[preprocessing-the-data]]
+
+<Youtube id="8PmhEIXhBvI"/>
+
+auto-regressive နဲ့ masked language modeling နှစ်ခုလုံးအတွက်၊ common preprocessing step ကတော့ examples အားလုံးကို concatenate လုပ်ပြီးမှ corpus တစ်ခုလုံးကို အရွယ်အစားတူ chunks တွေအဖြစ် ခွဲထုတ်တာပါ။ ဒါက ကျွန်တော်တို့ရဲ့ ပုံမှန်ချဉ်းကပ်မှုနဲ့ အတော်လေး ကွာခြားပါတယ်။ ပုံမှန်အားဖြင့်တော့ individual examples တွေကို ရိုးရှင်းစွာ tokenize လုပ်တာပါ။ ဘာကြောင့် အရာအားလုံးကို concatenate လုပ်ရတာလဲ။ အကြောင်းရင်းကတော့ individual examples တွေက အရှည်လွန်ကဲရင် truncate လုပ်ခံရနိုင်ပြီး၊ ဒါက language modeling task အတွက် အသုံးဝင်နိုင်တဲ့ အချက်အလက်တွေ ဆုံးရှုံးစေနိုင်လို့ပါပဲ!
+
+ဒါကြောင့် စတင်ဖို့၊ ကျွန်တော်တို့ corpus ကို ပုံမှန်အတိုင်း tokenize လုပ်ပါမယ်၊ ဒါပေမယ့် tokenizer မှာ `truncation=True` option ကို _မသတ်မှတ်ပါဘူး_။ word IDs တွေ ရနိုင်တယ်ဆိုရင်လည်း (Chapter 6 မှာ ဖော်ပြထားတဲ့အတိုင်း fast tokenizer ကို အသုံးပြုနေရင် ရနိုင်ပါတယ်) အဲဒါတွေကို ယူပါမယ်၊ ဘာလို့လဲဆိုတော့ နောက်ပိုင်းမှာ whole word masking လုပ်ဖို့ လိုအပ်မှာမို့လို့ပါ။ ဒါကို ရိုးရှင်းတဲ့ function တစ်ခုထဲမှာ ထည့်သွင်းပါမယ်၊ ပြီးတော့ `text` နဲ့ `label` columns တွေကို ကျွန်တော်တို့ မလိုအပ်တော့တဲ့အတွက် ဖယ်ရှားလိုက်ပါမယ်။
+
+```python
+def tokenize_function(examples):
+    result = tokenizer(examples["text"])
+    if tokenizer.is_fast:
+        result["word_ids"] = [result.word_ids(i) for i in range(len(result["input_ids"]))]
+    return result
+
+
+# Fast multithreading ကို activate လုပ်ဖို့ batched=True ကို အသုံးပြုပါ။
+tokenized_datasets = imdb_dataset.map(
+    tokenize_function, batched=True, remove_columns=["text", "label"]
+)
+tokenized_datasets
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['attention_mask', 'input_ids', 'word_ids'],
+        num_rows: 25000
+    })
+    test: Dataset({
+        features: ['attention_mask', 'input_ids', 'word_ids'],
+        num_rows: 25000
+    })
+    unsupervised: Dataset({
+        features: ['attention_mask', 'input_ids', 'word_ids'],
+        num_rows: 50000
+    })
+})
+```
+
+DistilBERT က BERT-like model တစ်ခုဖြစ်တဲ့အတွက်၊ encoded texts တွေဟာ အခြားအခန်းတွေမှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့ `input_ids` နဲ့ `attention_mask` တွေအပြင် ကျွန်တော်တို့ ထည့်သွင်းခဲ့တဲ့ `word_ids` တွေ ပါဝင်နေတာကို တွေ့နိုင်ပါတယ်။
+
+ကျွန်တော်တို့ movie reviews တွေကို tokenize လုပ်ပြီးပြီဆိုတော့၊ နောက်တစ်ဆင့်ကတော့ အားလုံးကို အတူတကွ group လုပ်ပြီး ရလဒ်ကို chunks တွေအဖြစ် ခွဲထုတ်တာပါ။ ဒါပေမယ့် ဒီ chunks တွေ ဘယ်လောက်ကြီးသင့်လဲ။ ဒါကို သင်ရရှိနိုင်တဲ့ GPU memory ပမာဏက အဆုံးအဖြတ်ပေးမှာဖြစ်ပေမယ့်၊ ကောင်းမွန်တဲ့ စတင်အမှတ်တစ်ခုက model ရဲ့ maximum context size ကို ကြည့်တာပါပဲ။ ဒါကို tokenizer ရဲ့ `model_max_length` attribute ကို စစ်ဆေးခြင်းဖြင့် ကောက်ချက်ချနိုင်ပါတယ်-
+
+```python
+tokenizer.model_max_length
+```
+
+```python out
+512
+```
+
+ဒီတန်ဖိုးက checkpoint နဲ့ ဆက်စပ်နေတဲ့ *tokenizer_config.json* file ကနေ ဆင်းသက်လာတာပါ။ ဒီကိစ္စမှာ context size ဟာ BERT နဲ့ အတူတူ 512 tokens ဖြစ်တာကို တွေ့နိုင်ပါတယ်။
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** [BigBird](https://huggingface.co/google/bigbird-roberta-base) နဲ့ [Longformer](hf.co/allenai/longformer-base-4096) လို Transformer models အချို့မှာ BERT နဲ့ အခြားအစောပိုင်း Transformer models တွေထက် အများကြီး ပိုရှည်တဲ့ context length ရှိပါတယ်။ ဒီ checkpoints တွေထဲက တစ်ခုအတွက် tokenizer ကို instantiate လုပ်ပြီး `model_max_length` က ၎င်းရဲ့ model card မှာ ဖော်ပြထားတာနဲ့ ကိုက်ညီခြင်းရှိမရှိ စစ်ဆေးပါ။
+
+ဒါကြောင့်၊ Google Colab မှာ တွေ့ရတဲ့ GPU တွေလိုမျိုးပေါ်မှာ ကျွန်တော်တို့ရဲ့ experiments တွေကို run ဖို့အတွက်၊ memory ထဲမှာ ဆံ့ဝင်နိုင်မယ့် နည်းနည်းပိုသေးငယ်တဲ့ အရာတစ်ခုကို ရွေးချယ်ပါမယ်-
+
+```python
+chunk_size = 128
+```
+
+> [!WARNING]
+> သေးငယ်သော chunk size ကို အသုံးပြုခြင်းက လက်တွေ့ကမ္ဘာအခြေအနေများတွင် ဆိုးကျိုးဖြစ်စေနိုင်ကြောင်း သတိပြုပါ၊ ထို့ကြောင့် သင်၏ model ကို အသုံးချမည့် use case နှင့် ကိုက်ညီသော အရွယ်အစားကို အသုံးပြုသင့်ပါသည်။
+
+အခုမှ ပျော်စရာအပိုင်းရောက်ပြီ။ concatenation ဘယ်လိုအလုပ်လုပ်လဲဆိုတာ ပြသဖို့၊ ကျွန်တော်တို့ရဲ့ tokenized training set ကနေ reviews အချို့ကို ယူပြီး review တစ်ခုစီအတွက် tokens အရေအတွက်ကို print ထုတ်ရအောင်-
+
+```python
+# Slicing လုပ်ခြင်းက feature တစ်ခုစီအတွက် list of lists တွေကို ထုတ်ပေးပါတယ်
+tokenized_samples = tokenized_datasets["train"][:3]
+
+for idx, sample in enumerate(tokenized_samples["input_ids"]):
+    print(f"'>>> Review {idx} length: {len(sample)}'")
+```
+
+```python out
+'>>> Review 0 length: 200'
+'>>> Review 1 length: 559'
+'>>> Review 2 length: 192'
+```
+
+ပြီးရင် ဒီ examples တွေအားလုံးကို ရိုးရှင်းတဲ့ dictionary comprehension နဲ့ concatenate လုပ်နိုင်ပါတယ်-
+
+```python
+concatenated_examples = {
+    k: sum(tokenized_samples[k], []) for k in tokenized_samples.keys()
+}
+total_length = len(concatenated_examples["input_ids"])
+print(f"'>>> Concatenated reviews length: {total_length}'")
+```
+
+```python out
+'>>> Concatenated reviews length: 951'
+```
+
+ကောင်းပါပြီ၊ စုစုပေါင်းအရှည် မှန်ကန်ပါတယ် — ဒါဆို အခု concatenated reviews တွေကို `chunk_size` က ပေးထားတဲ့ အရွယ်အစား chunks တွေအဖြစ် ခွဲထုတ်ရအောင်။ ဒါကိုလုပ်ဖို့၊ `concatenated_examples` ထဲက features တွေကို iterate လုပ်ပြီး list comprehension ကို အသုံးပြုကာ feature တစ်ခုစီရဲ့ slices တွေကို ဖန်တီးပါမယ်။ ရလဒ်ကတော့ feature တစ်ခုစီအတွက် chunks dictionary တစ်ခုပါပဲ-
+
+```python
+chunks = {
+    k: [t[i : i + chunk_size] for i in range(0, total_length, chunk_size)]
+    for k, t in concatenated_examples.items()
+}
+
+for chunk in chunks["input_ids"]:
+    print(f"'>>> Chunk length: {len(chunk)}'")
+```
+
+```python out
+'>>> Chunk length: 128'
+'>>> Chunk length: 128'
+'>>> Chunk length: 128'
+'>>> Chunk length: 128'
+'>>> Chunk length: 128'
+'>>> Chunk length: 128'
+'>>> Chunk length: 128'
+'>>> Chunk length: 55'
+```
+
+ဒီဥပမာမှာ သင်တွေ့ရတဲ့အတိုင်း၊ နောက်ဆုံး chunk က အများအားဖြင့် maximum chunk size ထက် သေးငယ်ပါလိမ့်မယ်။ ဒါကို ဖြေရှင်းဖို့ အဓိကနည်းလမ်းနှစ်ခုရှိပါတယ်။
+
+*   နောက်ဆုံး chunk က `chunk_size` ထက် သေးငယ်ရင် ဖယ်ရှားပါ။
+*   နောက်ဆုံး chunk ကို ၎င်း၏အရှည် `chunk_size` နဲ့ တူညီသည်အထိ padding လုပ်ပါ။
+
+ဒီနေရာမှာ ပထမနည်းလမ်းကို ကျွန်တော်တို့ အသုံးပြုပါမယ်၊ ဒါကြောင့် အထက်ပါ logic အားလုံးကို ကျွန်တော်တို့ရဲ့ tokenized datasets တွေပေါ်မှာ အသုံးပြုနိုင်မယ့် function တစ်ခုတည်းမှာ ထည့်သွင်းလိုက်ရအောင်။
+
+```python
+def group_texts(examples):
+    # စာသားများအားလုံးကို concatenate လုပ်ပါ
+    concatenated_examples = {k: sum(examples[k], []) for k in examples.keys()}
+    # concatenate လုပ်ထားသော စာသားများ၏ အရှည်ကို တွက်ချက်ပါ
+    total_length = len(concatenated_examples[list(examples.keys())[0]])
+    # chunk_size ထက် သေးငယ်သော နောက်ဆုံး chunk ကို ဖယ်ရှားပါ
+    total_length = (total_length // chunk_size) * chunk_size
+    # max_len chunks များဖြင့် ပိုင်းခြားပါ
+    result = {
+        k: [t[i : i + chunk_size] for i in range(0, total_length, chunk_size)]
+        for k, t in concatenated_examples.items()
+    }
+    # labels column အသစ်တစ်ခု ဖန်တီးပါ
+    result["labels"] = result["input_ids"].copy()
+    return result
+```
+
+`group_texts()` ရဲ့ နောက်ဆုံးအဆင့်မှာ ကျွန်တော်တို့ဟာ `input_ids` ရဲ့ copy ဖြစ်တဲ့ `labels` column အသစ်တစ်ခုကို ဖန်တီးတာကို သတိပြုပါ။ မကြာခင်မှာ ကျွန်တော်တို့ တွေ့ရမယ့်အတိုင်း၊ masked language modeling မှာ objective က input batch ထဲက ကျပန်း mask လုပ်ထားတဲ့ tokens တွေကို ခန့်မှန်းဖို့ဖြစ်ပြီး၊ `labels` column တစ်ခု ဖန်တီးခြင်းဖြင့် ကျွန်တော်တို့ရဲ့ language model ကို သင်ယူဖို့အတွက် ground truth ကို ပံ့ပိုးပေးပါတယ်။
+
+အခု `group_texts()` ကို ကျွန်တော်တို့ရဲ့ သစ္စာရှိ `Dataset.map()` function ကို အသုံးပြုပြီး tokenized datasets တွေပေါ်မှာ အသုံးပြုရအောင်-
+
+```python
+lm_datasets = tokenized_datasets.map(group_texts, batched=True)
+lm_datasets
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['attention_mask', 'input_ids', 'labels', 'word_ids'],
+        num_rows: 61289
+    })
+    test: Dataset({
+        features: ['attention_mask', 'input_ids', 'labels', 'word_ids'],
+        num_rows: 59905
+    })
+    unsupervised: Dataset({
+        features: ['attention_mask', 'input_ids', 'labels', 'word_ids'],
+        num_rows: 122963
+    })
+})
+```
+
+texts တွေကို group လုပ်ပြီးမှ chunk လုပ်ခြင်းက ကျွန်တော်တို့ရဲ့ မူရင်း `train` နဲ့ `test` splits တွေအတွက် ၂၅,၀၀၀ ထက် ပိုများတဲ့ examples တွေ ထုတ်ပေးခဲ့တာကို သင်တွေ့နိုင်ပါတယ်။ ဒါက မူရင်း corpus ကနေ examples များစွာကို ဖြန့်ကျက်ထားတဲ့ _contiguous tokens_ တွေပါဝင်တဲ့ examples တွေ အခု ကျွန်တော်တို့မှာ ရှိနေလို့ပါပဲ။ chunk တစ်ခုထဲက special `[SEP]` နဲ့ `[CLS]` tokens တွေကို ရှာဖွေခြင်းဖြင့် ဒါကို ရှင်းရှင်းလင်းလင်း မြင်နိုင်ပါတယ်။
+
+```python
+tokenizer.decode(lm_datasets["train"][1]["input_ids"])
+```
+
+```python out
+".... at.......... high. a classic line : inspector : i'm here to sack one of your teachers. student : welcome to bromwell high. i expect that many adults of my age think that bromwell high is far fetched. what a pity that it isn't! [SEP] [CLS] homelessness ( or houselessness as george carlin stated ) has been an issue for years but never a plan to help those on the street that were once considered human who did everything from going to school, work, or vote for the matter. most people think of the homeless"
+```
+
+ဒီဥပမာမှာ high school ရုပ်ရှင်တစ်ခုနဲ့ homelessness အကြောင်း ရုပ်ရှင် reviews နှစ်ခု ထပ်နေတာကို သင်တွေ့နိုင်ပါတယ်။ masked language modeling အတွက် labels တွေက ဘယ်လိုပုံစံရှိလဲဆိုတာလည်း စစ်ဆေးကြည့်ရအောင်။
+
+```python out
+tokenizer.decode(lm_datasets["train"][1]["labels"])
+```
+
+```python out
+".... at.......... high. a classic line : inspector : i'm here to sack one of your teachers. student : welcome to bromwell high. i expect that many adults of my age think that bromwell high is far fetched. what a pity that it isn't! [SEP] [CLS] homelessness ( or houselessness as george carlin stated ) has been an issue for years but never a plan to help those on the street that were once considered human who did everything from going to school, work, or vote for the matter. most people think of the homeless"
+```
+
+ကျွန်တော်တို့ရဲ့ `group_texts()` function ကနေ မျှော်လင့်ထားတဲ့အတိုင်း၊ ဒါက decode လုပ်ထားတဲ့ `input_ids` နဲ့ တူညီနေပါတယ်။ — ဒါပေမယ့် ကျွန်တော်တို့ရဲ့ model က ဘာမှ သင်ယူနိုင်မှာ မဟုတ်ဘူးလား။ ကျွန်တော်တို့ အဓိကအဆင့်တစ်ခု လွဲနေပါတယ်။ input တွေထဲမှာ `[MASK]` tokens တွေကို ကျပန်းနေရာတွေမှာ ထည့်သွင်းရပါမယ်။ fine-tuning လုပ်နေစဉ်မှာ အထူး data collator တစ်ခုကို အသုံးပြုပြီး ဒါကို ဘယ်လိုလုပ်ရမလဲဆိုတာ ကြည့်ရအောင်။
+
+## `Trainer` API ဖြင့် DistilBERT ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-distilbert-with-the-trainer-api]]
+
+masked language model တစ်ခုကို fine-tuning လုပ်တာဟာ [Chapter 3](/course/chapter3) မှာ ကျွန်တော်တို့ လုပ်ခဲ့တဲ့ sequence classification model တစ်ခုကို fine-tuning လုပ်တာနဲ့ လုံးဝနီးပါး တူညီပါတယ်။ တစ်ခုတည်းသော ကွာခြားချက်ကတော့ text အုပ်စုတစ်ခုစီမှာ tokens အချို့ကို ကျပန်း mask လုပ်နိုင်တဲ့ special data collator တစ်ခု လိုအပ်တာပါပဲ။ ကံကောင်းစွာနဲ့ပဲ၊ 🤗 Transformers က ဒီ task အတွက် သီးသန့် `DataCollatorForLanguageModeling` နဲ့အတူ ထွက်ရှိလာပါတယ်။ ကျွန်တော်တို့က tokenizer နဲ့ mask လုပ်မယ့် tokens ရဲ့ အချိုးကို သတ်မှတ်ပေးမယ့် `mlm_probability` argument ကိုပဲ ပေးဖို့လိုပါတယ်။ BERT အတွက် အသုံးပြုခဲ့တဲ့ ပမာဏနဲ့ literature မှာ အသုံးများတဲ့ ၁၅% ကို ရွေးချယ်ပါမယ်။
+
+```python
+from transformers import DataCollatorForLanguageModeling
+
+data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm_probability=0.15)
+```
+
+random masking ဘယ်လိုအလုပ်လုပ်လဲဆိုတာ ကြည့်ဖို့၊ data collator ကို ဥပမာအချို့ ပေးကြည့်ရအောင်။ ၎င်းက `dict` များ၏ list တစ်ခုကို မျှော်လင့်ထားတာကြောင့် (အဲဒီ `dict` တစ်ခုစီက contiguous text တစ်ခုရဲ့ chunk တစ်ခုကို ကိုယ်စားပြုပါတယ်)၊ ကျွန်တော်တို့ဟာ batch ကို collator ကို မပေးပို့ခင် dataset ကို အရင် iterate လုပ်ပါတယ်။ ဒီ data collator အတွက် `"word_ids"` key ကို ဖယ်ရှားလိုက်ပါတယ်၊ ဘာလို့လဲဆိုတော့ ၎င်းက ဒါကို မမျှော်လင့်ထားလို့ပါ။
+
+```python
+samples = [lm_datasets["train"][i] for i in range(2)]
+for sample in samples:
+    _ = sample.pop("word_ids")
+
+for chunk in data_collator(samples)["input_ids"]:
+    print(f"\n'>>> {tokenizer.decode(chunk)}'")
+```
+
+```python output
+'>>> [CLS] bromwell [MASK] is a cartoon comedy. it ran at the same [MASK] as some other [MASK] about school life, [MASK] as " teachers ". [MASK] [MASK] [MASK] in the teaching [MASK] lead [MASK] to believe that bromwell high\'[MASK] satire is much closer to reality than is " teachers ". the scramble [MASK] [MASK] financially, the [MASK]ful students whogn [MASK] right through [MASK] pathetic teachers\'pomp, the pettiness of the whole situation, distinction remind me of the schools i knew and their students. when i saw [MASK] episode in [MASK] a student repeatedly tried to burn down the school, [MASK] immediately recalled. [MASK]...'
+
+'>>> .... at.. [MASK]... [MASK]... high. a classic line plucked inspector : i\'[MASK] here to [MASK] one of your [MASK]. student : welcome to bromwell [MASK]. i expect that many adults of my age think that [MASK]mwell [MASK] is [MASK] fetched. what a pity that it isn\'t! [SEP] [CLS] [MASK]ness ( or [MASK]lessness as george 宇in stated )公 been an issue for years but never [MASK] plan to help those on the street that were once considered human [MASK] did everything from going to school, [MASK], [MASK] vote for the matter. most people think [MASK] the homeless'
+```
+
+ကောင်းပါပြီ၊ အလုပ်ဖြစ်ပါတယ်။ `[MASK]` token ကို ကျွန်တော်တို့ရဲ့ text ထဲမှာ ကျပန်းနေရာအမျိုးမျိုးမှာ ထည့်သွင်းထားတာကို ကျွန်တော်တို့ မြင်နိုင်ပါတယ်။ ဒါတွေက training လုပ်နေစဉ်မှာ ကျွန်တော်တို့ model က ခန့်မှန်းရမယ့် tokens တွေ ဖြစ်ပါလိမ့်မယ် — data collator ရဲ့ ကောင်းကွက်ကတော့ batch တိုင်းမှာ `[MASK]` ထည့်သွင်းမှုကို random လုပ်ပေးမှာပါပဲ!
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** အပေါ်က code snippet ကို အကြိမ်ပေါင်းများစွာ run ပြီး random masking ဘယ်လိုဖြစ်လဲဆိုတာ သင့်မျက်စိနဲ့ မြင်တွေ့ပါ။ `tokenizer.decode()` method ကို `tokenizer.convert_ids_to_tokens()` နဲ့ အစားထိုးပြီး တခါတလေ စကားလုံးတစ်ခုကနေ single token တစ်ခုပဲ mask လုပ်ခံရပြီး တခြား tokens တွေက mask လုပ်မခံရဘူးဆိုတာကို ကြည့်ပါ။
+
+{#if fw === 'pt'}
+
+random masking ရဲ့ ဘေးထွက်ဆိုးကျိုးတစ်ခုကတော့ ကျွန်တော်တို့ရဲ့ evaluation metrics တွေက `Trainer` ကို အသုံးပြုတဲ့အခါ deterministic ဖြစ်မှာ မဟုတ်ပါဘူး။ ဘာလို့လဲဆိုတော့ training နဲ့ test sets တွေအတွက် data collator တူတူကို အသုံးပြုလို့ပါ။ နောက်ပိုင်းမှာ 🤗 Accelerate နဲ့ fine-tuning လုပ်တာကို ကြည့်တဲ့အခါ၊ randomness ကို ဘယ်လို freeze လုပ်နိုင်မလဲဆိုတာကို custom evaluation loop ရဲ့ flexibility ကို အသုံးပြုပြီး ကြည့်ရပါမယ်။
+
+{/if}
+
+masked language modeling အတွက် models တွေကို train လုပ်တဲ့အခါ အသုံးပြုနိုင်တဲ့ နည်းလမ်းတစ်ခုကတော့ တစ်ဦးချင်းစီ tokens တွေကို mask လုပ်ရုံသာမကဘဲ စကားလုံးတစ်ခုလုံးကို အတူတကွ mask လုပ်တာပါ။ ဒီချဉ်းကပ်မှုကို _whole word masking_ လို့ခေါ်ပါတယ်။ whole word masking ကို အသုံးပြုချင်တယ်ဆိုရင်၊ ကျွန်တော်တို့ကိုယ်တိုင် data collator တစ်ခု တည်ဆောက်ဖို့ လိုအပ်ပါလိမ့်မယ်။ data collator ဆိုတာ samples list တစ်ခုကို ယူပြီး batch တစ်ခုအဖြစ် ပြောင်းလဲပေးတဲ့ function တစ်ခုသာ ဖြစ်ပါတယ်။ ဒါကြောင့် အခု ဒါကို လုပ်ဆောင်လိုက်ရအောင်။ ကျွန်တော်တို့ဟာ word indices တွေနဲ့ သက်ဆိုင်ရာ tokens တွေကြား map တစ်ခု ဖန်တီးဖို့အတွက် အရင်က တွက်ချက်ထားတဲ့ word IDs တွေကို အသုံးပြုပါမယ်။ ပြီးရင် ဘယ်စကားလုံးတွေကို mask လုပ်ရမယ်ဆိုတာ ကျပန်းဆုံးဖြတ်ပြီး အဲဒီ mask ကို inputs တွေပေါ်မှာ အသုံးပြုပါမယ်။ labels တွေက mask words တွေနဲ့ ကိုက်ညီတဲ့ အရာတွေကလွဲလို့ အားလုံး `-100` ဖြစ်နေတာကို သတိပြုပါ။
+
+{#if fw === 'pt'}
+
+```py
+import collections
+import numpy as np
+
+from transformers import default_data_collator
+
+wwm_probability = 0.2
+
+
+def whole_word_masking_data_collator(features):
+    for feature in features:
+        word_ids = feature.pop("word_ids")
+
+        # စကားလုံးတွေနဲ့ သက်ဆိုင်ရာ token indices တွေကြား map တစ်ခု ဖန်တီးပါ
+        mapping = collections.defaultdict(list)
+        current_word_index = -1
+        current_word = None
+        for idx, word_id in enumerate(word_ids):
+            if word_id is not None:
+                if word_id != current_word:
+                    current_word = word_id
+                    current_word_index += 1
+                mapping[current_word_index].append(idx)
+
+        # စကားလုံးတွေကို ကျပန်း mask လုပ်ပါ
+        mask = np.random.binomial(1, wwm_probability, (len(mapping),))
+        input_ids = feature["input_ids"]
+        labels = feature["labels"]
+        new_labels = [-100] * len(labels)
+        for word_id in np.where(mask)[0]:
+            word_id = word_id.item()
+            for idx in mapping[word_id]:
+                new_labels[idx] = labels[idx]
+                input_ids[idx] = tokenizer.mask_token_id
+        feature["labels"] = new_labels
+
+    return default_data_collator(features)
+```
+
+{:else}
+
+```py
+import collections
+import numpy as np
+
+from transformers.data.data_collator import tf_default_data_collator
+
+wwm_probability = 0.2
+
+
+def whole_word_masking_data_collator(features):
+    for feature in features:
+        word_ids = feature.pop("word_ids")
+
+        # စကားလုံးတွေနဲ့ သက်ဆိုင်ရာ token indices တွေကြား map တစ်ခု ဖန်တီးပါ
+        mapping = collections.defaultdict(list)
+        current_word_index = -1
+        current_word = None
+        for idx, word_id in enumerate(word_ids):
+            if word_id is not None:
+                if word_id != current_word:
+                    current_word = word_id
+                    current_word_index += 1
+                mapping[current_word_index].append(idx)
+
+        # စကားလုံးတွေကို ကျပန်း mask လုပ်ပါ
+        mask = np.random.binomial(1, wwm_probability, (len(mapping),))
+        input_ids = feature["input_ids"]
+        labels = feature["labels"]
+        new_labels = [-100] * len(labels)
+        for word_id in np.where(mask)[0]:
+            word_id = word_id.item()
+            for idx in mapping[word_id]:
+                new_labels[idx] = labels[idx]
+                input_ids[idx] = tokenizer.mask_token_id
+        feature["labels"] = new_labels
+
+    return tf_default_data_collator(features)
+```
+
+{/if}
+
+နောက်တစ်ခုကတော့ ယခင်ကလိုပဲ တူညီတဲ့ samples တွေပေါ်မှာ စမ်းကြည့်နိုင်ပါတယ်-
+
+```py
+samples = [lm_datasets["train"][i] for i in range(2)]
+batch = whole_word_masking_data_collator(samples)
+
+for chunk in batch["input_ids"]:
+    print(f"\n'>>> {tokenizer.decode(chunk)}'")
+```
+
+```python out
+'>>> [CLS] bromwell high is a cartoon comedy [MASK] it ran at the same time as some other programs about school life, such as " teachers ". my 35 years in the teaching profession lead me to believe that bromwell high\'s satire is much closer to reality than is " teachers ". the scramble to survive financially, the insightful students who can see right through their pathetic teachers\'pomp, the pettiness of the whole situation, all remind me of the schools i knew and their students. when i saw the episode in which a student repeatedly tried to burn down the school, i immediately recalled.....'
+
+'>>> .... [MASK] [MASK] [MASK] [MASK]....... high. a classic line : inspector : i\'m here to sack one of your teachers. student : welcome to bromwell high. i expect that many adults of my age think that bromwell high is far fetched. what a pity that it isn\'t! [SEP] [CLS] homelessness ( or houselessness as george carlin stated ) has been an issue for years but never a plan to help those on the street that were once considered human who did everything from going to school, work, or vote for the matter. most people think of the homeless'
+```
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** အပေါ်က code snippet ကို အကြိမ်ပေါင်းများစွာ run ပြီး random masking ဘယ်လိုဖြစ်လဲဆိုတာ သင့်မျက်စိနဲ့ မြင်တွေ့ပါ။ `tokenizer.decode()` method ကို `tokenizer.convert_ids_to_tokens()` နဲ့ အစားထိုးပြီး စကားလုံးတစ်ခုကနေ tokens တွေဟာ အမြဲတမ်း အတူတကွ mask လုပ်ခံရတယ်ဆိုတာ ကြည့်ပါ။
+
+အခု ကျွန်တော်တို့မှာ data collators နှစ်ခုရှိပြီဆိုတော့၊ ကျန်တဲ့ fine-tuning အဆင့်တွေကတော့ ပုံမှန်အတိုင်းပါပဲ။ ကံကောင်းစွာနဲ့ P100 GPU 😭😭 မရရင် Google Colab မှာ training က အချိန်အတော်ကြာနိုင်တာကြောင့်၊ training set ရဲ့ အရွယ်အစားကို ထောင်ဂဏန်းအနည်းငယ်လောက်အထိ downsample လုပ်ပါမယ်။ စိတ်မပူပါနဲ့၊ ကျွန်တော်တို့ ကောင်းမွန်တဲ့ language model တစ်ခုတော့ ရရှိဦးမှာပါ။ 🤗 Datasets မှာ dataset တစ်ခုကို မြန်မြန်ဆန်ဆန် downsample လုပ်နိုင်တဲ့ နည်းလမ်းတစ်ခုက [Chapter 5](/course/chapter5) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့ `Dataset.train_test_split()` function ကို အသုံးပြုခြင်းပါပဲ။
+
+```python
+train_size = 10_000
+test_size = int(0.1 * train_size)
+
+downsampled_dataset = lm_datasets["train"].train_test_split(
+    train_size=train_size, test_size=test_size, seed=42
+)
+downsampled_dataset
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['attention_mask', 'input_ids', 'labels', 'word_ids'],
+        num_rows: 10000
+    })
+    test: Dataset({
+        features: ['attention_mask', 'input_ids', 'labels', 'word_ids'],
+        num_rows: 1000
+    })
+})
+```
+
+ဒါက အလိုအလျောက် `train` နဲ့ `test` splits အသစ်တွေ ဖန်တီးပေးခဲ့ပြီး၊ training set အရွယ်အစားကို examples ၁၀,၀၀၀ အဖြစ် သတ်မှတ်ထားကာ validation set ကို အဲဒီရဲ့ ၁၀% အဖြစ် သတ်မှတ်ထားပါတယ် — သင့်မှာ အားကောင်းတဲ့ GPU ရှိရင် ဒါကို ပိုတိုးမြှင့်နိုင်ပါတယ်။ နောက်တစ်ခုလုပ်ရမှာက Hugging Face Hub ကို login ဝင်တာပါပဲ။ သင် ဒီ code ကို notebook တစ်ခုထဲမှာ run နေတယ်ဆိုရင်၊ အောက်ပါ utility function နဲ့ လုပ်နိုင်ပါတယ်။
+
+```python
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+ဒါက သင်ရဲ့ credentials တွေ ထည့်သွင်းနိုင်မယ့် widget တစ်ခုကို ပြသပါလိမ့်မယ်။ ဒါမှမဟုတ်၊ သင်အကြိုက်ဆုံး terminal မှာ အောက်ပါအတိုင်း run နိုင်ပါတယ်။
+
+```
+huggingface-cli login
+```
+
+ပြီးတော့ အဲဒီမှာ login ဝင်ပါ။
+
+{#if fw === 'tf'}
+
+ကျွန်တော်တို့ login ဝင်ပြီးတာနဲ့၊ ကျွန်တော်တို့ရဲ့ `tf.data` datasets တွေကို သတ်မှတ်နိုင်ပါတယ်။ ဒါကိုလုပ်ဖို့၊ `prepare_tf_dataset()` method ကို အသုံးပြုပါမယ်။ ဒါက ကျွန်တော်တို့ model ကို အသုံးပြုပြီး dataset ထဲမှာ ဘယ် columns တွေ ပါသင့်လဲဆိုတာကို အလိုအလျောက် ခန့်မှန်းပေးပါတယ်။ ဘယ် columns တွေကို အသုံးပြုမယ်ဆိုတာကို တိတိကျကျ ထိန်းချုပ်ချင်တယ်ဆိုရင် `Dataset.to_tf_dataset()` method ကို အစားထိုးအသုံးပြုနိုင်ပါတယ်။ အရာရာကို ရိုးရှင်းစေဖို့၊ ဒီနေရာမှာ standard data collator ကိုပဲ အသုံးပြုပါမယ်၊ ဒါပေမယ့် whole word masking collator ကို စမ်းပြီး ရလဒ်တွေကို နှိုင်းယှဉ်နိုင်ပါတယ်။
+
+```python
+tf_train_dataset = model.prepare_tf_dataset(
+    downsampled_dataset["train"],
+    collate_fn=data_collator,
+    shuffle=True,
+    batch_size=32,
+)
+
+tf_eval_dataset = model.prepare_tf_dataset(
+    downsampled_dataset["test"],
+    collate_fn=data_collator,
+    shuffle=False,
+    batch_size=32,
+)
+```
+
+နောက်တစ်ခုကတော့ training hyperparameters တွေကို သတ်မှတ်ပြီး model ကို compile လုပ်တာပါ။ ကျွန်တော်တို့က 🤗 Transformers library ကနေ `create_optimizer()` function ကို အသုံးပြုပါတယ်။ ဒါက linear learning rate decay ပါဝင်တဲ့ `AdamW` optimizer ကို ပေးပါတယ်။ model ရဲ့ built-in loss ကိုလည်း အသုံးပြုပါတယ်၊ ဒါက `compile()` ကို argument အဖြစ် loss မသတ်မှတ်ထားတဲ့အခါ default ပါပဲ၊ ပြီးတော့ training precision ကို `"mixed_float16"` လို့ သတ်မှတ်ပါတယ်။ သင် Colab GPU ဒါမှမဟုတ် accelerated float16 support မရှိတဲ့ တခြား GPU ကို အသုံးပြုနေတယ်ဆိုရင် အဲဒီ line ကို comment လုပ်ထားသင့်ပါတယ်။
+
+ဒါ့အပြင်၊ epoch တစ်ခုစီတိုင်းမှာ model ကို Hub ကို save လုပ်မယ့် `PushToHubCallback` တစ်ခုကိုလည်း တည်ဆောက်ပါတယ်။ သင် push လုပ်ချင်တဲ့ repository နာမည်ကို `hub_model_id` argument နဲ့ သတ်မှတ်နိုင်ပါတယ် (အထူးသဖြင့် organization တစ်ခုကို push လုပ်ဖို့ ဒီ argument ကို အသုံးပြုရပါလိမ့်မယ်)။ ဥပမာ၊ model ကို [`huggingface-course` organization](https://huggingface.co/huggingface-course) ကို push လုပ်ဖို့အတွက်၊ ကျွန်တော်တို့ `hub_model_id="huggingface-course/distilbert-finetuned-imdb"` ကို ထည့်သွင်းခဲ့ပါတယ်။ default အားဖြင့်၊ အသုံးပြုတဲ့ repository က သင့် namespace ထဲမှာရှိပြီး သင်သတ်မှတ်ထားတဲ့ output directory အမည်အတိုင်း ဖြစ်ပါလိမ့်မယ်၊ ဒါကြောင့် ကျွန်တော်တို့ ကိစ္စမှာတော့ `"lewtun/distilbert-finetuned-imdb"` ဖြစ်ပါလိမ့်မယ်။
+
+```python
+from transformers import create_optimizer
+from transformers.keras_callbacks import PushToHubCallback
+import tensorflow as tf
+
+num_train_steps = len(tf_train_dataset)
+optimizer, schedule = create_optimizer(
+    init_lr=2e-5,
+    num_warmup_steps=1_000,
+    num_train_steps=num_train_steps,
+    weight_decay_rate=0.01,
+)
+model.compile(optimizer=optimizer)
+
+# mixed-precision float16 ဖြင့် train လုပ်ပါ။
+tf.keras.mixed_precision.set_global_policy("mixed_float16")
+
+model_name = model_checkpoint.split("/")[-1]
+callback = PushToHubCallback(
+    output_dir=f"{model_name}-finetuned-imdb", tokenizer=tokenizer
+)
+```
+
+ကျွန်တော်တို့ အခု `model.fit()` ကို run ဖို့ အဆင်သင့်ပါပြီ။ ဒါပေမယ့် ဒါကို မလုပ်ခင်၊ language models တွေရဲ့ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ဖို့ အသုံးများတဲ့ metric တစ်ခုဖြစ်တဲ့ _perplexity_ အကြောင်း အတိုချုံး ကြည့်ရအောင်။
+
+{:else}
+
+ကျွန်တော်တို့ login ဝင်ပြီးတာနဲ့၊ `Trainer` အတွက် arguments တွေကို သတ်မှတ်နိုင်ပါတယ်။
+
+```python
+from transformers import TrainingArguments
+
+batch_size = 64
+# epoch တိုင်းမှာ training loss ကို ပြသပါ
+logging_steps = len(downsampled_dataset["train"]) // batch_size
+model_name = model_checkpoint.split("/")[-1]
+
+training_args = TrainingArguments(
+    output_dir=f"{model_name}-finetuned-imdb",
+    overwrite_output_dir=True,
+    evaluation_strategy="epoch",
+    learning_rate=2e-5,
+    weight_decay=0.01,
+    per_device_train_batch_size=batch_size,
+    per_device_eval_batch_size=batch_size,
+    push_to_hub=True,
+    fp16=True,
+    logging_steps=logging_steps,
+)
+```
+
+ဒီနေရာမှာ ကျွန်တော်တို့ဟာ default options အချို့ကို ပြောင်းလဲခဲ့ပါတယ်၊ `logging_steps` အပါအဝင် ဒါက epoch တိုင်းမှာ training loss ကို ခြေရာခံဖို့ သေချာစေပါတယ်။ mixed-precision training ကို ဖွင့်ဖို့ `fp16=True` ကိုလည်း အသုံးပြုခဲ့ပါတယ်၊ ဒါက ကျွန်တော်တို့ကို speed ကို ထပ်တိုးပေးပါတယ်။ default အားဖြင့်၊ `Trainer` က model ရဲ့ `forward()` method ရဲ့ အစိတ်အပိုင်းမဟုတ်တဲ့ columns တွေကို ဖယ်ရှားပါလိမ့်မယ်။ ဒါက whole word masking collator ကို အသုံးပြုနေတယ်ဆိုရင်၊ training လုပ်နေစဉ် `word_ids` column ကို မဆုံးရှုံးစေဖို့ `remove_unused_columns=False` ကိုလည်း သတ်မှတ်ဖို့ လိုအပ်တယ်လို့ ဆိုလိုတာပါ။
+
+သင် push လုပ်ချင်တဲ့ repository နာမည်ကို `hub_model_id` argument နဲ့ သတ်မှတ်နိုင်တာကို သတိပြုပါ (အထူးသဖြင့် organization တစ်ခုကို push လုပ်ဖို့ ဒီ argument ကို အသုံးပြုရပါလိမ့်မယ်)။ ဥပမာ၊ ကျွန်တော်တို့ model ကို [`huggingface-course` organization](https://huggingface.co/huggingface-course) ကို push လုပ်တဲ့အခါ၊ `TrainingArguments` မှာ `hub_model_id="huggingface-course/distilbert-finetuned-imdb"` ကို ထည့်သွင်းခဲ့ပါတယ်။ default အားဖြင့်၊ အသုံးပြုတဲ့ repository က သင့် namespace ထဲမှာရှိပြီး သင်သတ်မှတ်ထားတဲ့ output directory အမည်အတိုင်း ဖြစ်ပါလိမ့်မယ်၊ ဒါကြောင့် ကျွန်တော်တို့ ကိစ္စမှာတော့ `"lewtun/distilbert-finetuned-imdb"` ဖြစ်ပါလိမ့်မယ်။
+
+အခု `Trainer` ကို instantiate လုပ်ဖို့ အရာအားလုံး အသင့်ပါပဲ။ ဒီနေရာမှာ standard `data_collator` ကိုပဲ အသုံးပြုပါမယ်၊ ဒါပေမယ့် whole word masking collator ကို စမ်းပြီး ရလဒ်တွေကို နှိုင်းယှဉ်နိုင်ပါတယ်။
+
+```python
+from transformers import Trainer
+
+trainer = Trainer(
+    model=model,
+    args=training_args,
+    train_dataset=downsampled_dataset["train"],
+    eval_dataset=downsampled_dataset["test"],
+    data_collator=data_collator,
+    tokenizer=tokenizer,
+)
+```
+
+ကျွန်တော်တို့ အခု `trainer.train()` ကို run ဖို့ အဆင်သင့်ပါပြီ — ဒါပေမယ့် ဒါကို မလုပ်ခင်၊ language models တွေရဲ့ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ဖို့ အသုံးများတဲ့ metric တစ်ခုဖြစ်တဲ့ _perplexity_ အကြောင်း အတိုချုံး ကြည့်ရအောင်။
+
+{/if}
+
+### Language Models များအတွက် Perplexity[[perplexity-for-language-models]]
+
+<Youtube id="NURcDHhYe98"/>
+
+text classification ဒါမှမဟုတ် question answering လို အခြား tasks တွေနဲ့မတူဘဲ (အဲဒီ tasks တွေမှာ training လုပ်ဖို့ labeled corpus တစ်ခု ပေးထားပါတယ်)၊ language modeling မှာတော့ ကျွန်တော်တို့မှာ explicit labels တွေ မရှိပါဘူး။ ဒါဆို ဘယ်အရာက ကောင်းမွန်တဲ့ language model တစ်ခုကို ဖြစ်စေသလဲဆိုတာ ဘယ်လို ဆုံးဖြတ်မလဲ။ သင့်ဖုန်းထဲက autocorrect feature လိုပဲ၊ ကောင်းမွန်တဲ့ language model ဆိုတာ သဒ္ဒါမှန်ကန်တဲ့ စာကြောင်းတွေကို မြင့်မားတဲ့ probabilities တွေ သတ်မှတ်ပေးပြီး၊ အဓိပ္ပာယ်မရှိတဲ့ စာကြောင်းတွေကို နိမ့်ကျတဲ့ probabilities တွေ သတ်မှတ်ပေးတဲ့ model တစ်ခုပါပဲ။ ဒါက ဘယ်လိုပုံစံရှိလဲဆိုတာ ပိုကောင်းကောင်း သိရအောင်၊ အွန်လိုင်းမှာ "autocorrect fails" တွေ အများကြီး တွေ့နိုင်ပါတယ်။ အဲဒီမှာ လူတစ်ယောက်ရဲ့ ဖုန်းထဲက model က ရယ်စရာကောင်းပြီး (မကြာခဏ မသင့်လျော်တဲ့) ဖြည့်စွက်မှုတွေကို ထုတ်လုပ်ပေးခဲ့တာပါ။
+
+{#if fw === 'pt'}
+
+ကျွန်တော်တို့ရဲ့ test set မှာ သဒ္ဒါမှန်ကန်တဲ့ စာကြောင်းတွေ အများစု ပါဝင်တယ်လို့ ယူဆရင်၊ ကျွန်တော်တို့ရဲ့ language model ရဲ့ အရည်အသွေးကို တိုင်းတာတဲ့ နည်းလမ်းတစ်ခုကတော့ test set ထဲက စာကြောင်းအားလုံးရဲ့ နောက်လာမယ့် စကားလုံးအတွက် model က သတ်မှတ်ပေးတဲ့ probabilities တွေကို တွက်ချက်တာပါပဲ။ မြင့်မားတဲ့ probabilities တွေက model ဟာ မမြင်ဖူးသေးတဲ့ examples တွေကြောင့် "အံ့သြ" ခြင်း ဒါမှမဟုတ် "တွေဝေ" ခြင်း မဖြစ်ဘူးဆိုတာကို ပြသပြီး၊ language ထဲက grammar ရဲ့ အခြေခံ patterns တွေကို သင်ယူပြီးပြီဆိုတာကို အကြံပြုပါတယ်။ perplexity ရဲ့ သင်္ချာဆိုင်ရာ အဓိပ္ပာယ်ဖွင့်ဆိုချက်အမျိုးမျိုး ရှိပေမယ့်၊ ကျွန်တော်တို့ အသုံးပြုမယ့် တစ်ခုကတော့ cross-entropy loss ရဲ့ exponential အဖြစ် သတ်မှတ်ထားပါတယ်။ ဒါကြောင့်၊ ကျွန်တော်တို့ရဲ့ pretrained model ရဲ့ perplexity ကို `Trainer.evaluate()` function ကို အသုံးပြုပြီး test set ပေါ်က cross-entropy loss ကို တွက်ချက်ကာ ရလဒ်ရဲ့ exponential ကို ယူခြင်းဖြင့် တွက်ချက်နိုင်ပါတယ်။
+
+```python
+import math
+
+eval_results = trainer.evaluate()
+print(f">>> Perplexity: {math.exp(eval_results['eval_loss']):.2f}")
+```
+
+{:else}
+
+ကျွန်တော်တို့ရဲ့ test set မှာ သဒ္ဒါမှန်ကန်တဲ့ စာကြောင်းတွေ အများစု ပါဝင်တယ်လို့ ယူဆရင်၊ ကျွန်တော်တို့ရဲ့ language model ရဲ့ အရည်အသွေးကို တိုင်းတာတဲ့ နည်းလမ်းတစ်ခုကတော့ test set ထဲက စာကြောင်းအားလုံးရဲ့ နောက်လာမယ့် စကားလုံးအတွက် model က သတ်မှတ်ပေးတဲ့ probabilities တွေကို တွက်ချက်တာပါပဲ။ မြင့်မားတဲ့ probabilities တွေက model ဟာ မမြင်ဖူးသေးတဲ့ examples တွေကြောင့် "အံ့သြ" ခြင်း ဒါမှမဟုတ် "တွေဝေ" ခြင်း မဖြစ်ဘူးဆိုတာကို ပြသပြီး၊ language ထဲက grammar ရဲ့ အခြေခံ patterns တွေကို သင်ယူပြီးပြီဆိုတာကို အကြံပြုပါတယ်။ perplexity ရဲ့ သင်္ချာဆိုင်ရာ အဓိပ္ပာယ်ဖွင့်ဆိုချက်အမျိုးမျိုး ရှိပေမယ့်၊ ကျွန်တော်တို့ အသုံးပြုမယ့် တစ်ခုကတော့ cross-entropy loss ရဲ့ exponential အဖြစ် သတ်မှတ်ထားပါတယ်။ ဒါကြောင့်၊ ကျွန်တော်တို့ရဲ့ pretrained model ရဲ့ perplexity ကို `model.evaluate()` method ကို အသုံးပြုပြီး test set ပေါ်က cross-entropy loss ကို တွက်ချက်ကာ ရလဒ်ရဲ့ exponential ကို ယူခြင်းဖြင့် တွက်ချက်နိုင်ပါတယ်။
+
+```python
+import math
+
+eval_loss = model.evaluate(tf_eval_dataset)
+print(f"Perplexity: {math.exp(eval_loss):.2f}")
+```
+
+{/if}
+
+```python out
+>>> Perplexity: 21.75
+```
+
+Perplexity score နိမ့်လေ၊ language model ပိုကောင်းလေပါပဲ။ ဒီနေရာမှာ ကျွန်တော်တို့ရဲ့ စတင်တဲ့ model မှာ အတော်လေး မြင့်မားတဲ့ တန်ဖိုးရှိတာကို တွေ့နိုင်ပါတယ်။ fine-tuning လုပ်ခြင်းဖြင့် ဒါကို လျှော့ချနိုင်မလား ကြည့်ရအောင်။ ဒါကို လုပ်ဖို့၊ ပထမဆုံး training loop ကို run ပါ။
+
+{#if fw === 'pt'}
+
+```python
+trainer.train()
+```
+
+{:else}
+
+```python
+model.fit(tf_train_dataset, validation_data=tf_eval_dataset, callbacks=[callback])
+```
+
+{/if}
+
+ပြီးရင် ယခင်ကအတိုင်း test set ပေါ်က ရလဒ် perplexity ကို တွက်ချက်ပါ။
+
+{#if fw === 'pt'}
+
+```python
+eval_results = trainer.evaluate()
+print(f">>> Perplexity: {math.exp(eval_results['eval_loss']):.2f}")
+```
+
+{:else}
+
+```python
+eval_loss = model.evaluate(tf_eval_dataset)
+print(f"Perplexity: {math.exp(eval_loss):.2f}")
+```
+
+{/if}
+
+```python out
+>>> Perplexity: 11.32
+```
+
+ကောင်းပါပြီ — ဒါက perplexity မှာ အတော်လေး လျှော့ချနိုင်ခဲ့တာဖြစ်ပြီး၊ model က movie reviews domain အကြောင်း တစ်ခုခု သင်ယူခဲ့ပြီးပြီဆိုတာ ပြောပြနေတာပါပဲ!
+
+{#if fw === 'pt'}
+
+training ပြီးသွားတာနဲ့၊ training information ပါတဲ့ model card ကို Hub ကို push လုပ်နိုင်ပါတယ် (checkpoints တွေကို training လုပ်နေစဉ်မှာပဲ save လုပ်ပါတယ်)။
+
+```python
+trainer.push_to_hub()
+```
+
+{/if}
+
+> [!TIP]
+> ✏️ **သင့်အလှည့်ပါ!** data collator ကို whole word masking collator သို့ ပြောင်းလဲပြီး အထက်ပါ training ကို run ပါ။ ပိုကောင်းတဲ့ ရလဒ်တွေ ရပါသလား။
+
+{#if fw === 'pt'}
+
+ကျွန်တော်တို့ရဲ့ use case မှာ training loop နဲ့ ပတ်သက်ပြီး ထူးခြားတဲ့ အရာတစ်ခုခု လုပ်ဖို့ မလိုအပ်ခဲ့ပါဘူး၊ ဒါပေမယ့် တချို့ကိစ္စတွေမှာတော့ custom logic အချို့ကို implement လုပ်ဖို့ လိုအပ်နိုင်ပါတယ်။ ဒီ applications တွေအတွက် 🤗 Accelerate ကို အသုံးပြုနိုင်ပါတယ် — ကြည့်ရအောင်!
+
+## 🤗 Accelerate ဖြင့် DistilBERT ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-distilbert-with-accelerate]]
+
+`Trainer` နဲ့ တွေ့ခဲ့ရတဲ့အတိုင်း၊ masked language model တစ်ခုကို fine-tuning လုပ်တာဟာ [Chapter 3](/course/chapter3) က text classification ဥပမာနဲ့ အလွန်ဆင်တူပါတယ်။ တကယ်တော့၊ တစ်ခုတည်းသော အသေးစိတ်အချက်ကတော့ special data collator ကို အသုံးပြုတာဖြစ်ပြီး၊ ဒါကို ဒီအပိုင်းရဲ့ အစောပိုင်းမှာ ကျွန်တော်တို့ ဖော်ပြခဲ့ပြီးပါပြီ!
+
+သို့သော်လည်း၊ `DataCollatorForLanguageModeling` က evaluation တစ်ခုစီနဲ့ random masking ကို အသုံးပြုတယ်ဆိုတာ ကျွန်တော်တို့ တွေ့ခဲ့ရပါတယ်၊ ဒါကြောင့် ကျွန်တော်တို့ရဲ့ perplexity scores တွေမှာ training run တစ်ခုစီနဲ့ အတူ အပြောင်းအလဲအချို့ တွေ့ရမှာပါ။ randomness ရဲ့ ဒီအရင်းအမြစ်ကို ဖယ်ရှားဖို့ နည်းလမ်းတစ်ခုကတော့ test set တစ်ခုလုံးပေါ်မှာ masking ကို _တစ်ကြိမ်_ အသုံးပြုပြီး၊ ပြီးရင် evaluation လုပ်နေစဉ် batches တွေကို စုစည်းဖို့ 🤗 Transformers က default data collator ကို အသုံးပြုတာပါပဲ။ ဒါဘယ်လိုအလုပ်လုပ်လဲဆိုတာ မြင်ရအောင်၊ `DataCollatorForLanguageModeling` နဲ့ ပထမဆုံးတွေ့ဆုံခဲ့တာနဲ့ ဆင်တူတဲ့ batch ပေါ်မှာ masking ကို အသုံးပြုတဲ့ ရိုးရှင်းတဲ့ function တစ်ခုကို implement လုပ်ရအောင်။
+
+```python
+def insert_random_mask(batch):
+    features = [dict(zip(batch, t)) for t in zip(*batch.values())]
+    masked_inputs = data_collator(features)
+    # dataset ထဲက column တစ်ခုစီအတွက် "masked_" prefix ပါတဲ့ column အသစ်တစ်ခု ဖန်တီးပါ
+    return {"masked_" + k: v.numpy() for k, v in masked_inputs.items()}
+```
+
+နောက်တစ်ခုကတော့ ဒီ function ကို ကျွန်တော်တို့ test set ပေါ်မှာ အသုံးပြုပြီး unmasked columns တွေကို ဖယ်ရှားကာ masked columns တွေနဲ့ အစားထိုးပါမယ်။ အထက်ပါ `data_collator` ကို သင့်လျော်တဲ့ တစ်ခုနဲ့ အစားထိုးခြင်းဖြင့် whole word masking ကို အသုံးပြုနိုင်ပါတယ်၊ ဒီကိစ္စမှာ ပထမဆုံး line ကို ဒီနေရာမှာ ဖယ်ရှားသင့်ပါတယ်။
+
+```py
+downsampled_dataset = downsampled_dataset.remove_columns(["word_ids"])
+eval_dataset = downsampled_dataset["test"].map(
+    insert_random_mask,
+    batched=True,
+    remove_columns=downsampled_dataset["test"].column_names,
+)
+eval_dataset = eval_dataset.rename_columns(
+    {
+        "masked_input_ids": "input_ids",
+        "masked_attention_mask": "attention_mask",
+        "masked_labels": "labels",
+    }
+)
+```
+
+ပြီးရင် dataloaders တွေကို ပုံမှန်အတိုင်း တည်ဆောက်နိုင်ပါတယ်၊ ဒါပေမယ့် evaluation set အတွက် 🤗 Transformers က `default_data_collator` ကို အသုံးပြုပါမယ်။
+
+```python
+from torch.utils.data import DataLoader
+from transformers import default_data_collator
+
+batch_size = 64
+train_dataloader = DataLoader(
+    downsampled_dataset["train"],
+    shuffle=True,
+    batch_size=batch_size,
+    collate_fn=data_collator,
+)
+eval_dataloader = DataLoader(
+    eval_dataset, batch_size=batch_size, collate_fn=default_data_collator
+)
+```
+
+ဒီနေရာကစပြီး 🤗 Accelerate နဲ့ standard steps တွေကို လိုက်နာရပါမယ်။ ပထမဆုံးလုပ်ရမှာက pretrained model ရဲ့ အသစ် version တစ်ခုကို load လုပ်တာပါပဲ။
+
+```
+model = AutoModelForMaskedLM.from_pretrained(model_checkpoint)
+```
+
+ပြီးရင် optimizer ကို သတ်မှတ်ဖို့ လိုအပ်ပါတယ်၊ standard `AdamW` ကို အသုံးပြုပါမယ်။
+
+```python
+from torch.optim import AdamW
+
+optimizer = AdamW(model.parameters(), lr=5e-5)
+```
+
+ဒီ objects တွေနဲ့၊ `Accelerator` object နဲ့ training အတွက် အရာအားလုံးကို အခု ကျွန်တော်တို့ ပြင်ဆင်နိုင်ပါပြီ။
+
+```python
+from accelerate import Accelerator
+
+accelerator = Accelerator()
+model, optimizer, train_dataloader, eval_dataloader = accelerator.prepare(
+    model, optimizer, train_dataloader, eval_dataloader
+)
+```
+
+ကျွန်တော်တို့ရဲ့ model, optimizer, နဲ့ dataloaders တွေ configure လုပ်ပြီးပြီဆိုတော့၊ learning rate scheduler ကို အောက်ပါအတိုင်း သတ်မှတ်နိုင်ပါတယ်။
+
+```python
+from transformers import get_scheduler
+
+num_train_epochs = 3
+num_update_steps_per_epoch = len(train_dataloader)
+num_training_steps = num_train_epochs * num_update_steps_per_epoch
+
+lr_scheduler = get_scheduler(
+    "linear",
+    optimizer=optimizer,
+    num_warmup_steps=0,
+    num_training_steps=num_training_steps,
+)
+```
+
+training မလုပ်ခင် နောက်ဆုံးလုပ်စရာတစ်ခုပဲ ရှိပါတယ်။ Hugging Face Hub ပေါ်မှာ model repository တစ်ခု ဖန်တီးတာပါ။ Hugging Face Hub library ကို အသုံးပြုပြီး ကျွန်တော်တို့ရဲ့ repo ရဲ့ နာမည်အပြည့်အစုံကို အရင်ဆုံး generate လုပ်နိုင်ပါတယ်။
+
+```python
+from huggingface_hub import get_full_repo_name
+
+model_name = "distilbert-base-uncased-finetuned-imdb-accelerate"
+repo_name = get_full_repo_name(model_name)
+repo_name
+```
+
+```python out
+'lewtun/distilbert-base-uncased-finetuned-imdb-accelerate'
+```
+
+ပြီးရင် 🤗 Hub က `Repository` class ကို အသုံးပြုပြီး repository ကို ဖန်တီးပြီး clone လုပ်ပါ။
+
+```python
+from huggingface_hub import Repository
+
+output_dir = model_name
+repo = Repository(output_dir, clone_from=repo_name)
+```
+
+ဒါတွေ လုပ်ဆောင်ပြီးပြီဆိုတာနဲ့၊ training နဲ့ evaluation loop အပြည့်အစုံကို ရေးရုံပါပဲ။
+
+```python
+from tqdm.auto import tqdm
+import torch
+import math
+
+progress_bar = tqdm(range(num_training_steps))
+
+for epoch in range(num_train_epochs):
+    # Training
+    model.train()
+    for batch in train_dataloader:
+        outputs = model(**batch)
+        loss = outputs.loss
+        accelerator.backward(loss)
+
+        optimizer.step()
+        lr_scheduler.step()
+        optimizer.zero_grad()
+        progress_bar.update(1)
+
+    # Evaluation
+    model.eval()
+    losses = []
+    for step, batch in enumerate(eval_dataloader):
+        with torch.no_grad():
+            outputs = model(**batch)
+
+        loss = outputs.loss
+        losses.append(accelerator.gather(loss.repeat(batch_size)))
+
+    losses = torch.cat(losses)
+    losses = losses[: len(eval_dataset)]
+    try:
+        perplexity = math.exp(torch.mean(losses))
+    except OverflowError:
+        perplexity = float("inf")
+
+    print(f">>> Epoch {epoch}: Perplexity: {perplexity}")
+
+    # Save and upload
+    accelerator.wait_for_everyone()
+    unwrapped_model = accelerator.unwrap_model(model)
+    unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)
+    if accelerator.is_main_process:
+        tokenizer.save_pretrained(output_dir)
+        repo.push_to_hub(
+            commit_message=f"Training in progress epoch {epoch}", blocking=False
+        )
+```
+
+```python out
+>>> Epoch 0: Perplexity: 11.397545307900472
+>>> Epoch 1: Perplexity: 10.904909330983092
+>>> Epoch 2: Perplexity: 10.729503505340409
+```
+
+ကောင်းပါပြီ၊ epoch တိုင်းမှာ perplexity ကို အကဲဖြတ်နိုင်ခဲ့ပြီး multiple training runs တွေ reproducible ဖြစ်အောင် သေချာစေခဲ့ပါတယ်။
+
+{/if}
+
+## ကျွန်တော်တို့ရဲ့ Fine-tuned Model ကို အသုံးပြုခြင်း[[using-our-fine-tuned-model]]
+
+သင်ရဲ့ fine-tuned model နဲ့ Hub ပေါ်က ၎င်းရဲ့ widget ကို အသုံးပြုခြင်းဖြင့် ဒါမှမဟုတ် 🤗 Transformers က `pipeline` နဲ့ locally အသုံးပြုခြင်းဖြင့် အပြန်အလှန်ဆက်သွယ်နိုင်ပါတယ်။ `fill-mask` pipeline ကို အသုံးပြုပြီး ကျွန်တော်တို့ရဲ့ model ကို download လုပ်ဖို့ နောက်ဆုံးနည်းလမ်းကို အသုံးပြုရအောင်။
+
+```python
+from transformers import pipeline
+
+mask_filler = pipeline(
+    "fill-mask", model="huggingface-course/distilbert-base-uncased-finetuned-imdb"
+)
+```
+
+ပြီးရင် pipeline ကို ကျွန်တော်တို့ရဲ့ sample text ဖြစ်တဲ့ "This is a great [MASK]" ကို ပေးပို့ပြီး ထိပ်တန်း ၅ ခုသော predictions တွေက ဘာတွေလဲဆိုတာ ကြည့်နိုင်ပါတယ်။
+
+```python
+preds = mask_filler(text)
+
+for pred in preds:
+    print(f">>> {pred['sequence']}")
+```
+
+```python out
+'>>> this is a great movie.'
+'>>> this is a great film.'
+'>>> this is a great story.'
+'>>> this is a great movies.'
+'>>> this is a great character.'
+```
+
+ကောင်းပါပြီ။ ကျွန်တော်တို့ model က movie တွေနဲ့ ပိုမိုဆက်စပ်နေတဲ့ စကားလုံးတွေကို ခန့်မှန်းဖို့ ၎င်းရဲ့ weights တွေကို ရှင်းရှင်းလင်းလင်း လိုက်လျောညီထွေဖြစ်အောင် လုပ်ခဲ့တာကို တွေ့နိုင်ပါတယ်။
+
+<Youtube id="0Oxphw4Q9fo"/>
+
+ဒါက language model တစ်ခုကို train လုပ်ခြင်းနဲ့ ပတ်သက်တဲ့ ကျွန်တော်တို့ရဲ့ ပထမဆုံး experiment ကို နိဂုံးချုပ်လိုက်ပါပြီ။ [section 6](/course/en/chapter7/6) မှာ GPT-2 လို auto-regressive model တစ်ခုကို အစကနေ ဘယ်လို train လုပ်ရမယ်ဆိုတာ သင်ယူရမှာပါ၊ သင့်ကိုယ်ပိုင် Transformer model ကို ဘယ်လို pretrain လုပ်နိုင်မလဲဆိုတာ ကြည့်ချင်တယ်ဆိုရင် အဲဒီကို သွားပါ။
+
+> [!TIP]
+> ✏️ **သင့်အလှည့်ပါ!** data collator ကို whole word masking collator သို့ ပြောင်းလဲပြီးနောက် အထက်ပါ training ကို run ပါ။ pretrained နဲ့ fine-tuned DistilBERT checkpoints နှစ်ခုလုံးအတွက် IMDb labels တွေပေါ်မှာ classifier တစ်ခုကို fine-tune လုပ်ခြင်းဖြင့် domain adaptation ရဲ့ အကျိုးကျေးဇူးတွေကို quantification လုပ်ကြည့်ပါ။ text classification အကြောင်း ပြန်လည်လေ့လာဖို့ လိုအပ်ရင် [Chapter 3](/course/chapter3) ကို ကြည့်ပါ။
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **Masked Language Model (MLM)**: စာကြောင်းတစ်ခုထဲမှ စကားလုံးအချို့ကို ဝှက်ထားပြီး ၎င်းတို့ကို ခန့်မှန်းစေခြင်းဖြင့် model ကို လေ့ကျင့်သော task (BERT ကဲ့သို့)။
+*   **Fine-tuning**: ကြိုတင်လေ့ကျင့်ထားပြီးသား (pre-trained) မော်ဒယ်တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (specific task) အတွက် အနည်းငယ်သော ဒေတာနဲ့ ထပ်မံလေ့ကျင့်ပေးခြင်းကို ဆိုလိုပါတယ်။
+*   **Transformer Models**: Natural Language Processing (NLP) မှာ အောင်မြင်မှုများစွာရရှိခဲ့တဲ့ deep learning architecture တစ်မျိုးပါ။
+*   **Pretrained Model**: အကြီးစား ဒေတာအမြောက်အမြားဖြင့် ကြိုတင်လေ့ကျင့်ထားပြီးဖြစ်သော AI (Artificial Intelligence) မော်ဒယ်။
+*   **Hugging Face Hub**: AI မော်ဒယ်တွေ၊ datasets တွေနဲ့ demo တွေကို အခြားသူတွေနဲ့ မျှဝေဖို့၊ ရှာဖွေဖို့နဲ့ ပြန်လည်အသုံးပြုဖို့အတွက် အွန်လိုင်း platform တစ်ခု ဖြစ်ပါတယ်။
+*   **Downstream Performance**: Model တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (downstream task) ပေါ်တွင် fine-tune လုပ်ပြီးနောက် ရရှိသော စွမ်းဆောင်ရည်။
+*   **Corpus**: စာသား (သို့မဟုတ် အခြားဒေတာ) အစုအဝေးကြီးတစ်ခု။
+*   **Transfer Learning**: ကြိုတင်လေ့ကျင့်ထားသော model ၏ ဗဟုသုတကို အခြားဆက်စပ် task သို့ လွှဲပြောင်းအသုံးပြုခြင်း။
+*   **Language Models**: လူသားဘာသာစကား၏ ဖြန့်ဝေမှုကို နားလည်ရန် လေ့ကျင့်ထားသော AI မော်ဒယ်တစ်ခု။
+*   **Task-specific Head**: Transformer မော်ဒယ်၏ အဓိကကိုယ်ထည် (body) အပေါ်တွင် ထည့်သွင်းထားသော အပိုအစိတ်အပိုင်း (layer တစ်ခု သို့မဟုတ် နှစ်ခု) ဖြစ်ပြီး သီးခြားလုပ်ငန်း (task) တစ်ခုအတွက် မော်ဒယ်၏ output များကို ချိန်ညှိပေးသည်။
+*   **Legal Contracts**: ဥပဒေရေးရာ စာချုပ်များ။
+*   **Scientific Articles**: သိပ္ပံနည်းကျ ဆောင်းပါးများ။
+*   **Vanilla Transformer Model**: အထူးပြုပြင်မွမ်းမံမှုများမရှိသော အခြေခံ Transformer model။
+*   **BERT (Bidirectional Encoder Representations from Transformers)**: Google မှ တီထွင်ခဲ့သော Transformer-based language model တစ်ခု။
+*   **Domain-specific Words**: သီးခြားနယ်ပယ်တစ်ခုအတွက်သာ အဓိပ္ပာယ်ရှိသော စကားလုံးများ။
+*   **Rare Tokens**: မကြာခဏမပေါ်ပေါက်သော tokens များ။
+*   **In-domain Data**: Model ကို အသုံးပြုမည့် အဓိကနယ်ပယ်နှင့် သက်ဆိုင်သော data။
+*   **Domain Adaptation**: Pretrained model တစ်ခုကို သီးခြား domain တစ်ခုရှိ data များနှင့် လိုက်လျောညီထွေဖြစ်အောင် ထပ်မံ fine-tune လုပ်ခြင်း။
+*   **ULMFiT (Universal Language Model Fine-tuning for Text Classification)**: Matthew Howard နှင့် Sebastian Ruder တို့က ၂၀၁၈ ခုနှစ်တွင် တင်ပြခဲ့သော Transfer Learning နည်းလမ်းတစ်ခု။
+*   **Neural Architectures**: Artificial Neural Networks ၏ ဖွဲ့စည်းတည်ဆောက်ပုံ။
+*   **LSTMs (Long Short-Term Memory)**: Recurrent Neural Networks (RNNs) ရဲ့ အထူးပြုပုံစံတစ်ခုဖြစ်ပြီး အချိန်ကြာမြင့်စွာ တည်ရှိနေတဲ့ မှတ်ဉာဏ် (long-term dependencies) တွေကို သင်ယူနိုင်စွမ်းရှိပါတယ်။
+*   **Autocomplete**: စာရိုက်နေစဉ် စကားလုံးများ သို့မဟုတ် စာကြောင်းများကို အလိုအလျောက် ဖြည့်ဆည်းပေးသည့် လုပ်ဆောင်ချက်။
+*   **`[MASK]` Token**: Masked Language Modeling (MLM) တွင် ဝှက်ထားသော စကားလုံးကို ကိုယ်စားပြုရန် အသုံးပြုသော special token။
+*   **`[CLS]` Token**: BERT model တွင် sequence ၏ အစကို ကိုယ်စားပြုသော special token။
+*   **`[SEP]` Token**: BERT model တွင် sentence တစ်ခု၏ အဆုံး သို့မဟုတ် sentence နှစ်ခုကြား ပိုင်းခြားရန် အသုံးပြုသော special token။
+*   **Fill-Mask Filter**: Hugging Face Hub တွင် masked language modeling task အတွက် models များကို ရှာဖွေရာတွင် အသုံးပြုသော filter။
+*   **RoBERTa (Robustly Optimized BERT Pretraining Approach)**: BERT ကို ပိုမိုကောင်းမွန်အောင် ပြုပြင်ထားသော model တစ်ခု။
+*   **DistilBERT**: BERT ၏ သေးငယ်ပြီး ပိုမိုမြန်ဆန်သော version တစ်ခု။
+*   **Knowledge Distillation**: ကြီးမားသော "teacher model" မှ ဗဟုသုတများကို သေးငယ်သော "student model" သို့ လွှဲပြောင်းပေးသည့် training နည်းလမ်း။
+*   **Teacher Model**: Knowledge distillation တွင် အသုံးပြုသော ကြီးမားပြီး စွမ်းဆောင်ရည်မြင့်မားသော model။
+*   **Student Model**: Knowledge distillation တွင် teacher model မှ သင်ယူသော သေးငယ်ပြီး မြန်ဆန်သော model။
+*   **Parameters**: Model ၏ လုပ်ဆောင်ချက်ကို သတ်မှတ်ပေးသော အတွင်းပိုင်းတန်ဖိုးများ။
+*   **`AutoModelForMaskedLM` Class**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး မော်ဒယ်အမည်ကို အသုံးပြုပြီး Masked Language Modeling အတွက် သက်ဆိုင်ရာ model ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **`model_checkpoint`**: pretrained model ၏ နာမည် (ဥပမာ- "distilbert-base-uncased")။
+*   **`num_parameters()` Method**: model ၏ parameter အရေအတွက်ကို ပြန်ပေးသော method (PyTorch တွင်)။
+*   **`summary()` Method**: model ၏ layers များ၊ output shapes များ၊ parameter အရေအတွက်များ စသည်တို့ကို အကျဉ်းချုပ်ပြသသော method (TensorFlow/Keras တွင်)။
+*   **Statistical Patterns**: ဒေတာများတွင် တွေ့ရသော မှန်မှန်ကန်ကန် ဖြစ်ပေါ်နေသော ပုံစံများ။
+*   **English Wikipedia**: အင်္ဂလိပ်ဘာသာစကားဖြင့် ရေးသားထားသော Wikipedia စွယ်စုံကျမ်း။
+*   **BookCorpus**: စာအုပ်များစွာပါဝင်သော text corpus။
+*   **`AutoTokenizer` Class**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး မော်ဒယ်အမည်ကို အသုံးပြုပြီး သက်ဆိုင်ရာ tokenizer ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **Logits**: Neural network ၏ output layer မှ ထုတ်ပေးသော raw, unnormalized prediction scores များ။
+*   **`tokenizer()` Function**: tokenizer ကို အသုံးပြုပြီး text ကို input IDs အဖြစ် ပြောင်းလဲခြင်း။
+*   **`return_tensors="pt"` / `"np"`**: PyTorch (pt) သို့မဟုတ် NumPy (np) tensors များကို ပြန်ပေးရန် သတ်မှတ်ခြင်း။
+*   **`model(**inputs).logits`**: model ကို inputs များပေးပြီး logits များကို ထုတ်ယူခြင်း။
+*   **`torch.where()`**: PyTorch tensor တစ်ခုအတွင်း အခြေအနေတစ်ခုနှင့် ကိုက်ညီသော elements များ၏ index များကို ရှာဖွေသော function။
+*   **`tokenizer.mask_token_id`**: tokenizer ၏ `[MASK]` token ၏ ID။
+*   **`mask_token_index`**: `[MASK]` token ၏ index။
+*   **`token_logits`**: model မှ ထုတ်ပေးသော tokens အားလုံးအတွက် logits။
+*   **`mask_token_logits`**: `[MASK]` token ၏ နေရာအတွက် logits။
+*   **`torch.topk()`**: PyTorch tensor တစ်ခု၏ ထိပ်တန်း k ခုသော တန်ဖိုးများနှင့် ၎င်းတို့၏ index များကို ရယူသော function။
+*   **`np.argwhere()`**: NumPy array တစ်ခုအတွင်း အခြေအနေတစ်ခုနှင့် ကိုက်ညီသော elements များ၏ index များကို ရှာဖွေသော function။
+*   **`np.argsort()`**: NumPy array တစ်ခု၏ တန်ဖိုးများကို စီထားပြီးနောက် ၎င်းတို့၏ original index များကို ပြန်ပေးသော function။
+*   **`tokenizer.mask_token`**: tokenizer ၏ `[MASK]` token (string ပုံစံ)။
+*   **`tokenizer.decode()` Method**: token IDs များကို မူရင်း string အဖြစ် ပြန်ပြောင်းပေးသော tokenizer method။
+*   **Large Movie Review Dataset (IMDb)**: ရုပ်ရှင် reviews များစွာပါဝင်သော dataset တစ်ခုဖြစ်ပြီး sentiment analysis အတွက် အသုံးပြုသည်။
+*   **Sentiment Analysis Models**: စာသားတစ်ခု၏ စိတ်ခံစားမှု (အပြုသဘော၊ အနုတ်သဘော၊ ကြားနေ) ကို ခွဲခြမ်းစိတ်ဖြာရန် လေ့ကျင့်ထားသော models။
+*   **`load_dataset()` Function**: Hugging Face Datasets library မှ dataset များကို download လုပ်ပြီး cache လုပ်ရန် အသုံးပြုသော function။
+*   **`imdb_dataset`**: IMDb dataset ကို load လုပ်ပြီးနောက် ရရှိသော `DatasetDict` object။
+*   **`train` split**: Model ကို လေ့ကျင့်ရန်အတွက် အသုံးပြုသော dataset အပိုင်း။
+*   **`test` split**: Model ၏ နောက်ဆုံး စွမ်းဆောင်ရည်ကို တိုင်းတာရန် အသုံးပြုသော dataset အပိုင်း။
+*   **`unsupervised` split**: labels မပါဝင်သော dataset အပိုင်း။
+*   **`Dataset.shuffle()` Method**: dataset အတွင်းရှိ elements များကို ကျပန်းရောနှော (shuffle) ရန် အသုံးပြုသော method။
+*   **`Dataset.select()` Function**: dataset မှ သတ်မှတ်ထားသော index များရှိ elements များကို ရွေးထုတ်ရန် အသုံးပြုသော method။
+*   **`seed`**: ကျပန်းထုတ်လုပ်ခြင်းလုပ်ငန်းစဉ်များတွင် ရလဒ်များကို reproducibility ဖြစ်စေရန် သတ်မှတ်သော တန်ဖိုး။
+*   **VHS Version**: ဗီဒီယိုခွေ (Video Home System) version။
+*   **Labels**: Model ကို သင်ကြားပေးရန်အတွက် data နှင့် တွဲဖက်ထားသော အဖြေများ သို့မဟုတ် အမျိုးအစားများ။
+*   **Sanity Check**: ပရိုဂရမ် သို့မဟုတ် ဒေတာတစ်ခု မှန်ကန်စွာ အလုပ်လုပ်ခြင်းရှိမရှိ စစ်ဆေးခြင်း။
+*   **Auto-regressive Language Modeling**: စာကြောင်းတစ်ခု၏ နောက်ဆက်တွဲ token (စကားလုံး) ကို ခန့်မှန်းခြင်းဖြင့် model ကို လေ့ကျင့်သော task။
+*   **Concatenate**: အရာများစွာကို တစ်ခုတည်းအဖြစ် ပေါင်းစပ်ခြင်း။
+*   **Truncate**: စာသား သို့မဟုတ် sequence တစ်ခုကို သတ်မှတ်ထားသော အရှည်အထိ ဖြတ်တောက်ခြင်း။
+*   **`tokenizer(examples["text"])`**: `examples` dictionary မှ `text` key ၏ value ကို tokenizer ဖြင့် လုပ်ဆောင်ခြင်း။
+*   **`tokenizer.is_fast`**: tokenizer သည် fast tokenizer (Rust-based) ဟုတ်မဟုတ် စစ်ဆေးသော property။
+*   **`result.word_ids(i)`**: `i`th sequence ရှိ token တစ်ခုစီအတွက် ၎င်းတို့သက်ဆိုင်သော word ၏ ID များကို ထုတ်ပေးသော tokenizer method။
+*   **`batched=True`**: `map()` method မှာ အသုံးပြုသော argument တစ်ခုဖြစ်ပြီး function ကို dataset ရဲ့ element အများအပြားပေါ်မှာ တစ်ပြိုင်နက်တည်း အသုံးပြုစေသည်။
+*   **`remove_columns=["text", "label"]`**: `map()` method တွင် မလိုအပ်သော columns များကို ဖယ်ရှားရန် argument။
+*   **`input_ids`**: Tokenizer မှ ထုတ်ပေးသော tokens တစ်ခုစီ၏ ထူးခြားသော ဂဏန်းဆိုင်ရာ ID များ။
+*   **`attention_mask`**: မော်ဒယ်ကို အာရုံစိုက်သင့်သည့် tokens များနှင့် လျစ်လျူရှုသင့်သည့် (padding) tokens များကို ခွဲခြားပေးသည့် binary mask။
+*   **`word_ids`**: tokenizer မှ ထုတ်ပေးသော word ID များ (token တစ်ခုစီသည် မည်သည့် word နှင့် သက်ဆိုင်သည်ကို ပြသသည်)။
+*   **GPU Memory**: GPU တွင် ပါဝင်သော မှတ်ဉာဏ်။
+*   **Maximum Context Size**: Model တစ်ခုက တစ်ချိန်တည်းမှာ လုပ်ဆောင်နိုင်သော tokens များ၏ အများဆုံးအရေအတွက်။
+*   **`model_max_length` Attribute**: tokenizer က သတ်မှတ်ထားသော model ၏ အများဆုံး input sequence length။
+*   **`tokenizer_config.json` File**: tokenizer ၏ configuration အချက်အလက်များကို သိမ်းဆည်းထားသော file။
+*   **BigBird**: Google မှ တီထွင်ခဲ့သော Transformer model တစ်ခုဖြစ်ပြီး ပိုမိုရှည်လျားသော sequence များကို ကိုင်တွယ်နိုင်ရန် "sparse attention" ကို အသုံးပြုသည်။
+*   **Longformer**: AllenAI မှ တီထွင်ခဲ့သော Transformer model တစ်ခုဖြစ်ပြီး ပိုမိုရှည်လျားသော sequence များကို ကိုင်တွယ်နိုင်ရန် "dilated sliding window attention" ကို အသုံးပြုသည်။
+*   **Contiguous Tokens**: ကပ်လျက်တည်ရှိနေသော tokens များ။
+*   **Ground Truth**: Training လုပ်ငန်းစဉ်တွင် model ကို သင်ယူရန်အတွက် အသုံးပြုသော အမှန်တကယ် မှန်ကန်သော တန်ဖိုးများ သို့မဟုတ် labels များ။
+*   **Data Collator**: `DataLoader` တစ်ခုမှာ အသုံးပြုတဲ့ function တစ်ခုဖြစ်ပြီး batch တစ်ခုအတွင်း samples တွေကို စုစည်းပေးသည်။
+*   **`DataCollatorForLanguageModeling`**: 🤗 Transformers library မှ Masked Language Modeling (MLM) အတွက် အထူးဒီဇိုင်းထုတ်ထားသော data collator။ ၎င်းသည် input tokens များကို ကျပန်း mask လုပ်ပြီး သက်ဆိုင်ရာ labels များကို ဖန်တီးပေးသည်။
+*   **`mlm_probability` Argument**: `DataCollatorForLanguageModeling` တွင် mask လုပ်မည့် tokens ရဲ့ ရာခိုင်နှုန်းကို သတ်မှတ်ရန် အသုံးပြုသော argument။
+*   **Batch**: မတူညီသော input များစွာကို တစ်ပြိုင်နက်တည်း လုပ်ဆောင်နိုင်ရန် အုပ်စုဖွဲ့ခြင်း။
+*   **`tokenizer.convert_ids_to_tokens()` Method**: input IDs များကို tokens များအဖြစ် ပြန်ပြောင်းပေးသော tokenizer method။
+*   **Deterministic**: ရလဒ်များသည် အမြဲတမ်း တူညီနေခြင်း။
+*   **Randomness**: ကျပန်းဖြစ်ခြင်း။
+*   **Freeze the Randomness**: ကျပန်းထုတ်လုပ်ခြင်းကို ရပ်ဆိုင်းခြင်း သို့မဟုတ် အပြောင်းအလဲမရှိစေရန် ထိန်းချုပ်ခြင်း။
+*   **Whole Word Masking**: Masked Language Modeling (MLM) တွင် token တစ်ခုစီကို mask လုပ်မည့်အစား စကားလုံးတစ်လုံးလုံးကို mask လုပ်သော နည်းလမ်း။
+*   **`collections.defaultdict(list)`**: dictionary တစ်ခုဖြစ်ပြီး key မရှိသေးပါက default value အဖြစ် empty list တစ်ခုကို ဖန်တီးပေးသည်။
+*   **`np.random.binomial(1, wwm_probability, (len(mapping),))`**: binomial distribution ကို အသုံးပြုပြီး mask လုပ်မည့် word များကို ကျပန်းရွေးချယ်ရန် NumPy function။
+*   **`np.where(mask)[0]`**: `mask` array ထဲက `True` ဖြစ်တဲ့ (mask လုပ်ခံရမယ့်) နေရာတွေရဲ့ index တွေကို ပြန်ပေးသော NumPy function။
+*   **`feature["input_ids"][idx] = tokenizer.mask_token_id`**: သတ်မှတ်ထားသော index ရှိ input ID ကို `[MASK]` token ၏ ID ဖြင့် အစားထိုးခြင်း။
+*   **`new_labels[idx] = labels[idx]`**: mask လုပ်ခံရသော token အတွက် label ကို မူရင်း label ဖြင့် ထားရှိခြင်း (မ mask လုပ်ခံရသော tokens များအတွက် `-100` ဖြစ်သည်)။
+*   **`-100`**: language modeling task များတွင် ignore လုပ်ရမည့် labels များကို ကိုယ်စားပြုသော တန်ဖိုး (PyTorch တွင်)။
+*   **`default_data_collator`**: 🤗 Transformers library မှ ပံ့ပိုးပေးသော default data collator။
+*   **P100 GPU**: NVIDIA Tesla P100 ကဲ့သို့ အစွမ်းထက်သော GPU။
+*   **Downsample**: dataset ၏ အရွယ်အစားကို လျှော့ချခြင်း။
+*   **`Dataset.train_test_split()` Function**: 🤗 Datasets library မှ dataset ကို training set နှင့် test set အဖြစ် ပိုင်းခြားရန် အသုံးပြုသော function။
+*   **`train_size`**: training set အတွက် examples အရေအတွက်။
+*   **`test_size`**: test set အတွက် examples အရေအတွက်။
+*   **Validation Set**: Training လုပ်နေစဉ် model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် အသုံးပြုသော dataset အပိုင်း။
+*   **Beefy GPU**: စွမ်းဆောင်ရည်မြင့်မားသော GPU။
+*   **`notebook_login()` Utility Function**: Jupyter/Colab Notebooks များတွင် Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော function။
+*   **Credentials**: အကောင့်ဝင်ရန် လိုအပ်သော အချက်အလက်များ (ဥပမာ- username, password, token)။
+*   **`huggingface-cli login`**: Hugging Face CLI (Command Line Interface) မှ Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော command။
+*   **`tf.data` Datasets**: TensorFlow framework တွင် efficient data pipelines များကို တည်ဆောက်ရန် အသုံးပြုသော dataset format။
+*   **`prepare_tf_dataset()` Method**: model ၏ input format နှင့် ကိုက်ညီသော `tf.data.Dataset` ကို ဖန်တီးရန် `AutoModel` class တွင်ပါဝင်သော method။
+*   **`Dataset.to_tf_dataset()` Method**: 🤗 Datasets library မှ dataset ကို `tf.data.Dataset` အဖြစ် ပြောင်းလဲရန် method။
+*   **`collate_fn` Argument**: `DataLoader` သို့မဟုတ် `prepare_tf_dataset()` တွင် batch တစ်ခုကို စုစည်းရန် အသုံးပြုသော function။
+*   **`shuffle=True`**: dataset ကို training မလုပ်ခင် shuffle လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`batch_size`**: training လုပ်ငန်းစဉ်တစ်ခုစီတွင် model သို့ ပေးပို့သော input samples အရေအတွက်။
+*   **Training Hyperparameters**: Training လုပ်ငန်းစဉ်၏ behavior ကို ထိန်းချုပ်သော parameters များ (ဥပမာ- learning rate, batch size)။
+*   **Compile Model**: TensorFlow/Keras တွင် model ကို training အတွက် ပြင်ဆင်ခြင်း (optimizer, loss function, metrics သတ်မှတ်ခြင်း)။
+*   **`create_optimizer()` Function**: 🤗 Transformers library မှ `AdamW` optimizer နှင့် learning rate scheduler ကို ဖန်တီးသော function။
+*   **`AdamW` Optimizer**: Adam optimizer ၏ weight decay ကို ပြုပြင်ထားသော version။
+*   **Linear Learning Rate Decay**: Training လုပ်ငန်းစဉ်တစ်လျှောက် learning rate ကို ဖြည်းဖြည်းချင်း လျှော့ချသော နည်းလမ်း။
+*   **`init_lr`**: အစောပိုင်း learning rate။
+*   **`num_warmup_steps`**: learning rate ကို ဖြည်းဖြည်းချင်း မြှင့်တင်ရန် steps အရေအတွက်။
+*   **`num_train_steps`**: training steps စုစုပေါင်းအရေအတွက်။
+*   **`weight_decay_rate`**: weight decay (regularization) ၏ ပမာဏ။
+*   **Built-in Loss**: Model ၏ internal loss function။
+*   **Training Precision**: Training လုပ်ရာတွင် အသုံးပြုသော floating point precision (ဥပမာ- `float32`, `mixed_float16`)။
+*   **`mixed_float16`**: Training လုပ်ရာတွင် `float16` နှင့် `float32` ကို ပေါင်းစပ်အသုံးပြုခြင်းဖြင့် memory အသုံးပြုမှုကို လျှော့ချပြီး speed ကို မြှင့်တင်ခြင်း။
+*   **Accelerated Float16 Support**: GPU ဟာ float16 precision နဲ့ computation တွေကို မြန်မြန်ဆန်ဆန် လုပ်ဆောင်နိုင်ခြင်း။
+*   **`PushToHubCallback`**: TensorFlow/Keras မှာ model ကို Hugging Face Hub ကို push လုပ်ရန်အတွက် callback။
+*   **`hub_model_id` Argument**: `TrainingArguments` သို့မဟုတ် `PushToHubCallback` တွင် model ကို push လုပ်မည့် Hugging Face Hub repository ၏ ID ကို သတ်မှတ်ရန် argument။
+*   **Organization**: Hugging Face Hub တွင် models များကို မျှဝေရန် အသုံးပြုနိုင်သော အဖွဲ့အစည်းအကောင့်။
+*   **Namespace**: Hugging Face Hub တွင် အသုံးပြုသူအမည် သို့မဟုတ် organization အမည်။
+*   **Output Directory**: training results များကို သိမ်းဆည်းမည့် directory။
+*   **`model.fit()` Method**: TensorFlow/Keras တွင် model ကို train လုပ်ရန် method။
+*   **`validation_data`**: `model.fit()` တွင် validation set ကို ပေးပို့ရန် argument။
+*   **`callbacks`**: Training လုပ်ငန်းစဉ်အတွင်း သတ်မှတ်ထားသော အချိန်များတွင် run နိုင်သော functions များ။
+*   **Perplexity**: Language model တစ်ခု၏ စွမ်းဆောင်ရည်ကို တိုင်းတာသော metric တစ်ခု။ နိမ့်လေ ကောင်းလေ။
+*   **Cross-entropy Loss**: Classification tasks များတွင် အသုံးပြုသော common loss function တစ်ခု။
+*   **Exponential**: သင်္ချာ function `exp(x)` သို့မဟုတ် `e^x`။
+*   **`Trainer.evaluate()` Function**: Hugging Face Trainer တွင် model ကို evaluation set ပေါ်တွင် အကဲဖြတ်ရန် method။
+*   **`math.exp()` Function**: Python ၏ `math` module မှ exponential function။
+*   **`eval_results['eval_loss']`**: evaluation loss တန်ဖိုး။
+*   **`trainer.train()`**: Hugging Face Trainer ဖြင့် model ကို train လုပ်ရန် method။
+*   **`Trainer.push_to_hub()`**: training ပြီးနောက် model card နှင့် checkpoints များကို Hub သို့ push လုပ်ရန် method။
+*   **Autoregressive Model**: အနာဂတ် tokens များကို ယခင် tokens များကို အခြေခံ၍ ခန့်မှန်းသော model အမျိုးအစား (ဥပမာ- GPT-2)။
+*   **GPT-2 (Generative Pre-trained Transformer 2)**: OpenAI မှ ထုတ်လုပ်သော autoregressive language model တစ်ခု။
+*   **Classifier**: ဒေတာအချက်အလက်များကို သတ်မှတ်ထားသော အမျိုးအစားများ သို့မဟုတ် အတန်းများထဲသို့ ခွဲခြားသတ်မှတ်သော model။
+*   **Text Classification**: စာသားကို သတ်မှတ်ထားသော အမျိုးအစားများထဲသို့ ခွဲခြားသတ်မှတ်ခြင်းနှင့် သက်ဆိုင်သော ပြဿနာ။
+*   **Custom Logic**: စံလုပ်ဆောင်မှုများထက် ကျော်လွန်သော ကိုယ်ပိုင်ရေးသားထားသည့် လုပ်ဆောင်ချက်များ။
+*   **`insert_random_mask()` Function**: batch တစ်ခုအတွင်း tokens များကို ကျပန်း mask လုပ်ရန် ကိုယ်တိုင်ရေးသားထားသော function။
+*   **`zip(*batch.values())`**: dictionary ၏ values များကို unzipping လုပ်ပြီး ၎င်းတို့၏ elements များကို pair လုပ်ခြင်း။
+*   **`dict(zip(batch, t))`**: `batch` dictionary ၏ keys များကို `t` ရှိ values များနှင့် pair လုပ်ခြင်းဖြင့် dictionary အသစ်တစ်ခု ဖန်တီးခြင်း။
+*   **`v.numpy()`**: PyTorch tensor ကို NumPy array အဖြစ် ပြောင်းလဲခြင်း။
+*   **`Dataset.remove_columns()`**: dataset မှ columns များကို ဖယ်ရှားရန် method။
+*   **`downsampled_dataset["test"].column_names`**: dataset ၏ test split တွင်ရှိသော columns များ၏ နာမည်များ။
+*   **`Dataset.rename_columns()`**: dataset ရှိ columns များကို အမည်ပြောင်းရန် method။
+*   **Dataloaders**: dataset မှ data များကို batch အလိုက် load လုပ်ပေးသော utility (PyTorch တွင် `DataLoader`, TensorFlow တွင် `tf.data.Dataset`)။
+*   **`torch.utils.data.DataLoader`**: PyTorch တွင် dataset မှ data များကို batch အလိုက် load လုပ်ပေးသော class။
+*   **`shuffle=True`**: `DataLoader` တွင် data ကို shuffle လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`collate_fn`**: `DataLoader` တွင် batch တစ်ခုကို စုစည်းရန် အသုံးပြုသော function။
+*   **`Accelerator` Object**: 🤗 Accelerate library မှ distributed training, mixed-precision training စသည်တို့ကို လွယ်ကူစေရန် အသုံးပြုသော object။
+*   **`AdamW`**: PyTorch မှာ အသုံးပြုတဲ့ AdamW optimizer။ Model ၏ parameters များကို training လုပ်ရာမှာ အသုံးပြုသည်။
+*   **`model.parameters()`**: model ၏ လေ့ကျင့်နိုင်သော parameters (weights နှင့် biases) များကို ပြန်ပေးသော method။
+*   **`lr`**: learning rate။
+*   **`accelerator.prepare()`**: model, optimizer, dataloaders များကို distributed training အတွက် ပြင်ဆင်ရန် `Accelerator` method။
+*   **Learning Rate Scheduler**: training လုပ်နေစဉ်အတွင်း learning rate ကို အချိန်နှင့်အမျှ ပြောင်းလဲရန် အသုံးပြုသော function။
+*   **`get_scheduler()` Function**: 🤗 Transformers library မှ learning rate scheduler ကို ဖန်တီးသော function။
+*   **`"linear"` (Scheduler Type)**: learning rate ကို linear နည်းဖြင့် လျှော့ချသော scheduler အမျိုးအစား။
+*   **`num_warmup_steps`**: learning rate ကို ဖြည်းဖြည်းချင်း မြှင့်တင်ရန် steps အရေအတွက်။
+*   **`num_training_steps`**: training steps စုစုပေါင်းအရေအတွက်။
+*   **Model Repository**: Hugging Face Hub တွင် model files များကို သိမ်းဆည်းထားသော နေရာ။
+*   **`get_full_repo_name()` Function**: Hugging Face Hub library မှ repository ၏ နာမည်အပြည့်အစုံကို ရယူသော function။
+*   **`Repository` Class**: `huggingface_hub` library မှ Git repository များကို ကိုင်တွယ်ရန်အတွက် class။
+*   **`output_dir`**: training results များကို သိမ်းဆည်းမည့် directory။
+*   **`clone_from`**: repository ကို clone လုပ်ရန်အတွက် remote repository ၏ URL သို့မဟုတ် နာမည်။
+*   **`tqdm.auto.tqdm`**: Python loop များကို progress bar ဖြင့် ပြသရန် library။
+*   **`progress_bar`**: training progress ကို ပြသသော progress bar object။
+*   **`model.train()`**: PyTorch model ကို training mode သို့ ပြောင်းလဲခြင်း။
+*   **`model(**batch)`**: PyTorch model ကို input batch ပေးပြီး output ရယူခြင်း။
+*   **`outputs.loss`**: model မှ ထုတ်ပေးသော loss တန်ဖိုး။
+*   **`accelerator.backward(loss)`**: distributed training တွင် loss ကို backpropagate လုပ်ရန် `Accelerator` method။
+*   **`optimizer.step()`**: တွက်ချက်ထားသော gradients များကို အသုံးပြုပြီး model ၏ parameters များကို update လုပ်သော optimizer method။
+*   **`lr_scheduler.step()`**: learning rate scheduler ၏ learning rate ကို update လုပ်ရန် method။
+*   **`optimizer.zero_grad()`**: gradients များကို zero သို့ ပြန်လည်သတ်မှတ်ခြင်း။
+*   **`progress_bar.update(1)`**: progress bar ကို 1 step တိုးမြှင့်ခြင်း။
+*   **`model.eval()`**: PyTorch model ကို evaluation mode သို့ ပြောင်းလဲခြင်း။
+*   **`torch.no_grad()`**: PyTorch တွင် gradient computation ကို disable လုပ်ရန် context manager (evaluation လုပ်နေစဉ် အသုံးပြုသည်)။
+*   **`accelerator.gather()`**: distributed training တွင် processes များစွာမှ tensors များကို စုစည်းရန် `Accelerator` method။
+*   **`loss.repeat(batch_size)`**: loss တန်ဖိုးကို `batch_size` အကြိမ် ထပ်ခါတလဲလဲ ပြုလုပ်ခြင်း။
+*   **`torch.cat()`**: PyTorch တွင် tensors များကို ပေါင်းစပ်ခြင်း။
+*   **`torch.mean()`**: PyTorch tensor ၏ mean (ပျမ်းမျှ) ကို တွက်ချက်ခြင်း။
+*   **`float("inf")`**: သင်္ချာဆိုင်ရာ infinity တန်ဖိုး။
+*   **`accelerator.wait_for_everyone()`**: distributed training တွင် processes အားလုံး အလုပ်ပြီးဆုံးရန် စောင့်ဆိုင်းခြင်း။
+*   **`accelerator.unwrap_model(model)`**: distributed training အတွက် wrap လုပ်ထားသော model ကို မူရင်း model အဖြစ် ပြန်လည်ထုတ်ယူခြင်း။
+*   **`unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)`**: model ကို output directory တွင် save လုပ်ရန် method။
+*   **`accelerator.is_main_process`**: လက်ရှိ process သည် distributed training ၏ main process ဟုတ်မဟုတ် စစ်ဆေးသော property။
+*   **`tokenizer.save_pretrained(output_dir)`**: tokenizer ကို output directory တွင် save လုပ်ရန် method။
+*   **`repo.push_to_hub(commit_message=..., blocking=False)`**: repository ကို Hugging Face Hub သို့ push လုပ်ရန် method။ `blocking=False` ဆိုသည်မှာ push လုပ်ငန်းစဉ် ပြီးဆုံးရန် စောင့်ဆိုင်းမည်မဟုတ်ပါ။
+*   **Widget**: Hugging Face Hub ပေါ်ရှိ model demo ကို အပြန်အလှန်ဆက်သွယ်နိုင်သော အစိတ်အပိုင်း။
+*   **`pipeline()` Function**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ လုပ်ဆောင်ချက်တစ်ခုဖြစ်ပြီး မော်ဒယ်တွေကို သီးခြားလုပ်ငန်းတာဝန်များ (ဥပမာ- စာသားခွဲခြားသတ်မှတ်ခြင်း၊ စာသားထုတ်လုပ်ခြင်း) အတွက် အသုံးပြုရလွယ်ကူအောင် ပြုလုပ်ပေးပါတယ်။
+*   **Classifier**: ဒေတာအချက်အလက်များကို သတ်မှတ်ထားသော အမျိုးအစားများ သို့မဟုတ် အတန်းများထဲသို့ ခွဲခြားသတ်မှတ်သော model။
+*   **Quantify**: အတိုင်းအတာတစ်ခုဖြင့် တန်ဖိုးဖြတ်ခြင်း။

--- a/chapters/my/chapter7/4.mdx
+++ b/chapters/my/chapter7/4.mdx
@@ -1,0 +1,1114 @@
+<FrameworkSwitchCourse {fw} />
+
+# ဘာသာပြန်ခြင်း[[translation]]
+
+{#if fw === 'pt'}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section4_pt.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section4_pt.ipynb"},
+]} />
+
+{:else}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section4_tf.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section4_tf.ipynb"},
+]} />
+
+{/if}
+
+အခု ဘာသာပြန်ခြင်းထဲကို နက်နက်နဲနဲ လေ့လာကြည့်ရအောင်။ ဒါက နောက်ထပ် [sequence-to-sequence task](/course/chapter1/7) တစ်ခုဖြစ်ပြီး၊ ဒါဟာ sequence တစ်ခုကနေ နောက်တစ်ခုကို သွားတဲ့ ပြဿနာတစ်ခုအဖြစ် ဖော်စပ်နိုင်ပါတယ်။ ဒီသဘောအရ ပြဿနာက [summarization](/course/chapter7/6) နဲ့ အတော်လေး နီးစပ်ပြီး၊ ဒီနေရာမှာ ကျွန်တော်တို့ တွေ့ရမယ့်အရာတွေကို အခြား sequence-to-sequence problem တွေအတွက် လိုက်လျောညီထွေ ပြုပြင်နိုင်ပါတယ်၊ ဥပမာ...
+
+-   **Style transfer**: သတ်မှတ်ထားတဲ့ style နဲ့ ရေးသားထားတဲ့ texts တွေကို တခြား style (ဥပမာ - formal ကနေ casual ဒါမှမဟုတ် Shakespearean English ကနေ modern English) ကို *ဘာသာပြန်* ပေးမယ့် model တစ်ခုကို ဖန်တီးခြင်း။
+-   **Generative question answering**: context တစ်ခုပေးထားပြီး မေးခွန်းတွေအတွက် အဖြေတွေကို ထုတ်ပေးမယ့် model တစ်ခုကို ဖန်တီးခြင်း။
+
+<Youtube id="1JvfrvZgi6c"/>
+
+သင့်မှာ ဘာသာစကားနှစ်ခု (သို့မဟုတ် ထို့ထက်ပိုသော) ဖြင့် ကြီးမားသော texts corpus တစ်ခုရှိတယ်ဆိုရင်၊ [causal language modeling](/course/chapter7/6) အပိုင်းမှာ ကျွန်တော်တို့ လုပ်ဆောင်မှာလိုပဲ translation model အသစ်တစ်ခုကို အစကနေ train လုပ်နိုင်ပါတယ်။ သို့သော်လည်း၊ ရှိပြီးသား translation model တစ်ခုကို fine-tune လုပ်တာက ပိုမြန်ပါလိမ့်မယ်။ ဥပမာ - သင်ဟာ သီးခြား language pair တစ်ခုအတွက် fine-tune လုပ်ချင်တဲ့ mT5 ဒါမှမဟုတ် mBART လို multilingual model တစ်ခု၊ ဒါမှမဟုတ် သင့်ရဲ့ သီးခြား corpus အတွက် fine-tune လုပ်ချင်တဲ့ ဘာသာစကားတစ်ခုကနေ တခြားဘာသာစကားတစ်ခုကို ဘာသာပြန်ဖို့အတွက် အထူးပြု model တစ်ခု ဖြစ်နိုင်ပါတယ်။
+
+ဒီအပိုင်းမှာ၊ [KDE4 dataset](https://huggingface.co/datasets/kde4) ပေါ်မှာ English ကနေ French ကို ဘာသာပြန်ဖို့ pretrained လုပ်ထားတဲ့ Marian model တစ်ခုကို fine-tune လုပ်ပါမယ် (Hugging Face ဝန်ထမ်းအများစုက ဘာသာစကားနှစ်ခုလုံးကို ပြောတတ်လို့ပါ)။ KDE4 dataset ဟာ [KDE apps](https://apps.kde.org/) အတွက် localized files တွေရဲ့ dataset တစ်ခုပါ။ ကျွန်တော်တို့ အသုံးပြုမယ့် model ကို [Opus dataset](https://opus.nlpl.eu/) ကနေ ယူထားတဲ့ French နဲ့ English texts ကြီးမားတဲ့ corpus တစ်ခုပေါ်မှာ pretrained လုပ်ခဲ့တာဖြစ်ပြီး၊ အဲဒီ Opus dataset ထဲမှာ KDE4 dataset ပါဝင်ပါတယ်။ ဒါပေမယ့် ကျွန်တော်တို့ အသုံးပြုမယ့် pretrained model က ၎င်းရဲ့ pretraining အတွင်းမှာ အဲဒီ data တွေကို တွေ့မြင်ခဲ့ရဖူးရင်တောင်မှ၊ fine-tuning လုပ်ပြီးနောက်မှာ ပိုကောင်းတဲ့ version တစ်ခုကို ရရှိနိုင်တယ်ဆိုတာ ကျွန်တော်တို့ တွေ့မြင်ရပါလိမ့်မယ်။
+
+ကျွန်တော်တို့ ပြီးစီးသွားတာနဲ့၊ ဒီလိုမျိုး predictions တွေ လုပ်ဆောင်နိုင်တဲ့ model တစ်ခု ရရှိပါလိမ့်မယ်။
+
+<iframe src="https://course-demos-marian-finetuned-kde4-en-to-fr.hf.space" frameBorder="0" height="350" title="Gradio app" class="block dark:hidden container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
+
+<a class="flex justify-center" href="/huggingface-course/marian-finetuned-kde4-en-to-fr">
+<img class="block dark:hidden lg:w-3/5" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/modeleval-marian-finetuned-kde4-en-to-fr.png" alt="One-hot encoded labels for question answering."/>
+<img class="hidden dark:block lg:w-3/5" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/modeleval-marian-finetuned-kde4-en-to-fr-dark.png" alt="One-hot encoded labels for question answering."/>
+</a>
+
+ယခင်အပိုင်းတွေမှာလိုပဲ၊ အောက်ပါ code ကို အသုံးပြုပြီး ကျွန်တော်တို့ train လုပ်ပြီး Hub ကို upload လုပ်မယ့် model ကို [ဒီနေရာမှာ](https://huggingface.co/huggingface-course/marian-finetuned-kde4-en-to-fr?text=This+plugin+allows+you+to+automatically+translate+web+pages+between+several+languages.) double-check လုပ်နိုင်ပါတယ်။
+
+## ဒေတာများကို ပြင်ဆင်ခြင်း[[preparing-the-data]]
+
+translation model တစ်ခုကို အစကနေ fine-tune လုပ်ဖို့ ဒါမှမဟုတ် train လုပ်ဖို့အတွက်၊ task နဲ့ သင့်လျော်တဲ့ dataset တစ်ခု ကျွန်တော်တို့ လိုအပ်ပါလိမ့်မယ်။ အရင်က ပြောခဲ့သလိုပဲ၊ ဒီအပိုင်းမှာ [KDE4 dataset](https://huggingface.co/datasets/kde4) ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။ ဒါပေမယ့် သင့်ရဲ့ ကိုယ်ပိုင် data ကို အသုံးပြုဖို့ code ကို အလွယ်တကူ ပြုပြင်ပြောင်းလဲနိုင်ပါတယ်၊ သင်ဘာသာပြန်လိုသော ဘာသာစကားနှစ်ခု (source and target) မှာ စာကြောင်းအတွဲများ ရှိသမျှကာလပတ်လုံးပေါ့။ သင့်ရဲ့ custom data ကို `Dataset` ထဲမှာ ဘယ်လို load လုပ်ရမလဲဆိုတာ မှတ်မိဖို့ လိုအပ်ရင် [Chapter 5](/course/chapter5) ကို ပြန်ကြည့်နိုင်ပါတယ်။
+
+### KDE4 Dataset[[the-kde4-dataset]]
+
+ပုံမှန်အတိုင်းပါပဲ၊ ကျွန်တော်တို့ရဲ့ dataset ကို `load_dataset()` function အသုံးပြုပြီး download လုပ်ပါတယ်။
+
+```py
+from datasets import load_dataset
+
+raw_datasets = load_dataset("kde4", lang1="en", lang2="fr")
+```
+
+သင်ဟာ မတူညီတဲ့ language pair တစ်ခုနဲ့ အလုပ်လုပ်ချင်တယ်ဆိုရင်၊ ၎င်းတို့ရဲ့ codes တွေနဲ့ သတ်မှတ်နိုင်ပါတယ်။ ဒီ dataset အတွက် ဘာသာစကား ၉၂ မျိုး ရရှိနိုင်ပါတယ်။ ၎င်းတို့အားလုံးကို ၎င်းရဲ့ [dataset card](https://huggingface.co/datasets/kde4) ပေါ်ရှိ language tags များကို ချဲ့ထွင်ကြည့်ရှုခြင်းဖြင့် မြင်နိုင်ပါတယ်။
+
+<img src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/language_tags.png" alt="Language available for the KDE4 dataset." width="100%">
+
+dataset ကို ကြည့်ရအောင်...
+
+```py
+raw_datasets
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['id', 'translation'],
+        num_rows: 210173
+    })
+})
+```
+
+ကျွန်တော်တို့မှာ စာကြောင်းအတွဲပေါင်း ၂၁၀,၁၇၃ ခုရှိပေမယ့်၊ split တစ်ခုတည်းမှာပဲ ရှိနေတာကြောင့် ကိုယ်ပိုင် validation set တစ်ခု ဖန်တီးဖို့ လိုအပ်ပါလိမ့်မယ်။ [Chapter 5](/course/chapter5) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့အတိုင်း၊ `Dataset` မှာ ကျွန်တော်တို့ကို ကူညီပေးနိုင်တဲ့ `train_test_split()` method တစ်ခု ရှိပါတယ်။ reproducibility အတွက် seed တစ်ခု ပေးပါမယ်။
+
+```py
+split_datasets = raw_datasets["train"].train_test_split(train_size=0.9, seed=20)
+split_datasets
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['id', 'translation'],
+        num_rows: 189155
+    })
+    test: Dataset({
+        features: ['id', 'translation'],
+        num_rows: 21018
+    })
+})
+```
+
+`"test"` key ကို `"validation"` အဖြစ် ဒီလို ပြန်လည်နာမည်ပြောင်းနိုင်ပါတယ်။
+
+```py
+split_datasets["validation"] = split_datasets.pop("test")
+```
+
+အခု dataset ရဲ့ element တစ်ခုကို ကြည့်ရအောင်...
+
+```py
+split_datasets["train"][1]["translation"]
+```
+
+```python out
+{'en': 'Default to expanded threads',
+ 'fr': 'Par défaut, développer les fils de discussion'}
+```
+
+ကျွန်တော်တို့ တောင်းဆိုခဲ့တဲ့ ဘာသာစကားနှစ်ခုတွဲထဲမှာ စာကြောင်းနှစ်ကြောင်းပါတဲ့ dictionary တစ်ခု ရရှိပါတယ်။ ဒီ dataset ရဲ့ ထူးခြားချက်တစ်ခုကတော့ နည်းပညာဆိုင်ရာ computer science ဝေါဟာရတွေ အပြည့်အစုံကို French ဘာသာနဲ့ ဘာသာပြန်ထားတာပါပဲ။ သို့သော်လည်း၊ French အင်ဂျင်နီယာတွေက စကားပြောတဲ့အခါ computer science-specific words တွေကို English နဲ့ပဲ ထားလေ့ရှိပါတယ်။ ဒီနေရာမှာ ဥပမာအားဖြင့်၊ "threads" ဆိုတဲ့ စကားလုံးက French စာကြောင်းမှာ ပေါ်လာနိုင်ပါတယ်၊ အထူးသဖြင့် နည်းပညာဆိုင်ရာ စကားပြောဆိုမှုတွေမှာပေါ့။ ဒါပေမယ့် ဒီ dataset မှာတော့ "fils de discussion" လို့ ပိုမှန်ကန်တဲ့ စကားလုံးနဲ့ ဘာသာပြန်ထားပါတယ်။ ကျွန်တော်တို့ အသုံးပြုမယ့် pretrained model က French နဲ့ English စာကြောင်းများစွာပါဝင်တဲ့ ပိုကြီးမားတဲ့ corpus တစ်ခုပေါ်မှာ pretrained လုပ်ထားတာဖြစ်ပြီး၊ စကားလုံးကို မူရင်းအတိုင်းထားခဲ့ခြင်းက ပိုလွယ်ကူတဲ့ ရွေးချယ်မှုတစ်ခုကို ရယူပါတယ်။
+
+```py
+from transformers import pipeline
+
+model_checkpoint = "Helsinki-NLP/opus-mt-en-fr"
+translator = pipeline("translation", model=model_checkpoint)
+translator("Default to expanded threads")
+```
+
+```python out
+[{'translation_text': 'Par défaut pour les threads élargis'}]
+```
+
+ဒီအပြုအမူရဲ့ နောက်ထပ်ဥပမာတစ်ခုကို "plugin" ဆိုတဲ့ စကားလုံးနဲ့ မြင်နိုင်ပါတယ်။ ဒါက တရားဝင် French စကားလုံး မဟုတ်ပေမယ့်၊ native speakers အများစုက နားလည်ပြီး ဘာသာပြန်ဖို့ စိတ်မပူပါဘူး။
+KDE4 dataset မှာ ဒီစကားလုံးကို French ဘာသာနဲ့ ပိုမိုတရားဝင်တဲ့ "module d'extension" လို့ ဘာသာပြန်ထားပါတယ်-
+
+```py
+split_datasets["train"][172]["translation"]
+```
+
+```python out
+{'en': 'Unable to import %1 using the OFX importer plugin. This file is not the correct format.',
+ 'fr': "Impossible d'importer %1 en utilisant le module d'extension d'importation OFX. Ce fichier n'a pas un format correct."}
+```
+
+သို့သော်လည်း၊ ကျွန်တော်တို့ရဲ့ pretrained model ကတော့ ကျစ်လျစ်ပြီး ရင်းနှီးပြီးသား English စကားလုံးကိုပဲ ဆုပ်ကိုင်ထားပါတယ်-
+
+```py
+translator(
+    "Unable to import %1 using the OFX importer plugin. This file is not the correct format."
+)
+```
+
+```python out
+[{'translation_text': "Impossible d'importer %1 en utilisant le plugin d'importateur OFX. Ce fichier n'est pas le bon format."}]
+```
+
+ကျွန်တော်တို့ရဲ့ fine-tuned model က dataset ရဲ့ ဒီထူးခြားချက်တွေကို လက်ခံမလားဆိုတာ ကြည့်ရတာ စိတ်ဝင်စားစရာ ကောင်းပါလိမ့်မယ် (spoiler alert: လက်ခံပါလိမ့်မယ်)။
+
+<Youtube id="0Oxphw4Q9fo"/>
+
+> [!TIP]
+> ✏️ **သင့်အလှည့်!** French မှာ မကြာခဏ အသုံးပြုတဲ့ နောက်ထပ် English စကားလုံးတစ်လုံးက "email" ဖြစ်ပါတယ်။ training dataset မှာ ဒီစကားလုံးကို အသုံးပြုထားတဲ့ ပထမဆုံး sample ကို ရှာပါ။ ဘယ်လို ဘာသာပြန်ထားလဲ။ pretrained model က အဲဒီ English စာကြောင်းကို ဘယ်လို ဘာသာပြန်လဲ။
+
+### ဒေတာများကို စီမံဆောင်ရွက်ခြင်း[[processing-the-data]]
+
+<Youtube id="XAR8jnZZuUs"/>
+
+အခုဆိုရင် သင်ဟာ လုပ်ဆောင်ရမယ့် အဆင့်တွေကို သိပြီးဖြစ်ပါလိမ့်မယ်- texts တွေအားလုံးကို token IDs အစုအဝေးအဖြစ် ပြောင်းလဲဖို့ လိုအပ်ပါတယ်။ ဒါမှ model က ၎င်းတို့ကို နားလည်နိုင်မှာပါ။ ဒီ task အတွက်၊ inputs နဲ့ targets နှစ်ခုလုံးကို tokenize လုပ်ဖို့ လိုအပ်ပါလိမ့်မယ်။ ကျွန်တော်တို့ရဲ့ ပထမဆုံး task ကတော့ `tokenizer` object ကို ဖန်တီးဖို့ပါပဲ။ အရင်က ဖော်ပြခဲ့တဲ့အတိုင်း၊ Marian English to French pretrained model ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။ သင်ဟာ ဒီ code ကို အခြား language pair တစ်ခုနဲ့ စမ်းသပ်နေတယ်ဆိုရင်၊ model checkpoint ကို သေချာလိုက်လျောညီထွေ ပြုပြင်ပါ။ [Helsinki-NLP](https://huggingface.co/Helsinki-NLP) organization က multiple languages နဲ့ models ပေါင်း တစ်ထောင်ကျော်ကို ပံ့ပိုးပေးပါတယ်။
+
+```python
+from transformers import AutoTokenizer
+
+model_checkpoint = "Helsinki-NLP/opus-mt-en-fr"
+tokenizer = AutoTokenizer.from_pretrained(model_checkpoint, return_tensors="pt")
+```
+
+သင်ဟာ `model_checkpoint` ကို [Hub](https://huggingface.co/models) က သင်နှစ်သက်တဲ့ model တစ်ခုခု ဒါမှမဟုတ် pretrained model နဲ့ tokenizer တစ်ခုကို သိမ်းဆည်းထားတဲ့ local folder တစ်ခုနဲ့လည်း အစားထိုးနိုင်ပါတယ်။
+
+> [!TIP]
+> 💡 သင်ဟာ mBART, mBART-50, ဒါမှမဟုတ် M2M100 လို multilingual tokenizer တစ်ခုကို အသုံးပြုနေတယ်ဆိုရင်၊ `tokenizer.src_lang` နဲ့ `tokenizer.tgt_lang` တို့ကို မှန်ကန်တဲ့ တန်ဖိုးတွေနဲ့ သတ်မှတ်ခြင်းဖြင့် သင့် inputs နဲ့ targets တွေရဲ့ language codes တွေကို tokenizer မှာ သတ်မှတ်ဖို့ လိုပါလိမ့်မယ်။
+
+ကျွန်တော်တို့ရဲ့ data ကို ပြင်ဆင်တာက အလွန်ရိုးရှင်းပါတယ်။ မှတ်သားစရာ တစ်ခုတည်းသော အရာကတော့၊ tokenizer က output language (ဒီနေရာမှာ French) မှာရှိတဲ့ targets တွေကို စီမံဆောင်ရွက်တယ်ဆိုတာကို သေချာစေဖို့ လိုအပ်ပါတယ်။ ဒါကို tokenizer ရဲ့ `__call__` method ရဲ့ `text_targets` argument ကို targets တွေ ပေးခြင်းဖြင့် လုပ်ဆောင်နိုင်ပါတယ်။
+
+ဒါက ဘယ်လိုအလုပ်လုပ်တယ်ဆိုတာ ကြည့်ဖို့၊ training set ထဲက ဘာသာစကားတစ်ခုစီရဲ့ sample တစ်ခုကို စီမံဆောင်ရွက်ကြည့်ရအောင်။
+
+```python
+en_sentence = split_datasets["train"][1]["translation"]["en"]
+fr_sentence = split_datasets["train"][1]["translation"]["fr"]
+
+inputs = tokenizer(en_sentence, text_target=fr_sentence)
+inputs
+```
+
+```python out
+{'input_ids': [47591, 12, 9842, 19634, 9, 0], 'attention_mask': [1, 1, 1, 1, 1, 1], 'labels': [577, 5891, 2, 3184, 16, 2542, 5, 1710, 0]}
+```
+
+ကျွန်တော်တို့ မြင်ရတဲ့အတိုင်း၊ output မှာ English စာကြောင်းနဲ့ ဆက်စပ်နေတဲ့ input IDs တွေ ပါဝင်နေပြီး၊ French စာကြောင်းနဲ့ ဆက်စပ်နေတဲ့ IDs တွေကတော့ `labels` field ထဲမှာ သိမ်းဆည်းထားပါတယ်။ သင် labels တွေကို tokenize လုပ်နေတယ်ဆိုတာကို ဖော်ပြဖို့ မေ့သွားရင်၊ ၎င်းတို့ကို input tokenizer က tokenize လုပ်ပါလိမ့်မယ်။ Marian model ရဲ့ ကိစ္စမှာတော့ ဒါက လုံးဝအဆင်ပြေမှာ မဟုတ်ပါဘူး။
+
+```python
+wrong_targets = tokenizer(fr_sentence)
+print(tokenizer.convert_ids_to_tokens(wrong_targets["input_ids"]))
+print(tokenizer.convert_ids_to_tokens(inputs["labels"]))
+```
+
+```python out
+[' Par', ' dé', 'f', 'aut', ',', ' dé', 've', 'lop', 'per', ' les', ' fil', 's', ' de', ' discussion', '</s>']
+[' Par', ' défaut', ',', ' développer', ' les', ' fils', ' de', ' discussion', '</s>']
+```
+
+ကျွန်တော်တို့ မြင်ရတဲ့အတိုင်း၊ French စာကြောင်းတစ်ခုကို preprocess လုပ်ဖို့ English tokenizer ကို အသုံးပြုခြင်းက tokens ပိုများစွာကို ရရှိစေပါတယ်။ ဘာလို့လဲဆိုတော့ tokenizer က French စကားလုံးတွေကို (English ဘာသာစကားမှာလည်း ပါဝင်တဲ့ "discussion" လို စကားလုံးတွေကလွဲလို့) မသိလို့ပါပဲ။
+
+`inputs` က ကျွန်တော်တို့ရဲ့ ပုံမှန် keys တွေ (input IDs, attention mask စသည်) ပါဝင်တဲ့ dictionary တစ်ခုဖြစ်တဲ့အတွက်၊ နောက်ဆုံးအဆင့်ကတော့ datasets တွေပေါ်မှာ ကျွန်တော်တို့ အသုံးပြုမယ့် preprocessing function ကို သတ်မှတ်ဖို့ပါပဲ။
+
+```python
+max_length = 128
+
+
+def preprocess_function(examples):
+    inputs = [ex["en"] for ex in examples["translation"]]
+    targets = [ex["fr"] for ex in examples["translation"]]
+    model_inputs = tokenizer(
+        inputs, text_target=targets, max_length=max_length, truncation=True
+    )
+    return model_inputs
+```
+
+ကျွန်တော်တို့ inputs နဲ့ outputs တွေအတွက် maximum length တူတူကို သတ်မှတ်ထားတာကို သတိပြုပါ။ ကျွန်တော်တို့ ကိုင်တွယ်နေတဲ့ texts တွေက အတော်လေး တိုတောင်းပုံရတာကြောင့်၊ ၁၂၈ ကို အသုံးပြုပါတယ်။
+
+> [!TIP]
+> 💡 သင်ဟာ T5 model (အထူးသဖြင့် `t5-xxx` checkpoints များထဲမှ တစ်ခု) ကို အသုံးပြုနေတယ်ဆိုရင်၊ model က input texts တွေမှာ `translate: English to French:` လိုမျိုး task ကို ဖော်ပြတဲ့ prefix တစ်ခု ပါဝင်ဖို့ မျှော်လင့်ပါလိမ့်မယ်။
+
+> [!WARNING]
+> ⚠️ ကျွန်တော်တို့ targets တွေရဲ့ attention mask ကို ဂရုမစိုက်ပါဘူး၊ ဘာလို့လဲဆိုတော့ model က အဲဒါကို မျှော်လင့်မှာ မဟုတ်လို့ပါ။ အဲဒီအစား၊ padding token နဲ့ ကိုက်ညီတဲ့ labels တွေကို `-100` အဖြစ် သတ်မှတ်ထားသင့်ပါတယ်။ ဒါမှ loss computation မှာ ၎င်းတို့ကို လျစ်လျူရှုနိုင်မှာပါ။ ဒါကို နောက်ပိုင်းမှာ ကျွန်တော်တို့ရဲ့ data collator က လုပ်ဆောင်ပေးပါလိမ့်မယ်။ ဘာလို့လဲဆိုတော့ ကျွန်တော်တို့ dynamic padding ကို အသုံးပြုနေလို့ပါ၊ ဒါပေမယ့် သင်ဒီနေရာမှာ padding ကို အသုံးပြုတယ်ဆိုရင်၊ padding token နဲ့ ကိုက်ညီတဲ့ labels အားလုံးကို `-100` အဖြစ် သတ်မှတ်ဖို့ preprocessing function ကို ပြင်ဆင်သင့်ပါတယ်။
+
+အခုဆိုရင် ကျွန်တော်တို့ အဲဒီ preprocessing ကို dataset ရဲ့ splits အားလုံးပေါ်မှာ တစ်ခါတည်း အသုံးပြုနိုင်ပါပြီ-
+
+```py
+tokenized_datasets = split_datasets.map(
+    preprocess_function,
+    batched=True,
+    remove_columns=split_datasets["train"].column_names,
+)
+```
+
+data ကို preprocess လုပ်ပြီးတာနဲ့၊ ကျွန်တော်တို့ရဲ့ pretrained model ကို fine-tune လုပ်ဖို့ အဆင်သင့်ပါပဲ!
+
+{#if fw === 'pt'}
+
+## `Trainer` API ဖြင့် Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model-with-the-trainer-api]]
+
+`Trainer` ကို အသုံးပြုတဲ့ code အမှန်တကယ်က အရင်ကနဲ့ တူတူပဲ ဖြစ်ပါလိမ့်မယ်၊ သေးငယ်တဲ့ ပြောင်းလဲမှုတစ်ခုပဲ ရှိပါမယ်- ဒီနေရာမှာ `Seq2SeqTrainer` ([`Seq2SeqTrainer`](https://huggingface.co/transformers/main_classes/trainer.html#seq2seqtrainer)) ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။ ဒါက `Trainer` ရဲ့ subclass တစ်ခုဖြစ်ပြီး၊ inputs တွေကနေ outputs တွေကို predict လုပ်ဖို့ `generate()` method ကို အသုံးပြုပြီး evaluation ကို မှန်ကန်စွာ ကိုင်တွယ်နိုင်စေပါလိမ့်မယ်။ metrics computation အကြောင်း ပြောတဲ့အခါ ဒါကို ပိုပြီး အသေးစိတ်လေ့လာပါမယ်။
+
+ပထမဆုံးအနေနဲ့၊ fine-tune လုပ်ဖို့အတွက် အမှန်တကယ် model တစ်ခု လိုအပ်ပါတယ်။ ပုံမှန် `AutoModel` API ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။
+
+```py
+from transformers import AutoModelForSeq2SeqLM
+
+model = AutoModelForSeq2SeqLM.from_pretrained(model_checkpoint)
+```
+
+{:else}
+
+## Keras ဖြင့် Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model-with-keras]]
+
+ပထမဆုံးအနေနဲ့၊ fine-tune လုပ်ဖို့အတွက် အမှန်တကယ် model တစ်ခု လိုအပ်ပါတယ်။ ပုံမှန် `AutoModel` API ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။
+
+```py
+from transformers import TFAutoModelForSeq2SeqLM
+
+model = TFAutoModelForSeq2SeqLM.from_pretrained(model_checkpoint, from_pt=True)
+```
+
+<Tip warning={false}>
+
+💡 `Helsinki-NLP/opus-mt-en-fr` checkpoint မှာ PyTorch weights တွေပဲ ရှိတာကြောင့်၊
+`from_pretrained()` method မှာ `from_pt=True` argument ကို အသုံးပြုခြင်းမရှိဘဲ
+model ကို load လုပ်ဖို့ ကြိုးစားရင် error ရပါလိမ့်မယ်။ သင် `from_pt=True` ကို သတ်မှတ်လိုက်တဲ့အခါ၊
+library က PyTorch weights တွေကို အလိုအလျောက် download လုပ်ပြီး သင့်အတွက် convert လုပ်ပေးပါလိမ့်မယ်။
+သင်တွေ့ရတဲ့အတိုင်း၊ 🤗 Transformers မှာ frameworks တွေကြား ပြောင်းလဲတာက အလွန်ရိုးရှင်းပါတယ်။
+
+</Tip>
+
+{/if}
+
+ဒီတစ်ခါ ကျွန်တော်တို့ translation task ပေါ်မှာ train လုပ်ထားပြီးသား model တစ်ခုကို အသုံးပြုနေတာဖြစ်ပြီး အမှန်တကယ် အသုံးပြုနိုင်နေပြီဆိုတာကို သတိပြုပါ။ ဒါကြောင့် weights တွေ ပျောက်ဆုံးနေတာ ဒါမှမဟုတ် အသစ် initialized လုပ်ထားတဲ့ weights တွေအကြောင်း warning မရှိပါဘူး။
+
+### Data Collation[[data-collation]]
+
+dynamic batching အတွက် padding ကို ကိုင်တွယ်ဖို့ data collator တစ်ခု ကျွန်တော်တို့ လိုအပ်ပါလိမ့်မယ်။ [Chapter 3](/course/chapter3) မှာလိုမျိုး `DataCollatorWithPadding` ကို ဒီကိစ္စမှာ အသုံးပြုလို့ မရပါဘူး၊ ဘာလို့လဲဆိုတော့ အဲဒါက inputs တွေကို (input IDs, attention mask, token type IDs) ပဲ padding လုပ်ပေးလို့ပါ။ ကျွန်တော်တို့ရဲ့ labels တွေကိုလည်း labels တွေမှာ တွေ့ရတဲ့ maximum length အထိ padding လုပ်သင့်ပါတယ်။ ပြီးတော့၊ အရင်က ပြောခဲ့သလိုပဲ၊ labels တွေကို padding လုပ်ဖို့ အသုံးပြုတဲ့ padding value ကို `-100` အဖြစ် သတ်မှတ်သင့်ပါတယ်။ ဒါမှ အဲဒီ padded values တွေကို loss computation မှာ လျစ်လျူရှုနိုင်မှာပါ။
+
+ဒါတွေအားလုံးကို [`DataCollatorForSeq2Seq`](https://huggingface.co/transformers/main_classes/data_collator.html#datacollatorforseq2seq) က လုပ်ဆောင်ပေးပါတယ်။ `DataCollatorWithPadding` လိုပဲ၊ ဒါက inputs တွေကို preprocess လုပ်ဖို့ အသုံးပြုတဲ့ `tokenizer` ကို ယူပါတယ်၊ ဒါပေမယ့် `model` ကိုလည်း ယူပါတယ်။ ဒါက ဘာလို့လဲဆိုတော့ ဒီ data collator က decoder input IDs တွေကို ပြင်ဆင်ပေးဖို့လည်း တာဝန်ရှိမှာပါ။ ဒါတွေက အစမှာ special token တစ်ခုနဲ့ labels တွေရဲ့ shift လုပ်ထားတဲ့ version တွေပါ။ ဒီ shift က မတူညီတဲ့ architectures တွေအတွက် အနည်းငယ်ကွာခြားစွာ လုပ်ဆောင်တာကြောင့်၊ `DataCollatorForSeq2Seq` က `model` object ကို သိဖို့ လိုအပ်ပါတယ်။
+
+{#if fw === 'pt'}
+
+```py
+from transformers import DataCollatorForSeq2Seq
+
+data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)
+```
+
+{:else}
+
+```py
+from transformers import DataCollatorForSeq2Seq
+
+data_collator = DataCollatorForSeq2Seq(tokenizer, model=model, return_tensors="tf")
+```
+
+{/if}
+
+samples အနည်းငယ်ပေါ်မှာ ဒါကို စမ်းသပ်ကြည့်ဖို့၊ ကျွန်တော်တို့ရဲ့ tokenized training set က ဥပမာတွေ စာရင်းတစ်ခုပေါ်မှာ ဒါကို ခေါ်လိုက်ရုံပါပဲ။
+
+```py
+batch = data_collator([tokenized_datasets["train"][i] for i in range(1, 3)])
+batch.keys()
+```
+
+```python out
+dict_keys(['attention_mask', 'input_ids', 'labels', 'decoder_input_ids'])
+```
+
+ကျွန်တော်တို့ရဲ့ labels တွေကို batch ရဲ့ maximum length အထိ `-100` ကို အသုံးပြုပြီး padding လုပ်ထားခြင်းရှိမရှိ စစ်ဆေးနိုင်ပါတယ်။
+
+```py
+batch["labels"]
+```
+
+```python out
+tensor([[  577,  5891,     2,  3184,    16,  2542,     5,  1710,     0,  -100,
+          -100,  -100,  -100,  -100,  -100,  -100],
+        [ 1211,     3,    49,  9409,  1211,     3, 29140,   817,  3124,   817,
+           550,  7032,  5821,  7907, 12649,     0]])
+```
+
+ပြီးတော့ decoder input IDs တွေကိုလည်း ကြည့်နိုင်ပါတယ်၊ ဒါတွေက labels တွေရဲ့ shifted versions တွေဆိုတာကို မြင်နိုင်ပါလိမ့်မယ်။
+
+```py
+batch["decoder_input_ids"]
+```
+
+```python out
+tensor([[59513,   577,  5891,     2,  3184,    16,  2542,     5,  1710,     0,
+         59513, 59513, 59513, 59513, 59513, 59513],
+        [59513,  1211,     3,    49,  9409,  1211,     3, 29140,   817,  3124,
+           817,   550,  7032,  5821,  7907, 12649]])
+```
+
+ဒီနေရာမှာ ကျွန်တော်တို့ရဲ့ dataset ထဲက ပထမဆုံးနဲ့ ဒုတိယမြောက် elements တွေအတွက် labels တွေပါ။
+
+```py
+for i in range(1, 3):
+    print(tokenized_datasets["train"][i]["labels"])
+```
+
+```python out
+[577, 5891, 2, 3184, 16, 2542, 5, 1710, 0]
+[1211, 3, 49, 9409, 1211, 3, 29140, 817, 3124, 817, 550, 7032, 5821, 7907, 12649, 0]
+```
+
+{#if fw === 'pt'}
+
+ကျွန်တော်တို့ ဒီ `data_collator` ကို `Seq2SeqTrainer` ဆီ ပေးပါမယ်။ နောက်တစ်ဆင့်အနေနဲ့ metric ကို ကြည့်ရအောင်။
+
+{:else}
+
+အခု ကျွန်တော်တို့ ဒီ `data_collator` ကို အသုံးပြုပြီး ကျွန်တော်တို့ရဲ့ datasets တစ်ခုစီကို training အတွက် အဆင်သင့်ဖြစ်တဲ့ `tf.data.Dataset` အဖြစ် ပြောင်းလဲနိုင်ပါပြီ။
+
+```python
+tf_train_dataset = model.prepare_tf_dataset(
+    tokenized_datasets["train"],
+    collate_fn=data_collator,
+    shuffle=True,
+    batch_size=32,
+)
+tf_eval_dataset = model.prepare_tf_dataset(
+    tokenized_datasets["validation"],
+    collate_fn=data_collator,
+    shuffle=False,
+    batch_size=16,
+)
+```
+
+{/if}
+
+### Metrics[[metrics]]
+
+<Youtube id="M05L1DhFqcw"/>
+
+{#if fw === 'pt'}
+
+`Seq2SeqTrainer` က ၎င်းရဲ့ superclass `Trainer` ကို ထပ်ထည့်ပေးတဲ့ feature ကတော့ evaluation ဒါမှမဟုတ် prediction လုပ်နေစဉ်အတွင်း `generate()` method ကို အသုံးပြုနိုင်ခြင်းပါပဲ။ training လုပ်နေစဉ်အတွင်း model က `decoder_input_ids` ကို အာရုံစိုက်မှု mask တစ်ခုနဲ့ အသုံးပြုပါလိမ့်မယ်။ ဒါက model က ခန့်မှန်းဖို့ ကြိုးစားနေတဲ့ token နောက်က tokens တွေကို မသုံးမိအောင် သေချာစေပြီး training ကို မြန်ဆန်စေပါတယ်။ inference လုပ်နေစဉ်အတွင်းမှာတော့ ကျွန်တော်တို့ labels တွေ မရှိတော့တဲ့အတွက် ဒါတွေကို အသုံးပြုနိုင်မှာ မဟုတ်ပါဘူး။ ဒါကြောင့် ကျွန်တော်တို့ရဲ့ model ကို ဒီ setup တူတူနဲ့ evaluate လုပ်တာက ကောင်းမွန်တဲ့ အကြံဥာဏ်တစ်ခုပါပဲ။
+
+[Chapter 1](/course/chapter1/6) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့အတိုင်း၊ decoder က tokens တွေကို တစ်ခုပြီးတစ်ခု ခန့်မှန်းခြင်းဖြင့် inference ကို လုပ်ဆောင်ပါတယ် — ဒါက 🤗 Transformers မှာ `generate()` method ကနေ နောက်ကွယ်မှာ အကောင်အထည်ဖော်ထားတာပါ။ ကျွန်တော်တို့ `predict_with_generate=True` လို့ သတ်မှတ်ထားရင် `Seq2SeqTrainer` က အဲဒီ method ကို evaluation အတွက် အသုံးပြုနိုင်စေပါလိမ့်မယ်။
+
+{/if}
+
+ဘာသာပြန်ခြင်းအတွက် အသုံးပြုတဲ့ ရိုးရာ metric ကတော့ [BLEU score](https://en.wikipedia.org/wiki/BLEU) ဖြစ်ပြီး၊ Kishore Papineni et al. ရေးသားခဲ့တဲ့ [၂၀၀၂ ခုနှစ် ဆောင်းပါး](https://aclanthology.org/P02-1040.pdf) မှာ မိတ်ဆက်ခဲ့တာပါ။ BLEU score က translation တွေဟာ ၎င်းတို့ရဲ့ labels တွေနဲ့ ဘယ်လောက်နီးစပ်သလဲဆိုတာကို အကဲဖြတ်ပါတယ်။ ဒါက model က ထုတ်ပေးတဲ့ outputs တွေရဲ့ နားလည်လွယ်မှု ဒါမှမဟုတ် သဒ္ဒါမှန်ကန်မှုကို တိုင်းတာတာမဟုတ်ပါဘူး၊ ဒါပေမယ့် generated outputs တွေထဲက စကားလုံးအားလုံးဟာ targets တွေမှာလည်း ပေါ်လာတယ်ဆိုတာကို သေချာစေဖို့ statistical rules တွေကို အသုံးပြုပါတယ်။ ဒါ့အပြင်၊ targets တွေမှာလည်း မထပ်တဲ့ စကားလုံးတွေ ထပ်ခါတလဲလဲ ပေါ်လာရင် (model က "the the the the the" လို စာကြောင်းတွေ ထုတ်မပေးအောင်) နဲ့ targets တွေမှာရှိတဲ့ စာကြောင်းတွေထက် ပိုတိုတဲ့ output စာကြောင်းတွေ (model က "the" လို စာကြောင်းတွေ ထုတ်မပေးအောင်) အတွက် အပြစ်ပေးတဲ့ rules တွေလည်း ရှိပါတယ်။
+
+BLEU ရဲ့ အားနည်းချက်တစ်ခုကတော့ text ကို tokenized လုပ်ပြီးသားဖြစ်ဖို့ မျှော်လင့်ထားတာကြောင့်၊ မတူညီတဲ့ tokenizers တွေ အသုံးပြုတဲ့ models တွေကြား score တွေကို နှိုင်းယှဉ်ဖို့ ခက်ခဲပါတယ်။ ဒါကြောင့်၊ ဒီနေ့ခေတ် translation models တွေကို benchmarking လုပ်ရာမှာ အသုံးအများဆုံး metric က [SacreBLEU](https://github.com/mjpost/sacrebleu) ဖြစ်ပြီး၊ ဒါက tokenization step ကို standardization လုပ်ခြင်းဖြင့် ဒီအားနည်းချက် (နှင့် အခြားအားနည်းချက်များ) ကို ဖြေရှင်းပေးပါတယ်။ ဒီ metric ကို အသုံးပြုဖို့၊ ပထမဆုံး SacreBLEU library ကို install လုပ်ဖို့ လိုအပ်ပါလိမ့်မယ်။
+
+```py
+!pip install sacrebleu
+```
+
+ပြီးရင် [Chapter 3](/course/chapter3) မှာ လုပ်ခဲ့သလိုပဲ `evaluate.load()` မှတစ်ဆင့် load လုပ်နိုင်ပါတယ်။
+
+```py
+import evaluate
+
+metric = evaluate.load("sacrebleu")
+```
+
+ဒီ metric က texts တွေကို inputs နဲ့ targets အဖြစ် ယူပါလိမ့်မယ်။ ဒါကို လက်ခံနိုင်ဖွယ်ရာ targets များစွာကို လက်ခံနိုင်အောင် ဒီဇိုင်းထုတ်ထားပါတယ်၊ ဘာလို့လဲဆိုတော့ တူညီတဲ့ စာကြောင်းတစ်ခုရဲ့ လက်ခံနိုင်ဖွယ် ဘာသာပြန်များစွာ ရှိတတ်လို့ပါပဲ — ကျွန်တော်တို့ အသုံးပြုနေတဲ့ dataset က တစ်ခုတည်းသာ ပံ့ပိုးပေးပေမယ့်၊ NLP မှာ labels အဖြစ် စာကြောင်းများစွာ ပေးထားတဲ့ datasets တွေကို တွေ့ရတာ မထူးဆန်းပါဘူး။ ဒါကြောင့်၊ predictions တွေက sentences စာရင်းတစ်ခု ဖြစ်သင့်ပြီး၊ references တွေကတော့ sentences စာရင်းများစွာပါဝင်တဲ့ စာရင်းတစ်ခု ဖြစ်သင့်ပါတယ်။
+
+ဥပမာတစ်ခု စမ်းကြည့်ရအောင်...
+
+```py
+predictions = [
+    "This plugin lets you translate web pages between several languages automatically."
+]
+references = [
+    [
+        "This plugin allows you to automatically translate web pages between several languages."
+    ]
+]
+metric.compute(predictions=predictions, references=references)
+```
+
+```python out
+{'score': 46.750469682990165,
+ 'counts': [11, 6, 4, 3],
+ 'totals': [12, 11, 10, 9],
+ 'precisions': [91.67, 54.54, 40.0, 33.33],
+ 'bp': 0.9200444146293233,
+ 'sys_len': 12,
+ 'ref_len': 13}
+```
+
+ဒါက 46.75 ရဲ့ BLEU score ကို ရရှိပြီး၊ ဒါက အတော်လေး ကောင်းမွန်ပါတယ်။ ဥပမာအနေနဲ့၊ ["Attention Is All You Need" စာတမ်း](https://arxiv.org/pdf/1706.03762.pdf) ထဲက မူရင်း Transformer model က English နဲ့ French ကြား အလားတူ translation task တစ်ခုမှာ 41.8 ရဲ့ BLEU score ကို ရရှိခဲ့ပါတယ်! (individual metrics တွေ (ဥပမာ- `counts` နဲ့ `bp`) အကြောင်း အသေးစိတ်အချက်အလက်တွေအတွက် [SacreBLEU repository](https://github.com/mjpost/sacrebleu/blob/078c440168c6adc89ba75fe6d63f0d922d42bcfe/sacrebleu/metrics/bleu.py#L74) ကို ကြည့်ပါ။) အခြားတစ်ဖက်မှာ၊ translation models တွေကနေ မကြာခဏ ထွက်လာတတ်တဲ့ ဆိုးရွားတဲ့ prediction အမျိုးအစားနှစ်ခု (ထပ်ခါတလဲလဲများစွာ ဒါမှမဟုတ် အလွန်တိုတောင်းခြင်း) နဲ့ စမ်းကြည့်ရင်၊ BLEU scores တွေ အတော်လေး ဆိုးရွားပါလိမ့်မယ်။
+
+```py
+predictions = ["This This This This"]
+references = [
+    [
+        "This plugin allows you to automatically translate web pages between several languages."
+    ]
+]
+metric.compute(predictions=predictions, references=references)
+```
+
+```python out
+{'score': 1.683602693167689,
+ 'counts': [1, 0, 0, 0],
+ 'totals': [4, 3, 2, 1],
+ 'precisions': [25.0, 16.67, 12.5, 12.5],
+ 'bp': 0.10539922456186433,
+ 'sys_len': 4,
+ 'ref_len': 13}
+```
+
+```py
+predictions = ["This plugin"]
+references = [
+    [
+        "This plugin allows you to automatically translate web pages between several languages."
+    ]
+]
+metric.compute(predictions=predictions, references=references)
+```
+
+```python out
+{'score': 0.0,
+ 'counts': [2, 1, 0, 0],
+ 'totals': [2, 1, 0, 0],
+ 'precisions': [100.0, 100.0, 0.0, 0.0],
+ 'bp': 0.004086771438464067,
+ 'sys_len': 2,
+ 'ref_len': 13}
+```
+
+score က ၀ ကနေ ၁၀၀ အထိ ရှိနိုင်ပြီး၊ မြင့်လေ ကောင်းလေပါပဲ။
+
+{#if fw === 'tf'}
+
+model outputs ကနေ metric က အသုံးပြုနိုင်တဲ့ texts တွေ ရယူဖို့၊ ကျွန်တော်တို့ `tokenizer.batch_decode()` method ကို အသုံးပြုပါမယ်။ labels တွေထဲက `-100` တွေအားလုံးကို ရှင်းလင်းဖို့ပဲ လိုအပ်ပါတယ်၊ tokenizer က padding token အတွက်လည်း အလိုအလျောက် လုပ်ပေးပါလိမ့်မယ်။ ကျွန်တော်တို့ရဲ့ model နဲ့ dataset ကို ယူပြီး metrics တွေ တွက်ချက်ပေးမယ့် function တစ်ခုကို သတ်မှတ်ရအောင်။ ကျွန်တော်တို့ စွမ်းဆောင်ရည်ကို သိသိသာသာ တိုးတက်စေမယ့် နည်းလမ်းတစ်ခုကိုလည်း အသုံးပြုပါမယ် -- TensorFlow ရဲ့ accelerated linear algebra compiler ဖြစ်တဲ့ [XLA](https://www.tensorflow.org/xla) နဲ့ ကျွန်တော်တို့ရဲ့ generation code ကို compile လုပ်တာပါ။ XLA က model ရဲ့ computation graph ကို optimizations မျိုးစုံ အသုံးပြုပြီး speed နဲ့ memory usage မှာ သိသိသာသာ တိုးတက်မှုကို ရရှိစေပါတယ်။ Hugging Face [blog](https://huggingface.co/blog/tf-xla-generate) မှာ ဖော်ပြထားတဲ့အတိုင်း၊ XLA က ကျွန်တော်တို့ရဲ့ input shapes တွေ အများကြီး ကွဲပြားခြင်း မရှိတဲ့အခါ အကောင်းဆုံး အလုပ်လုပ်ပါတယ်။ ဒါကို ကိုင်တွယ်ဖို့အတွက်၊ ကျွန်တော်တို့ inputs တွေကို ၁၂၈ ရဲ့ multiples တွေအထိ padding လုပ်ပြီး၊ padding collator နဲ့ dataset အသစ်တစ်ခု ပြုလုပ်ပါမယ်၊ ပြီးတော့ XLA နဲ့ compile လုပ်ဖို့ function တစ်ခုလုံးကို မှတ်သားပေးမယ့် `@tf.function(jit_compile=True)` decorator ကို ကျွန်တော်တို့ရဲ့ generation function မှာ အသုံးပြုပါမယ်။
+
+```py
+import numpy as np
+import tensorflow as tf
+from tqdm import tqdm
+
+generation_data_collator = DataCollatorForSeq2Seq(
+    tokenizer, model=model, return_tensors="tf", pad_to_multiple_of=128
+)
+
+tf_generate_dataset = model.prepare_tf_dataset(
+    tokenized_datasets["validation"],
+    collate_fn=generation_data_collator,
+    shuffle=False,
+    batch_size=8,
+)
+
+
+@tf.function(jit_compile=True)
+def generate_with_xla(batch):
+    return model.generate(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        max_new_tokens=128,
+    )
+
+
+def compute_metrics():
+    all_preds = []
+    all_labels = []
+
+    for batch, labels in tqdm(tf_generate_dataset):
+        predictions = generate_with_xla(batch)
+        decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
+        labels = labels.numpy()
+        labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+        decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+        decoded_preds = [pred.strip() for pred in decoded_preds]
+        decoded_labels = [[label.strip()] for label in decoded_labels]
+        all_preds.extend(decoded_preds)
+        all_labels.extend(decoded_labels)
+
+    result = metric.compute(predictions=all_preds, references=all_labels)
+    return {"bleu": result["score"]}
+```
+
+{:else}
+
+model outputs ကနေ metric က အသုံးပြုနိုင်တဲ့ texts တွေ ရယူဖို့၊ ကျွန်တော်တို့ `tokenizer.batch_decode()` method ကို အသုံးပြုပါမယ်။ labels တွေထဲက `-100` တွေအားလုံးကို ရှင်းလင်းဖို့ပဲ လိုအပ်ပါတယ် (tokenizer က padding token အတွက်လည်း အလိုအလျောက် လုပ်ပေးပါလိမ့်မယ်)။
+
+```py
+import numpy as np
+
+
+def compute_metrics(eval_preds):
+    preds, labels = eval_preds
+    # In case the model returns more than the prediction logits
+    if isinstance(preds, tuple):
+        preds = preds[0]
+
+    decoded_preds = tokenizer.batch_decode(preds, skip_special_tokens=True)
+
+    # Replace -100s in the labels as we can't decode them
+    labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+
+    # Some simple post-processing
+    decoded_preds = [pred.strip() for pred in decoded_preds]
+    decoded_labels = [[label.strip()] for label in decoded_labels]
+
+    result = metric.compute(predictions=decoded_preds, references=decoded_labels)
+    return {"bleu": result["score"]}
+```
+
+{/if}
+
+အခု ဒါပြီးသွားတာနဲ့၊ ကျွန်တော်တို့ရဲ့ model ကို fine-tune လုပ်ဖို့ အဆင်သင့်ပါပဲ!
+
+### Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model]]
+
+ပထမဆုံးအဆင့်က Hugging Face ကို log in ဝင်ဖို့ပါပဲ။ ဒါမှ သင်ရဲ့ ရလဒ်တွေကို Model Hub ကို upload လုပ်နိုင်ပါလိမ့်မယ်။ notebook မှာ ဒါကို ကူညီပေးမယ့် convenience function တစ်ခုရှိပါတယ်-
+
+```python
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+ဒါက သင့်ရဲ့ Hugging Face login credentials တွေကို ထည့်သွင်းနိုင်မယ့် widget တစ်ခုကို ပြသပါလိမ့်မယ်။
+
+သင် notebook မှာ အလုပ်မလုပ်ဘူးဆိုရင်၊ သင့် terminal မှာ အောက်ပါစာကြောင်းကို ရိုက်ထည့်လိုက်ရုံပါပဲ-
+
+```bash
+huggingface-cli login
+```
+
+{#if fw === 'tf'}
+
+မစတင်ခင်၊ training မလုပ်ဘဲ ကျွန်တော်တို့ရဲ့ model ကနေ ဘယ်လိုရလဒ်တွေ ရမလဲဆိုတာ ကြည့်ရအောင်-
+
+```py
+print(compute_metrics())
+```
+
+```
+{'bleu': 33.26983701454733}
+```
+
+ဒါပြီးသွားတာနဲ့၊ ကျွန်တော်တို့ရဲ့ model ကို compile လုပ်ပြီး train လုပ်ဖို့ လိုအပ်သမျှအားလုံးကို ပြင်ဆင်နိုင်ပါပြီ။ `tf.keras.mixed_precision.set_global_policy("mixed_float16")` ကို အသုံးပြုတာကို သတိပြုပါ -- ဒါက Keras ကို float16 ကို အသုံးပြုပြီး train လုပ်ဖို့ ပြောပါလိမ့်မယ်။ ဒါက float16 ကို ထောက်ပံ့တဲ့ GPUs တွေမှာ (Nvidia 20xx/V100 ဒါမှမဟုတ် အသစ်တွေ) သိသိသာသာ speedup ကို ပေးနိုင်ပါတယ်။
+
+```python
+from transformers import create_optimizer
+from transformers.keras_callbacks import PushToHubCallback
+import tensorflow as tf
+
+# The number of training steps is the number of samples in the dataset, divided by the batch size then multiplied
+# by the total number of epochs. Note that the tf_train_dataset here is a batched tf.data.Dataset,
+# not the original Hugging Face Dataset, so its len() is already num_samples // batch_size.
+num_epochs = 3
+num_train_steps = len(tf_train_dataset) * num_epochs
+
+optimizer, schedule = create_optimizer(
+    init_lr=5e-5,
+    num_warmup_steps=0,
+    num_train_steps=num_train_steps,
+    weight_decay_rate=0.01,
+)
+model.compile(optimizer=optimizer)
+
+# Train in mixed-precision float16
+tf.keras.mixed_precision.set_global_policy("mixed_float16")
+```
+
+နောက်တစ်ဆင့်အနေနဲ့၊ training လုပ်နေစဉ်အတွင်း ကျွန်တော်တို့ရဲ့ model ကို Hub သို့ upload လုပ်ဖို့ `PushToHubCallback` တစ်ခုကို သတ်မှတ်ပါမယ်။ [အပိုင်း ၂](/course/chapter7/2) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့အတိုင်း၊ ပြီးတော့ အဲဒီ callback နဲ့ model ကို ရိုးရှင်းစွာ fit လုပ်ပါမယ်-
+
+```python
+from transformers.keras_callbacks import PushToHubCallback
+
+callback = PushToHubCallback(
+    output_dir="marian-finetuned-kde4-en-to-fr", tokenizer=tokenizer
+)
+
+model.fit(
+    tf_train_dataset,
+    validation_data=tf_eval_dataset,
+    callbacks=[callback],
+    epochs=num_epochs,
+)
+```
+
+သင် push လုပ်ချင်တဲ့ repository ရဲ့ နာမည်ကို `hub_model_id` argument နဲ့ သတ်မှတ်နိုင်တာကို သတိပြုပါ။ (အထူးသဖြင့်၊ organization တစ်ခုသို့ push လုပ်ဖို့အတွက် ဒီ argument ကို အသုံးပြုရပါလိမ့်မယ်)။ ဥပမာ၊ ကျွန်တော်တို့ model ကို [`huggingface-course` organization](https://huggingface.co/huggingface-course) ကို push လုပ်ခဲ့တဲ့အခါ၊ `hub_model_id="huggingface-course/marian-finetuned-kde4-en-to-fr"` ကို `Seq2SeqTrainingArguments` မှာ ထပ်ထည့်ခဲ့ပါတယ်။ default အားဖြင့်၊ အသုံးပြုတဲ့ repository က သင့် namespace မှာ ရှိပြီး သင်သတ်မှတ်ထားတဲ့ output directory ရဲ့ နာမည်ကို ယူပါလိမ့်မယ်။ ဒါကြောင့် ဒီနေရာမှာ `"sgugger/marian-finetuned-kde4-en-to-fr"` ဖြစ်ပါလိမ့်မယ် (ဒါက ဒီအပိုင်းအစမှာ ကျွန်တော်တို့ ချိတ်ဆက်ခဲ့တဲ့ model ပါပဲ)။
+
+> [!TIP]
+> 💡 သင်အသုံးပြုနေတဲ့ output directory က ရှိပြီးသားဆိုရင်၊ ဒါဟာ သင် push လုပ်ချင်တဲ့ repository ရဲ့ local clone တစ်ခု ဖြစ်ဖို့ လိုအပ်ပါတယ်။ မဟုတ်ဘူးဆိုရင်၊ `model.fit()` ကို ခေါ်တဲ့အခါ error ရပါလိမ့်မယ်။ ပြီးတော့ နာမည်အသစ်တစ်ခု သတ်မှတ်ဖို့ လိုအပ်ပါလိမ့်မယ်။
+
+နောက်ဆုံးအနေနဲ့၊ training ပြီးဆုံးသွားပြီဆိုတော့ ကျွန်တော်တို့ရဲ့ metrics တွေ ဘယ်လိုပုံစံရှိလဲ ကြည့်ရအောင်။
+
+```py
+print(compute_metrics())
+```
+
+```
+{'bleu': 57.334066271545865}
+```
+
+ဒီအဆင့်မှာ၊ Model Hub ပေါ်က inference widget ကို အသုံးပြုပြီး သင့် model ကို စမ်းသပ်နိုင်ပြီး သင့်သူငယ်ချင်းတွေနဲ့ မျှဝေနိုင်ပါပြီ။ သင်ဟာ translation task တစ်ခုပေါ်မှာ model တစ်ခုကို အောင်မြင်စွာ fine-tune လုပ်ခဲ့ပါပြီ -- ဂုဏ်ယူပါတယ်!
+
+{:else}   ="no",
+    save_strategy="epoch",
+    learning_rate=2e-5,
+    per_device_train_batch_size=32,
+    per_device_eval_batch_size=64,
+    weight_decay=0.01,
+    save_total_limit=3,
+    num_train_epochs=3,
+    predict_with_generate=True,
+    fp16=True,
+    push_to_hub=True,
+)
+```
+
+ပုံမှန် hyperparameters တွေ (learning rate, epochs အရေအတွက်, batch size, weight decay အချို့) ကလွဲလို့၊ ယခင်အပိုင်းတွေမှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတာတွေနဲ့ နှိုင်းယှဉ်ရင် ဒီနေရာမှာ အပြောင်းအလဲအနည်းငယ် ရှိပါတယ်-
+
+-   ကျွန်တော်တို့ ပုံမှန် evaluation ကို မသတ်မှတ်ပါဘူး၊ ဘာလို့လဲဆိုတော့ evaluation လုပ်တာက အချိန်အကြာကြီး ယူလို့ပါ။ training မလုပ်ခင်နဲ့ နောက်ပိုင်းမှာ model ကို တစ်ကြိမ်ပဲ evaluate လုပ်ပါမယ်။
+-   `fp16=True` ကို ကျွန်တော်တို့ သတ်မှတ်ထားပါတယ်။ ဒါက modern GPUs တွေမှာ training ကို မြန်ဆန်စေပါတယ်။
+-   အပေါ်မှာ ဆွေးနွေးခဲ့တဲ့အတိုင်း `predict_with_generate=True` ကို ကျွန်တော်တို့ သတ်မှတ်ထားပါတယ်။
+-   epoch တစ်ခုစီရဲ့ အဆုံးမှာ model ကို Hub ကို upload လုပ်ဖို့ `push_to_hub=True` ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။
+
+သင် push လုပ်ချင်တဲ့ repository ရဲ့ နာမည်အပြည့်အစုံကို `hub_model_id` argument နဲ့ သတ်မှတ်နိုင်တာကို သတိပြုပါ။ (အထူးသဖြင့်၊ organization တစ်ခုသို့ push လုပ်ဖို့အတွက် ဒီ argument ကို အသုံးပြုရပါလိမ့်မယ်)။ ဥပမာ၊ ကျွန်တော်တို့ model ကို [`huggingface-course` organization](https://huggingface.co/huggingface-course) ကို push လုပ်ခဲ့တဲ့အခါ၊ `hub_model_id="huggingface-course/marian-finetuned-kde4-en-to-fr"` ကို `Seq2SeqTrainingArguments` မှာ ထပ်ထည့်ခဲ့ပါတယ်။ default အားဖြင့်၊ အသုံးပြုတဲ့ repository က သင့် namespace မှာ ရှိပြီး သင်သတ်မှတ်ထားတဲ့ output directory ရဲ့ နာမည်ကို ယူပါလိမ့်မယ်။ ဒါကြောင့် ကျွန်တော်တို့ရဲ့ ကိစ္စမှာ `"sgugger/marian-finetuned-kde4-en-to-fr"` ဖြစ်ပါလိမ့်မယ် (ဒါက ဒီအပိုင်းအစမှာ ကျွန်တော်တို့ ချိတ်ဆက်ခဲ့တဲ့ model ပါပဲ)။
+
+> [!TIP]
+> 💡 သင်အသုံးပြုနေတဲ့ output directory က ရှိပြီးသားဆိုရင်၊ ဒါဟာ သင် push လုပ်ချင်တဲ့ repository ရဲ့ local clone တစ်ခု ဖြစ်ဖို့ လိုအပ်ပါတယ်။ မဟုတ်ဘူးဆိုရင်၊ သင် `Seq2SeqTrainer` ကို သတ်မှတ်တဲ့အခါ error ရပါလိမ့်မယ်။ ပြီးတော့ နာမည်အသစ်တစ်ခု သတ်မှတ်ဖို့ လိုအပ်ပါလိမ့်မယ်။
+
+နောက်ဆုံးအနေနဲ့၊ ကျွန်တော်တို့ အရာအားလုံးကို `Seq2SeqTrainer` ကို ပေးလိုက်ရုံပါပဲ-
+
+```python
+from transformers import Seq2SeqTrainer
+
+trainer = Seq2SeqTrainer(
+    model,
+    args,
+    train_dataset=tokenized_datasets["train"],
+    eval_dataset=tokenized_datasets["validation"],
+    data_collator=data_collator,
+    tokenizer=tokenizer,
+    compute_metrics=compute_metrics,
+)
+```
+
+training မလုပ်ခင်၊ ကျွန်တော်တို့ရဲ့ model ရရှိတဲ့ score ကို အရင်ဆုံး ကြည့်ပါမယ်။ ဒါမှ ကျွန်တော်တို့ fine-tuning နဲ့ အခြေအနေကို ပိုဆိုးအောင် မလုပ်မိဘူးဆိုတာ double-check လုပ်နိုင်ပါတယ်။ ဒီ command က အချိန်အနည်းငယ် ကြာပါလိမ့်မယ်၊ ဒါကြောင့် ဒါအလုပ်လုပ်နေစဉ် ကော်ဖီသောက်နိုင်ပါတယ်။
+
+```python
+trainer.evaluate(max_length=max_length)
+```
+
+```python out
+{'eval_loss': 1.6964408159255981,
+ 'eval_bleu': 39.26865061007616,
+ 'eval_runtime': 965.8884,
+ 'eval_samples_per_second': 21.76,
+ 'eval_steps_per_second': 0.341}
+```
+
+BLEU score 39 က မဆိုးပါဘူး၊ ဒါက ကျွန်တော်တို့ရဲ့ model က English စာကြောင်းတွေကို French စာကြောင်းတွေအဖြစ် ဘာသာပြန်ရာမှာ ကောင်းမွန်နေပြီးသားဆိုတာကို ထင်ဟပ်ပါတယ်။
+
+နောက်တစ်ဆင့်က training ဖြစ်ပြီး၊ ဒါကလည်း အချိန်အနည်းငယ် ကြာပါလိမ့်မယ်။
+
+```python
+trainer.train()
+```
+
+training လုပ်နေစဉ်အတွင်း၊ model ကို save လုပ်တဲ့အခါတိုင်း (ဒီနေရာမှာ၊ epoch တိုင်း) ဒါကို Hub ကို နောက်ကွယ်မှာ upload လုပ်ပါတယ်ဆိုတာ သတိပြုပါ။ ဒီနည်းနဲ့၊ လိုအပ်ရင် အခြား machine တစ်ခုပေါ်မှာ သင်ရဲ့ training ကို ပြန်လည်စတင်နိုင်ပါလိမ့်မယ်။
+
+training ပြီးတာနဲ့၊ ကျွန်တော်တို့ model ကို ထပ်မံ evaluate လုပ်ပါမယ် — BLEU score မှာ တိုးတက်မှုအချို့ တွေ့ရဖို့ မျှော်လင့်ပါတယ်!
+
+```py
+trainer.evaluate(max_length=max_length)
+```
+
+```python out
+{'eval_loss': 0.8558505773544312,
+ 'eval_bleu': 52.94161337775576,
+ 'eval_runtime': 714.2576,
+ 'eval_samples_per_second': 29.426,
+ 'eval_steps_per_second': 0.461,
+ 'epoch': 3.0}
+```
+
+ဒါက ၁၄ မှတ်နီးပါး တိုးတက်လာတာဖြစ်ပြီး၊ ဒါဟာ အကောင်းဆုံးပါပဲ။
+
+နောက်ဆုံးအနေနဲ့၊ model ရဲ့ နောက်ဆုံး version ကို upload လုပ်ဖို့ `push_to_hub()` method ကို အသုံးပြုပါတယ်။ `Trainer` က evaluation results တွေ အားလုံးပါဝင်တဲ့ model card draft တစ်ခုကိုလည်း ရေးဆွဲပြီး upload လုပ်ပါတယ်။ ဒီ model card မှာ inference demo အတွက် widget ကို ရွေးချယ်ဖို့ Model Hub ကို ကူညီပေးတဲ့ metadata တွေ ပါဝင်ပါတယ်။ ပုံမှန်အားဖြင့်၊ model class ကနေ မှန်ကန်တဲ့ widget ကို ခန့်မှန်းနိုင်တာကြောင့် ဘာမှပြောစရာ မလိုပါဘူး၊ ဒါပေမယ့် ဒီကိစ္စမှာတော့ sequence-to-sequence problem မျိုးစုံအတွက် model class တူတူကို အသုံးပြုနိုင်တာကြောင့်၊ ဒါက translation model တစ်ခုဖြစ်တယ်လို့ ကျွန်တော်တို့ သတ်မှတ်ပါတယ်။
+
+```py
+trainer.push_to_hub(tags="translation", commit_message="Training complete")
+```
+
+ဒီ command က သင်စစ်ဆေးကြည့်ချင်တယ်ဆိုရင် ဒါက လုပ်ဆောင်ခဲ့တဲ့ commit ရဲ့ URL ကို ပြန်ပေးပါတယ်-
+
+```python out
+'https://huggingface.co/sgugger/marian-finetuned-kde4-en-to-fr/commit/3601d621e3baae2bc63d3311452535f8f58f6ef3'
+```
+
+ဒီအဆင့်မှာ၊ Model Hub ပေါ်က inference widget ကို အသုံးပြုပြီး သင့် model ကို စမ်းသပ်နိုင်ပြီး သင့်သူငယ်ချင်းတွေနဲ့ မျှဝေနိုင်ပါပြီ။ သင်ဟာ translation task တစ်ခုပေါ်မှာ model တစ်ခုကို အောင်မြင်စွာ fine-tune လုပ်ခဲ့ပါပြီ -- ဂုဏ်ယူပါတယ်!
+
+သင် training loop ကို နက်နက်နဲနဲ လေ့လာချင်တယ်ဆိုရင်၊ 🤗 Accelerate ကို အသုံးပြုပြီး အဲဒီအရာကို ဘယ်လိုလုပ်ရမလဲဆိုတာ အခု ကျွန်တော်တို့ ပြသပါမယ်။
+
+{/if}
+
+{#if fw === 'pt'}
+
+## Custom Training Loop တစ်ခု[[a-custom-training-loop]]
+
+အခု ပြည့်စုံတဲ့ training loop ကို ကြည့်ရအောင်၊ ဒါမှ သင်လိုအပ်တဲ့ အစိတ်အပိုင်းတွေကို အလွယ်တကူ customize လုပ်နိုင်ပါလိမ့်မယ်။ ဒါက [အပိုင်း ၂](/course/chapter7/2) နဲ့ [Chapter 3](/course/chapter3) မှာ ကျွန်တော်တို့ လုပ်ခဲ့တဲ့အရာတွေနဲ့ အတော်လေး တူပါလိမ့်မယ်။
+
+### Training အတွက် အားလုံးကို ပြင်ဆင်ခြင်း[[preparing-everything-for-training]]
+
+ဒါတွေအားလုံးကို အခုဆိုရင် သင်အကြိမ်အနည်းငယ် တွေ့ခဲ့ဖူးပြီးသားဖြစ်တဲ့အတွက်၊ code ကို အလွန်လျင်မြန်စွာပဲ ကြည့်သွားပါမယ်။ ပထမဆုံးအနေနဲ့ datasets တွေကို `"torch"` format ကို သတ်မှတ်ပြီး PyTorch tensors တွေ ရရှိအောင်လုပ်ပြီးနောက် datasets တွေကနေ `DataLoader` တွေကို တည်ဆောက်ပါမယ်။
+
+```py
+from torch.utils.data import DataLoader
+
+tokenized_datasets.set_format("torch")
+train_dataloader = DataLoader(
+    tokenized_datasets["train"],
+    shuffle=True,
+    collate_fn=data_collator,
+    batch_size=8,
+)
+eval_dataloader = DataLoader(
+    tokenized_datasets["validation"], collate_fn=data_collator, batch_size=8
+)
+```
+
+နောက်တစ်ဆင့်အနေနဲ့ ကျွန်တော်တို့ရဲ့ model ကို reinstantiate လုပ်ပါမယ်။ ဒါမှ ကျွန်တော်တို့ အရင်က fine-tuning ကို ဆက်မလုပ်ဘဲ pretrained model ကနေ ပြန်စတာ သေချာစေပါလိမ့်မယ်။
+
+```py
+model = AutoModelForSeq2SeqLM.from_pretrained(model_checkpoint)
+```
+
+ပြီးရင် optimizer တစ်ခု လိုအပ်ပါလိမ့်မယ်။
+
+```py
+from torch.optim import AdamW
+
+optimizer = AdamW(model.parameters(), lr=2e-5)
+```
+
+ဒီ objects တွေအားလုံး ရရှိပြီဆိုတာနဲ့၊ ဒါတွေကို `accelerator.prepare()` method ဆီ ပေးပို့နိုင်ပါပြီ။ သင် Colab notebook မှာ TPUs ပေါ်မှာ train လုပ်ချင်တယ်ဆိုရင်၊ ဒီ code အားလုံးကို training function တစ်ခုထဲကို ရွှေ့ဖို့ လိုအပ်မယ်ဆိုတာနဲ့ `Accelerator` ကို instantiate လုပ်တဲ့ cell တစ်ခုကိုမှ မ run သင့်ဘူးဆိုတာ မှတ်ထားပါ။
+
+```py
+from accelerate import Accelerator
+
+accelerator = Accelerator()
+model, optimizer, train_dataloader, eval_dataloader = accelerator.prepare(
+    model, optimizer, train_dataloader, eval_dataloader
+)
+```
+
+ကျွန်တော်တို့ `train_dataloader` ကို `accelerator.prepare()` ဆီ ပေးပို့ပြီးတာနဲ့၊ ၎င်းရဲ့ length ကို အသုံးပြုပြီး training steps အရေအတွက်ကို တွက်ချက်နိုင်ပါပြီ။ အဲဒီ method က `DataLoader` ရဲ့ length ကို ပြောင်းလဲစေမှာဖြစ်တဲ့အတွက်၊ dataloader ကို ပြင်ဆင်ပြီးမှ ဒါကို အမြဲတမ်းလုပ်သင့်တယ်ဆိုတာ မှတ်ထားပါ။ learning rate ကနေ ၀ အထိ classic linear schedule ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။
+
+```py
+from transformers import get_scheduler
+
+num_train_epochs = 3
+num_update_steps_per_epoch = len(train_dataloader)
+num_training_steps = num_train_epochs * num_update_steps_per_epoch
+
+lr_scheduler = get_scheduler(
+    "linear",
+    optimizer=optimizer,
+    num_warmup_steps=0,
+    num_training_steps=num_training_steps,
+)
+```
+
+နောက်ဆုံးအနေနဲ့၊ ကျွန်တော်တို့ model ကို Hub ကို push လုပ်ဖို့အတွက်၊ working folder တစ်ခုမှာ `Repository` object တစ်ခု ဖန်တီးဖို့ လိုအပ်ပါလိမ့်မယ်။ ပထမဆုံး Hugging Face Hub ကို log in ဝင်ပါ၊ သင်မဝင်ရသေးဘူးဆိုရင်ပေါ့။ ကျွန်တော်တို့ရဲ့ model ကို ပေးချင်တဲ့ model ID ကနေ repository နာမည်ကို ကျွန်တော်တို့ သတ်မှတ်ပါမယ် (သင် `repo_name` ကို သင့်စိတ်ကြိုက် နာမည်နဲ့ လွတ်လပ်စွာ အစားထိုးနိုင်ပါတယ်၊ ဒါက သင့် username ပါဝင်ဖို့ပဲ လိုအပ်ပါတယ်၊ အဲဒါက `get_full_repo_name()` function က လုပ်ဆောင်တာပါပဲ)။
+
+```py
+from huggingface_hub import Repository, get_full_repo_name
+
+model_name = "marian-finetuned-kde4-en-to-fr-accelerate"
+repo_name = get_full_repo_name(model_name)
+repo_name
+```
+
+```python out
+'sgugger/marian-finetuned-kde4-en-to-fr-accelerate'
+```
+
+ပြီးရင် အဲဒီ repository ကို local folder တစ်ခုမှာ clone လုပ်နိုင်ပါတယ်။ အကယ်၍ ဒါက ရှိပြီးသားဆိုရင်၊ ဒီ local folder က ကျွန်တော်တို့ အလုပ်လုပ်နေတဲ့ repository ရဲ့ clone တစ်ခု ဖြစ်ရပါလိမ့်မယ်။
+
+```py
+output_dir = "marian-finetuned-kde4-en-to-fr-accelerate"
+repo = Repository(output_dir, clone_from=repo_name)
+```
+
+အခု ကျွန်တော်တို့ `output_dir` ထဲမှာ သိမ်းဆည်းထားတဲ့ ဘာမဆိုကို `repo.push_to_hub()` method ကို ခေါ်ခြင်းဖြင့် upload လုပ်နိုင်ပါပြီ။ ဒါက epoch တစ်ခုစီရဲ့ အဆုံးမှာ intermediate models တွေကို upload လုပ်ဖို့ ကျွန်တော်တို့ကို ကူညီပေးပါလိမ့်မယ်။
+
+### Training Loop[[training-loop]]
+
+အခုဆိုရင် ပြည့်စုံတဲ့ training loop ကို ရေးဖို့ ကျွန်တော်တို့ အဆင်သင့်ပါပဲ။ ၎င်းရဲ့ evaluation အပိုင်းကို ရိုးရှင်းစေဖို့အတွက်၊ predictions နဲ့ labels တွေကို ယူပြီး ကျွန်တော်တို့ရဲ့ `metric` object က မျှော်လင့်ထားတဲ့ strings စာရင်းတွေအဖြစ် ပြောင်းလဲပေးမယ့် `postprocess()` function တစ်ခုကို ကျွန်တော်တို့ သတ်မှတ်ပါတယ်။
+
+```py
+def postprocess(predictions, labels):
+    predictions = predictions.cpu().numpy()
+    labels = labels.cpu().numpy()
+
+    decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
+
+    # Replace -100 in the labels as we can't decode them.
+    labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+
+    # Some simple post-processing
+    decoded_preds = [pred.strip() for pred in decoded_preds]
+    decoded_labels = [[label.strip()] for label in decoded_labels]
+    return decoded_preds, decoded_labels
+```
+
+training loop က [အပိုင်း ၂](/course/chapter7/2) နဲ့ [Chapter 3](/course/chapter3) ထဲက loop တွေနဲ့ အတော်လေး တူပါတယ်၊ evaluation အပိုင်းမှာ အနည်းငယ်ကွာခြားချက်တွေ ရှိပါတယ်။ — ဒါကြောင့် အဲဒါကို အာရုံစိုက်ရအောင်!
+
+ပထမဆုံး မှတ်သားရမယ့်အချက်ကတော့ predictions တွေကို တွက်ချက်ဖို့ `generate()` method ကို ကျွန်တော်တို့ အသုံးပြုတာပါ၊ ဒါပေမယ့် ဒါက ကျွန်တော်တို့ရဲ့ base model ပေါ်က method တစ်ခုဖြစ်ပြီး၊ 🤗 Accelerate က `prepare()` method မှာ ဖန်တီးခဲ့တဲ့ wrapped model မဟုတ်ပါဘူး။ ဒါကြောင့် model ကို အရင် unwrap လုပ်ပြီးမှ ဒီ method ကို ခေါ်တာပါ။
+
+ဒုတိယအချက်ကတော့ [token classification](/course/chapter7/2) နဲ့ တူတူပါပဲ၊ process နှစ်ခုက inputs နဲ့ labels တွေကို မတူညီတဲ့ shapes တွေအထိ padding လုပ်ထားနိုင်ပါတယ်။ ဒါကြောင့် `accelerator.pad_across_processes()` ကို အသုံးပြုပြီး predictions နဲ့ labels တွေကို `gather()` method ကို မခေါ်ခင် shapes တူတူဖြစ်အောင် လုပ်ပါတယ်။ ဒါကို မလုပ်ရင် evaluation က error ဖြစ်မှာ ဒါမှမဟုတ် အမြဲတမ်း hang နေပါလိမ့်မယ်။
+
+```py
+from tqdm.auto import tqdm
+import torch
+
+progress_bar = tqdm(range(num_training_steps))
+
+for epoch in range(num_train_epochs):
+    # Training
+    model.train()
+    for batch in train_dataloader:
+        outputs = model(**batch)
+        loss = outputs.loss
+        accelerator.backward(loss)
+
+        optimizer.step()
+        lr_scheduler.step()
+        optimizer.zero_grad()
+        progress_bar.update(1)
+
+    # Evaluation
+    model.eval()
+    for batch in tqdm(eval_dataloader):
+        with torch.no_grad():
+            generated_tokens = accelerator.unwrap_model(model).generate(
+                batch["input_ids"],
+                attention_mask=batch["attention_mask"],
+                max_length=128,
+            )
+        labels = batch["labels"]
+
+        # Necessary to pad predictions and labels for being gathered
+        generated_tokens = accelerator.pad_across_processes(
+            generated_tokens, dim=1, pad_index=tokenizer.pad_token_id
+        )
+        labels = accelerator.pad_across_processes(labels, dim=1, pad_index=-100)
+
+        predictions_gathered = accelerator.gather(generated_tokens)
+        labels_gathered = accelerator.gather(labels)
+
+        decoded_preds, decoded_labels = postprocess(predictions_gathered, labels_gathered)
+        metric.add_batch(predictions=decoded_preds, references=decoded_labels)
+
+    results = metric.compute()
+    print(f"epoch {epoch}, BLEU score: {results['score']:.2f}")
+
+    # Save and upload
+    accelerator.wait_for_everyone()
+    unwrapped_model = accelerator.unwrap_model(model)
+    unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)
+    if accelerator.is_main_process:
+        tokenizer.save_pretrained(output_dir)
+        repo.push_to_hub(
+            commit_message=f"Training in progress epoch {epoch}", blocking=False
+        )
+```
+
+```python out
+epoch 0, BLEU score: 53.47
+epoch 1, BLEU score: 54.24
+epoch 2, BLEU score: 54.44
+```
+
+ဒါပြီးသွားတာနဲ့၊ သင် `Seq2SeqTrainer` နဲ့ train လုပ်ခဲ့တဲ့ model နဲ့ ရလဒ်တွေ အတော်လေး ဆင်တူတဲ့ model တစ်ခု ရရှိပါလိမ့်မယ်။ ဒီ code ကို အသုံးပြုပြီး ကျွန်တော်တို့ train လုပ်ခဲ့တဲ့ model ကို [*huggingface-course/marian-finetuned-kde4-en-to-fr-accelerate*](https://huggingface.co/huggingface-course/marian-finetuned-kde4-en-to-fr-accelerate) မှာ စစ်ဆေးနိုင်ပါတယ်။ ပြီးတော့ training loop မှာ ပြောင်းလဲမှုအချို့ကို စမ်းသပ်ချင်တယ်ဆိုရင်၊ အပေါ်မှာ ပြသထားတဲ့ code ကို တိုက်ရိုက် edit လုပ်ပြီး အကောင်အထည်ဖော်နိုင်ပါတယ်!
+
+{/if}
+
+## Fine-tuned Model ကို အသုံးပြုခြင်း[[using-the-fine-tuned-model]]
+
+Model Hub ပေါ်က inference widget နဲ့ ကျွန်တော်တို့ fine-tune လုပ်ထားတဲ့ model ကို ဘယ်လိုအသုံးပြုနိုင်တယ်ဆိုတာ သင်ပြသခဲ့ပြီးပါပြီ။ `pipeline` ထဲမှာ ဒါကို locally အသုံးပြုဖို့အတွက်၊ သင့်လျော်တဲ့ model identifier ကိုပဲ ကျွန်တော်တို့ သတ်မှတ်ဖို့ လိုအပ်ပါတယ်။
+
+```py
+from transformers import pipeline
+
+# Replace this with your own checkpoint
+model_checkpoint = "huggingface-course/marian-finetuned-kde4-en-to-fr"
+translator = pipeline("translation", model=model_checkpoint)
+translator("Default to expanded threads")
+```
+
+```python out
+[{'translation_text': 'Par défaut, développer les fils de discussion'}]
+```
+
+မျှော်လင့်ထားတဲ့အတိုင်း၊ ကျွန်တော်တို့ရဲ့ pretrained model က ကျွန်တော်တို့ fine-tune လုပ်ခဲ့တဲ့ corpus နဲ့ ၎င်းရဲ့ ဗဟုသုတကို လိုက်လျောညီထွေဖြစ်အောင် လုပ်ခဲ့ပြီး၊ English စကားလုံး "threads" ကို မူရင်းအတိုင်းထားခဲ့ခြင်းအစား၊ အခု French တရားဝင် version အဖြစ် ဘာသာပြန်ပေးပါတယ်။ "plugin" အတွက်လည်း အတူတူပါပဲ။
+
+```py
+translator(
+    "Unable to import %1 using the OFX importer plugin. This file is not the correct format."
+)
+```
+
+```python out
+[{'translation_text': "Impossible d'importer %1 en utilisant le module externe d'importation OFX. Ce fichier n'est pas le bon format."}]
+```
+
+Domain adaptation ရဲ့ နောက်ထပ် ကောင်းမွန်တဲ့ ဥပမာတစ်ခုပါပဲ!
+
+> [!TIP]
+> ✏️ **သင့်အလှည့်!** သင်အရင်က ဖော်ထုတ်ခဲ့တဲ့ "email" စကားလုံးပါတဲ့ sample ပေါ်မှာ model က ဘာပြန်ပေးမလဲ။
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **Translation**: ဘာသာစကားတစ်ခုမှ အခြားဘာသာစကားတစ်ခုသို့ စာသားများကို ဘာသာပြန်ခြင်း။
+*   **Sequence-to-Sequence Task**: input sequence တစ်ခုမှ output sequence တစ်ခုကို ထုတ်လုပ်သော machine learning လုပ်ငန်း။
+*   **Summarization**: ရှည်လျားသော စာသားတစ်ခု၏ အနှစ်ချုပ်ကို ထုတ်လုပ်ခြင်း။
+*   **Style Transfer**: စာသားတစ်ခု၏ အကြောင်းအရာကို မပြောင်းလဲဘဲ ၎င်း၏ ရေးသားဟန် (style) ကို ပြောင်းလဲခြင်း။
+*   **Generative Question Answering**: ပေးထားသော context ကို အခြေခံ၍ မေးခွန်းတစ်ခုအတွက် အဖြေအသစ်တစ်ခုကို ထုတ်လုပ်ပေးခြင်း။
+*   **Corpus**: စာသား (သို့မဟုတ် အခြားဒေတာ) အစုအဝေးကြီးတစ်ခု။
+*   **From Scratch**: မော်ဒယ် (သို့မဟုတ် tokenizer) တစ်ခုကို မည်သည့် အစောပိုင်းလေ့ကျင့်မှုမျှ မရှိဘဲ လုံးဝအသစ်ကနေ စတင်တည်ဆောက်ခြင်းနှင့် လေ့ကျင့်ခြင်း။
+*   **Causal Language Modeling Pretraining**: စာကြောင်းတစ်ခု၏ နောက်ဆက်တွဲ token (စကားလုံး) ကို ခန့်မှန်းခြင်းဖြင့် model ကို လေ့ကျင့်သော task (GPT-2 ကဲ့သို့)။
+*   **Fine-tune**: ကြိုတင်လေ့ကျင့်ထားပြီးသား (pre-trained) မော်ဒယ်တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (specific task) အတွက် အနည်းငယ်သော ဒေတာနဲ့ ထပ်မံလေ့ကျင့်ပေးခြင်းကို ဆိုလိုပါတယ်။
+*   **Multilingual Model**: ဘာသာစကားများစွာကို နားလည်ပြီး လုပ်ဆောင်နိုင်သော model (ဥပမာ- mT5, mBART)။
+*   **Language Pair**: ဘာသာပြန်ခြင်းအတွက် အသုံးပြုသော ဘာသာစကားနှစ်ခုတွဲ (ဥပမာ- English-French)။
+*   **Marian Model**: Efficient Neural Machine Translation (NMT) အတွက် ဒီဇိုင်းထုတ်ထားသော Transformer-based model။
+*   **Pretrained**: Model တစ်ခုကို အကြီးစားဒေတာများဖြင့် အစောပိုင်းကတည်းက လေ့ကျင့်ထားခြင်း။
+*   **KDE4 Dataset**: KDE apps များအတွက် localized files များပါဝင်သော dataset တစ်ခု။
+*   **KDE Apps**: Linux desktop environment အတွက် ဖန်တီးထားသော open-source applications များ။
+*   **Opus Dataset**: ဘာသာစကားမျိုးစုံပါဝင်သော အကြီးစား parallel corpora (စာသားအစုအဝေး)။
+*   **Inference Widget**: Hugging Face Hub ပေါ်တွင် model တစ်ခုကို code ရေးစရာမလိုဘဲ တိုက်ရိုက်စမ်းသပ်နိုင်သော user interface။
+*   **Model Hub**: Hugging Face Hub ကို ရည်ညွှန်းပြီး AI မော်ဒယ်များ ရှာဖွေ၊ မျှဝေ၊ အသုံးပြုနိုင်သော ဗဟို platform။
+*   **`load_dataset()` Function**: Hugging Face Datasets library မှ dataset များကို download လုပ်ပြီး cache လုပ်ရန် အသုံးပြုသော function။
+*   **`lang1="en", lang2="fr"`**: `load_dataset()` function တွင် source language နှင့် target language ကို သတ်မှတ်ရန် အသုံးပြုသော arguments များ (English နှင့် French)။
+*   **Language Tags**: dataset card တွင် ဘာသာစကားများကို ဖော်ပြရန် အသုံးပြုသော tags များ။
+*   **`DatasetDict` Object**: Training set, validation set, နှင့် test set ကဲ့သို့သော dataset အများအပြားကို dictionary ပုံစံဖြင့် သိမ်းဆည်းထားသော object။
+*   **Split**: Dataset ကို training, validation, test စသည်ဖြင့် ခွဲခြားထားသော အပိုင်းများ။
+*   **`train_test_split()` Method**: `Dataset` object မှာပါဝင်ပြီး dataset ကို training and testing (သို့မဟုတ် validation) splits များအဖြစ် ခွဲခြားရန် အသုံးပြုသည်။
+*   **Seed**: ကျပန်းနံပါတ်ထုတ်လုပ်ခြင်းကို reproducibility အတွက် တူညီအောင် ထိန်းချုပ်သော တန်ဖိုး။
+*   **Reproducibility**: သတ်မှတ်ထားသော code နှင့် data ကို အသုံးပြု၍ တူညီသော ရလဒ်များကို ပြန်လည်ထုတ်လုပ်နိုင်ခြင်း။
+*   **Validation Set**: Training လုပ်နေစဉ် model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် အသုံးပြုသော dataset အပိုင်း။
+*   **Target Language**: ဘာသာပြန်လိုသော ဘာသာစကား။
+*   **`pipeline()` Function**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ လုပ်ဆောင်ချက်တစ်ခုဖြစ်ပြီး မော်ဒယ်တွေကို သီးခြားလုပ်ငန်းတာဝန်များ (ဥပမာ- စာသားခွဲခြားသတ်မှတ်ခြင်း၊ စာသားထုတ်လုပ်ခြင်း) အတွက် အသုံးပြုရလွယ်ကူအောင် ပြုလုပ်ပေးပါတယ်။
+*   **`AutoTokenizer`**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး မော်ဒယ်အမည်ကို အသုံးပြုပြီး သက်ဆိုင်ရာ tokenizer ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **`return_tensors="pt"`**: Tokenizer မှ output အဖြစ် PyTorch tensors များကို ပြန်ပေးရန် သတ်မှတ်ခြင်း။
+*   **`tokenizer.src_lang`**: Multilingual tokenizer များအတွက် source language ကို သတ်မှတ်သော attribute။
+*   **`tokenizer.tgt_lang`**: Multilingual tokenizer များအတွက် target language ကို သတ်မှတ်သော attribute။
+*   **`__call__` Method**: Python class object များကို function တစ်ခုကဲ့သို့ ခေါ်ဆိုနိုင်စေသော special method။
+*   **`text_targets` Argument**: Tokenizer ၏ `__call__` method တွင် target texts များကို ပေးပို့ရန် အသုံးပြုသော argument။
+*   **Input IDs**: Tokenizer မှ ထုတ်ပေးသော tokens တစ်ခုစီ၏ ထူးခြားသော ဂဏန်းဆိုင်ရာ ID များ။
+*   **Attention Mask**: မော်ဒယ်ကို အာရုံစိုက်သင့်သည့် tokens များနှင့် လျစ်လျူရှုသင့်သည့် (padding) tokens များကို ခွဲခြားပေးသည့် binary mask။
+*   **`labels` Field**: Model training အတွက် အမှန်တကယ် target values များ သိမ်းဆည်းထားသော field။
+*   **`convert_ids_to_tokens()` Method**: input IDs များကို tokens များအဖြစ် ပြန်ပြောင်းပေးသော tokenizer method။
+*   **Prefix**: စာသားတစ်ခု၏ အစတွင် ပူးတွဲထားသော စကားလုံး သို့မဟုတ် စာကြောင်း။
+*   **Padding Token**: စာကြောင်းများ၏ အရှည်ကို ညီမျှစေရန် ထပ်ဖြည့်ပေးသော special token။
+*   **Loss Computation**: Model ၏ ခန့်မှန်းချက်များနှင့် အမှန်တကယ် labels များကြား ကွာခြားမှုကို တိုင်းတာသော တန်ဖိုး (loss) ကို တွက်ချက်ခြင်း။
+*   **Dynamic Padding**: Batch တစ်ခုအတွင်းရှိ samples များကို အဲဒီ batch ထဲက အရှည်ဆုံး sample ရဲ့ အရှည်အထိသာ padding လုပ်တဲ့ နည်းလမ်း။
+*   **`map()` Method**: 🤗 Datasets library မှာ ပါဝင်တဲ့ method တစ်ခုဖြစ်ပြီး dataset ရဲ့ element တစ်ခုစီ ဒါမှမဟုတ် batch တစ်ခုစီပေါ်မှာ function တစ်ခုကို အသုံးပြုနိုင်စေသည်။
+*   **`batched=True`**: `map()` method မှာ အသုံးပြုသော argument တစ်ခုဖြစ်ပြီး function ကို dataset ရဲ့ element အများအပြားပေါ်မှာ တစ်ပြိုင်နက်တည်း အသုံးပြုစေသည်။
+*   **`remove_columns` Argument**: `map()` method တွင် မလိုအပ်သော columns များကို dataset မှ ဖယ်ရှားရန် အသုံးပြုသော argument။
+*   **`AutoModelForSeq2SeqLM`**: Sequence-to-sequence language modeling task များအတွက် သက်ဆိုင်ရာ model class ကို အလိုအလျောက် load လုပ်ပေးသော Hugging Face Transformers class။
+*   **`Seq2SeqTrainer`**: Hugging Face Transformers library မှ sequence-to-sequence models များကို လေ့ကျင့်ရန်အတွက် အထူးပြု Trainer subclass။
+*   **`generate()` Method**: model တစ်ခုမှ text sequence အသစ်များကို ထုတ်လုပ်ရန်အတွက် method။
+*   **`AutoModel` API**: Hugging Face Transformers library မှ model class များကို အလိုအလျောက် load လုပ်ရန်အတွက် API။
+*   **`TFAutoModelForSeq2SeqLM`**: TensorFlow framework အတွက် `AutoModelForSeq2SeqLM` ၏ version။
+*   **`from_pt=True`**: TensorFlow model ကို load လုပ်ရာတွင် PyTorch weights များကို convert လုပ်ပြီး အသုံးပြုရန် သတ်မှတ်ခြင်း။
+*   **PyTorch Weights**: PyTorch framework ဖြင့် လေ့ကျင့်ထားသော model ၏ parameters များ။
+*   **Data Collator**: batch တစ်ခုအတွင်းရှိ data samples များကို model input အတွက် သင့်လျော်သောပုံစံသို့ ပြောင်းလဲပေးသော function သို့မဟုတ် class။
+*   **`DataCollatorWithPadding`**: input IDs, attention masks စသည်တို့ကို padding လုပ်ပေးသော data collator။
+*   **`DataCollatorForSeq2Seq`**: Sequence-to-sequence models များအတွက် inputs နှင့် labels နှစ်ခုလုံးကို padding လုပ်ပေးပြီး decoder input IDs များကို ပြင်ဆင်ပေးသော data collator။
+*   **Decoder Input IDs**: decoder အတွက် input အဖြစ် အသုံးပြုသော shifted labels များ။
+*   **`tensor`**: PyTorch မှာ data များကို သိမ်းဆည်းရန် အသုံးပြုတဲ့ multi-dimensional array။
+*   **`prepare_tf_dataset()` Method**: Keras API ဖြင့် training လုပ်ရန်အတွက် `tf.data.Dataset` object တစ်ခုကို ပြင်ဆင်ပေးသော method။
+*   **`collate_fn` Argument**: `DataLoader` သို့မဟုတ် `prepare_tf_dataset()` တွင် data samples များကို batch တစ်ခုအဖြစ် စုစည်းရန် အသုံးပြုသော function။
+*   **`shuffle=True/False`**: dataset ကို training အတွက် ရောနှောခြင်းရှိမရှိ သတ်မှတ်ခြင်း။
+*   **`batch_size`**: training သို့မဟုတ် evaluation လုပ်ငန်းစဉ်တစ်ခုစီတွင် model သို့ ပေးပို့သော input samples အရေအတွက်။
+*   **BLEU Score (Bilingual Evaluation Understudy)**: ဘာသာပြန်ထားသော စာသားတစ်ခု၏ အရည်အသွေးကို တိုင်းတာရန် အသုံးပြုသော metric။
+*   **`evaluate.load("sacrebleu")`**: `sacrebleu` metric ကို load လုပ်ရန် evaluate library မှ function။
+*   **`metric.compute()` Method**: metric object ဖြင့် predictions များနှင့် references များအပေါ် အခြေခံ၍ score ကို တွက်ချက်သော method။
+*   **`tokenizer.batch_decode()` Method**: token IDs များကို စာသားများအဖြစ် ပြန်လည်ပြောင်းလဲရန် အသုံးပြုသော tokenizer method။
+*   **`-100`**: Padding values များ loss computation တွင် လျစ်လျူရှုခံရစေရန် labels တွင် အသုံးပြုသော special value။
+*   **XLA (Accelerated Linear Algebra)**: TensorFlow ၏ accelerated linear algebra compiler ဖြစ်ပြီး model computation graph များကို optimizations လုပ်ဆောင်၍ speed နှင့် memory usage ကို တိုးတက်စေသည်။
+*   **`@tf.function(jit_compile=True)` Decorator**: TensorFlow function တစ်ခုကို XLA ဖြင့် JIT (Just-In-Time) compile လုပ်ရန် မှတ်သားပေးသော decorator။
+*   **`tqdm`**: Python library တစ်ခုဖြစ်ပြီး loops များအတွက် progress bars များကို ဖန်တီးပေးသည်။
+*   **`model.generate()` Method**: model မှ text sequence အသစ်များကို ထုတ်လုပ်ရန်အတွက် method။
+*   **`decoded_preds`**: model မှ ထုတ်ပေးပြီး decode လုပ်ထားသော predictions များ။
+*   **`decoded_labels`**: decode လုပ်ထားသော အမှန်တကယ် labels များ။
+*   **`strip()` Method**: string တစ်ခု၏ အစ သို့မဟုတ် အဆုံးရှိ whitespace များကို ဖယ်ရှားသော Python string method။
+*   **`notebook_login()`**: Jupyter/Colab Notebooks များတွင် Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော function။
+*   **`huggingface-cli login`**: Hugging Face CLI (Command Line Interface) မှ Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော command။
+*   **GPUT (Graphics Processing Unit)**: ဂရပ်ဖစ်လုပ်ဆောင်မှုအတွက် အထူးဒီဇိုင်းထုတ်ထားသော processor တစ်မျိုးဖြစ်သော်လည်း AI/ML လုပ်ငန်းများတွင် အရှိန်မြှင့်ရန် အသုံးများသည်။
+*   **`create_optimizer()` Function**: Hugging Face Transformers library မှ optimizer နှင့် learning rate scheduler ကို ဖန်တီးပေးသော function။
+*   **`PushToHubCallback`**: Keras models များအတွက် training လုပ်နေစဉ်အတွင်း model ကို Hugging Face Hub သို့ upload လုပ်ရန် ကူညီပေးသော callback။
+*   **`model.compile()` Method**: Keras model ကို training အတွက် ပြင်ဆင်သော method (optimizer, loss function, metrics သတ်မှတ်ခြင်း)။
+*   **`model.fit()` Method**: Keras model ကို training data ဖြင့် လေ့ကျင့်သော method။
+*   **`validation_data`**: training လုပ်နေစဉ်အတွင်း model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် အသုံးပြုသော validation dataset။
+*   **`Seq2SeqTrainingArguments`**: Hugging Face Transformers library မှ sequence-to-sequence models များအတွက် training arguments များကို သတ်မှတ်သော class။
+*   **`evaluation_strategy="no"`**: evaluation ကို မလုပ်ဆောင်ရန် သတ်မှတ်ခြင်း။
+*   **`save_strategy="epoch"`**: model ကို epoch တိုင်း သိမ်းဆည်းရန် သတ်မှတ်ခြင်း။
+*   **`learning_rate`**: training လုပ်ငန်းစဉ်အတွင်း model ၏ parameters များကို မည်မျှပြောင်းလဲရမည်ကို ထိန်းချုပ်သော hyperparameter။
+*   **`per_device_train_batch_size`**: GPU/TPU တစ်ခုစီအတွက် training batch size။
+*   **`per_device_eval_batch_size`**: GPU/TPU တစ်ခုစီအတွက် evaluation batch size။
+*   **`weight_decay`**: overfitting ကို လျှော့ချရန်အတွက် regularization technique တစ်ခု။
+*   **`save_total_limit`**: သိမ်းဆည်းထားမည့် model checkpoints အရေအတွက်ကို ကန့်သတ်ခြင်း။
+*   **`num_train_epochs`**: model ကို training dataset တစ်ခုလုံးဖြင့် လေ့ကျင့်မည့် အကြိမ်အရေအတွက်။
+*   **`fp16=True`**: Float16 precision ဖြင့် training လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`push_to_hub=True`**: training ပြီးဆုံးပြီးနောက် model ကို Hugging Face Hub သို့ အလိုအလျောက် upload လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`hub_model_id` Argument**: `Seq2SeqTrainingArguments` တွင် Hugging Face Hub ပေါ်ရှိ model repository ၏ အမည်ကို သတ်မှတ်ရန် အသုံးပြုသော argument။
+*   **Namespace**: Hugging Face Hub တွင် သုံးစွဲသူအကောင့် သို့မဟုတ် organization အမည်။
+*   **Output Directory**: model, tokenizer နှင့် training logs များကို သိမ်းဆည်းမည့် local folder။
+*   **`Seq2SeqTrainer`**: Hugging Face Transformers library မှ sequence-to-sequence models များကို လေ့ကျင့်ရန်အတွက် အထူးပြု Trainer subclass။
+*   **`trainer.evaluate()` Method**: `Trainer` object ဖြင့် model ၏ စွမ်းဆောင်ရည်ကို evaluation dataset ပေါ်တွင် အကဲဖြတ်သော method။
+*   **`max_length`**: sequence များ၏ အမြင့်ဆုံးအရှည်။
+*   **`eval_loss`**: Evaluation dataset ပေါ်တွင် model ၏ loss တန်ဖိုး။
+*   **`eval_bleu`**: Evaluation dataset ပေါ်တွင် model ၏ BLEU score။
+*   **`eval_runtime`**: Evaluation လုပ်ဆောင်ရန် ကြာမြင့်သော အချိန်။
+*   **`eval_samples_per_second`**: Evaluation လုပ်နေစဉ် တစ်စက္ကန့်လျှင် လုပ်ဆောင်သော samples အရေအတွက်။
+*   **`eval_steps_per_second`**: Evaluation လုပ်နေစဉ် တစ်စက္ကန့်လျှင် လုပ်ဆောင်သော steps အရေအတွက်။
+*   **`epoch`**: Model ကို training dataset တစ်ခုလုံးဖြင့် လေ့ကျင့်သည့် အကြိမ်အရေအတွက်။
+*   **`trainer.train()` Method**: `Trainer` object ဖြင့် model ကို train လုပ်သော method။
+*   **`trainer.push_to_hub()` Method**: `Trainer` object ဖြင့် model ကို Hugging Face Hub သို့ upload လုပ်သော method။
+*   **`tags="translation"`**: Model card တွင် translation task အတွက် tag ကို ထည့်သွင်းခြင်း။
+*   **`commit_message`**: Git commit အတွက် မက်ဆေ့ချ်။
+*   **URL**: web ပေါ်ရှိ အရင်းအမြစ်တစ်ခု၏ လိပ်စာ။
+*   **Custom Training Loop**: `Trainer` API ကို အသုံးပြုမည့်အစား developer ကိုယ်တိုင် အသေးစိတ် ထိန်းချုပ်နိုင်သော training loop။
+*   **`DataLoader`**: Dataset ကနေ data တွေကို batch အလိုက် load လုပ်ပေးတဲ့ PyTorch utility class။
+*   **`tokenized_datasets.set_format("torch")`**: dataset ၏ output format ကို PyTorch tensors အဖြစ် သတ်မှတ်ခြင်း။
+*   **PyTorch Tensors**: PyTorch framework မှာ data တွေကို ကိုယ်စားပြုသော multi-dimensional array များ။
+*   **`AdamW`**: PyTorch မှာ အသုံးပြုတဲ့ AdamW optimizer။
+*   **`model.parameters()`**: model ၏ လေ့ကျင့်နိုင်သော parameters များကို ပြန်ပေးသော method။
+*   **`Accelerator`**: Hugging Face Accelerate library မှ distributed training (multiple GPUs, TPUs) ကို လွယ်ကူစေသော class။
+*   **`accelerator.prepare()` Method**: models, optimizers, dataloaders များကို distributed training အတွက် ပြင်ဆင်ပေးသော method။
+*   **TPUs (Tensor Processing Units)**: Google မှ AI/ML workloads များအတွက် အထူးဒီဇိုင်းထုတ်ထားသော processor တစ်မျိုး။
+*   **`get_scheduler()` Function**: Hugging Face Transformers library မှ learning rate scheduler ကို ရယူသော function။
+*   **`num_warmup_steps`**: learning rate ကို ဖြည်းဖြည်းချင်း တိုးမြှင့်မည့် training steps အရေအတွက်။
+*   **`num_training_steps`**: စုစုပေါင်း training steps အရေအတွက်။
+*   **`lr_scheduler`**: learning rate ကို training လုပ်နေစဉ်အတွင်း ပြောင်းလဲပေးသော scheduler။
+*   **`Repository` Object**: `huggingface_hub` library မှ Git repository များကို ကိုင်တွယ်ရန်အတွက် object။
+*   **Working Folder**: project files များကို သိမ်းဆည်းထားသော directory။
+*   **`get_full_repo_name()` Function**: Hugging Face Hub repository ၏ နာမည်အပြည့်အစုံကို ပြန်ပေးသော function (username ပါဝင်သည်)။
+*   **`repo.push_to_hub()` Method**: `Repository` object ဖြင့် Git repository ကို Hugging Face Hub သို့ push လုပ်သော method။
+*   **`commit_message`**: Git commit အတွက် မက်ဆေ့ချ်။
+*   **`blocking=False`**: `push_to_hub()` method ကို non-blocking mode ဖြင့် လုပ်ဆောင်စေပြီး code execution ကို ဆက်လက်လုပ်ဆောင်စေသည်။
+*   **`tqdm.auto`**: `tqdm` library ၏ auto-detection version။
+*   **`torch.no_grad()`**: PyTorch တွင် gradient computation ကို disable လုပ်ရန်အတွက် context manager။
+*   **`accelerator.unwrap_model(model).generate()`**: `Accelerator` ဖြင့် wrap လုပ်ထားသော model မှ underlying base model ကို ရယူပြီး `generate()` method ကို ခေါ်ခြင်း။
+*   **`accelerator.pad_across_processes()`**: Distributed training တွင် မတူညီသော processes များမှ tensors များကို တူညီသော shape ဖြစ်အောင် padding လုပ်ပေးသော method။
+*   **`dim=1`**: padding လုပ်မည့် dimension ကို သတ်မှတ်ခြင်း။
+*   **`pad_index`**: padding လုပ်ရန် အသုံးပြုမည့် index (တန်ဖိုး)။
+*   **`accelerator.gather()`**: Distributed training တွင် မတူညီသော processes များမှ tensors များကို စုစည်းပေးသော method။
+*   **`metric.add_batch()` Method**: metric object တွင် predictions များနှင့် references များကို batch အလိုက် ထည့်သွင်းသော method။
+*   **`accelerator.wait_for_everyone()`**: Distributed training တွင် processes အားလုံး အလုပ်ပြီးဆုံးရန် စောင့်ဆိုင်းသော method။
+*   **`unwrapped_model.save_pretrained()`**: pretrained model ကို local folder သို့ သိမ်းဆည်းသော method။
+*   **`save_function=accelerator.save`**: Distributed training တွင် model ကို သိမ်းဆည်းရန်အတွက် `accelerator.save` ကို အသုံးပြုရန် သတ်မှတ်ခြင်း။
+*   **`accelerator.is_main_process`**: လက်ရှိ process သည် main process ဖြစ်ခြင်းရှိမရှိ စစ်ဆေးသော property။
+*   **`tokenizer.save_pretrained()`**: tokenizer ကို local folder သို့ သိမ်းဆည်းသော method။
+*   **Domain Adaptation**: Model တစ်ခုကို မူရင်း train လုပ်ခဲ့သော domain မှ ကွဲပြားခြားနားသော domain အသစ်တစ်ခုတွင် ကောင်းမွန်စွာ စွမ်းဆောင်နိုင်စေရန် ချိန်ညှိခြင်း။

--- a/chapters/my/chapter7/5.mdx
+++ b/chapters/my/chapter7/5.mdx
@@ -1,0 +1,1315 @@
+<FrameworkSwitchCourse {fw} />
+
+# အနှစ်ချုပ်ဖော်ပြခြင်း (Summarization)[[summarization]]
+
+{#if fw === 'pt'}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section5_pt.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section5_pt.ipynb"},
+]} />
+
+{:else}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section5_tf.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section5_tf.ipynb"},
+]} />
+
+{/if}
+
+ဒီအပိုင်းမှာ Transformer models တွေကို ရှည်လျားတဲ့ document တွေကို အနှစ်ချုပ်အဖြစ် condensing (သိပ်သည်းအောင် ချုံ့) လုပ်ရာမှာ ဘယ်လိုအသုံးပြုနိုင်လဲဆိုတာ ကြည့်သွားပါမယ်။ ဒီလုပ်ငန်းကို _text summarization_ လို့ သိကြပါတယ်။ ဒါက NLP tasks တွေထဲမှာ အခက်ခဲဆုံးတစ်ခုပါ၊ ဘာလို့လဲဆိုတော့ ရှည်လျားတဲ့ စာပိုဒ်တွေကို နားလည်ခြင်းနဲ့ document တစ်ခုရဲ့ အဓိက ခေါင်းစဉ်တွေကို ဖော်ပြတဲ့ ကိုက်ညီတဲ့ စာသားကို ထုတ်လုပ်ခြင်းလို စွမ်းရည်မျိုးစုံ လိုအပ်လို့ပါပဲ။ သို့သော်လည်း၊ ကောင်းကောင်းလုပ်ဆောင်နိုင်ရင် text summarization ဟာ domain expert တွေရဲ့ ရှည်လျားတဲ့ document တွေကို အသေးစိတ်ဖတ်ရမယ့် ဝန်ထုပ်ဝန်ပိုးကို လျှော့ချခြင်းဖြင့် လုပ်ငန်းလုပ်ဆောင်မှု အမျိုးမျိုးကို အရှိန်မြှင့်တင်ပေးနိုင်တဲ့ အစွမ်းထက်တဲ့ ကိရိယာတစ်ခု ဖြစ်ပါတယ်။
+
+<Youtube id="yHnr5Dk2zCI"/>
+
+[Hugging Face Hub](https://huggingface.co/models?pipeline_tag=summarization&sort=downloads) ပေါ်မှာ summarization အတွက် fine-tuned models အမျိုးမျိုး ရှိနေပေမယ့်၊ ဒီ models တွေအားလုံးနီးပါးဟာ English documents တွေအတွက်ပဲ သင့်လျော်ပါတယ်။ ဒါကြောင့်၊ ဒီအပိုင်းမှာ ဆန်းသစ်မှုတစ်ခုအနေနဲ့၊ English နဲ့ Spanish အတွက် bilingual model တစ်ခုကို ကျွန်တော်တို့ train လုပ်ပါမယ်။ ဒီအပိုင်းရဲ့ အဆုံးမှာ၊ ဒီနေရာမှာ ပြသထားတဲ့အတိုင်း customer review တွေကို အနှစ်ချုပ်နိုင်တဲ့ [model](https://huggingface.co/huggingface-course/mt5-small-finetuned-amazon-en-es) တစ်ခုကို သင်ရရှိပါလိမ့်မယ်။
+
+<iframe src="https://course-demos-mt5-small-finetuned-amazon-en-es.hf.space" frameBorder="0" height="400" title="Gradio app" class="block dark:hidden container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
+
+ကျွန်တော်တို့ တွေ့မြင်ရမယ့်အတိုင်း၊ ဒီအနှစ်ချုပ်တွေက တိုတောင်းပါတယ်။ ဘာလို့လဲဆိုတော့ ၎င်းတို့ကို customer တွေရဲ့ product reviews တွေမှာ ပေးထားတဲ့ titles တွေကနေ သင်ယူထားလို့ပါပဲ။ ဒီ task အတွက် သင့်လျော်တဲ့ bilingual corpus တစ်ခုကို စုစည်းခြင်းဖြင့် စတင်ကြရအောင်။
+
+## Multilingual Corpus တစ်ခုကို ပြင်ဆင်ခြင်း[[preparing-a-multilingual-corpus]]
+
+ကျွန်တော်တို့ရဲ့ bilingual summarizer ကို ဖန်တီးဖို့ [Multilingual Amazon Reviews Corpus](https://huggingface.co/datasets/amazon_reviews_multi) ကို အသုံးပြုပါမယ်။ ဒီ corpus ဟာ ဘာသာစကား ၆ မျိုးနဲ့ Amazon product reviews တွေ ပါဝင်ပြီး multilingual classifiers တွေကို benchmark လုပ်ဖို့အတွက် ပုံမှန်အားဖြင့် အသုံးပြုပါတယ်။ ဒါပေမယ့် review တစ်ခုစီမှာ short title တစ်ခု ပါဝင်တာကြောင့်၊ ကျွန်တော်တို့ရဲ့ model ကနေ သင်ယူဖို့အတွက် titles တွေကို target summaries အဖြစ် အသုံးပြုနိုင်ပါတယ်! စတင်ဖို့ Hugging Face Hub ကနေ English နဲ့ Spanish subsets တွေကို download လုပ်ရအောင်။
+
+```python
+from datasets import load_dataset
+
+spanish_dataset = load_dataset("amazon_reviews_multi", "es")
+english_dataset = load_dataset("amazon_reviews_multi", "en")
+english_dataset
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['review_id', 'product_id', 'reviewer_id', 'stars', 'review_body', 'review_title', 'language', 'product_category'],
+        num_rows: 200000
+    })
+    validation: Dataset({
+        features: ['review_id', 'product_id', 'reviewer_id', 'stars', 'review_body', 'review_title', 'language', 'product_category'],
+        num_rows: 5000
+    })
+    test: Dataset({
+        features: ['review_id', 'product_id', 'reviewer_id', 'stars', 'review_body', 'review_title', 'language', 'product_category'],
+        num_rows: 5000
+    })
+})
+```
+
+သင်မြင်ရတဲ့အတိုင်း၊ ဘာသာစကားတစ်ခုစီအတွက် `train` split မှာ review ၂၀၀,၀၀၀ ရှိပြီး `validation` နဲ့ `test` splits တစ်ခုစီအတွက် review ၅,၀၀၀ စီ ရှိပါတယ်။ ကျွန်တော်တို့ စိတ်ဝင်စားတဲ့ review အချက်အလက်တွေက `review_body` နဲ့ `review_title` columns တွေမှာ ပါဝင်ပါတယ်။ [Chapter 5](/course/chapter5) မှာ သင်ယူခဲ့တဲ့ နည်းလမ်းတွေနဲ့ training set ကနေ random sample တစ်ခုကို ယူတဲ့ ရိုးရှင်းတဲ့ function တစ်ခုကို ဖန်တီးပြီး ဥပမာအချို့ကို ကြည့်ရအောင်။
+
+```python
+def show_samples(dataset, num_samples=3, seed=42):
+    sample = dataset["train"].shuffle(seed=seed).select(range(num_samples))
+    for example in sample:
+        print(f"\n'>> Title: {example['review_title']}'")
+        print(f"'>> Review: {example['review_body']}'")
+
+
+show_samples(english_dataset)
+```
+
+```python out
+'>> Title: Worked in front position, not rear'
+'>> Review: 3 stars because these are not rear brakes as stated in the item description. At least the mount adapter only worked on the front fork of the bike that I got it for.'
+
+'>> Title: meh'
+'>> Review: Does it’s job and it’s gorgeous but mine is falling apart, I had to basically put it together again with hot glue'
+
+'>> Title: Can\'t beat these for the money'
+'>> Review: Bought this for handling miscellaneous aircraft parts and hanger "stuff" that I needed to organize; it really fit the bill. The unit arrived quickly, was well packaged and arrived intact (always a good sign). There are five wall mounts-- three on the top and two on the bottom. I wanted to mount it on the wall, so all I had to do was to remove the top two layers of plastic drawers, as well as the bottom corner drawers, place it when I wanted and mark it; I then used some of the new plastic screw in wall anchors (the 50 pound variety) and it easily mounted to the wall. Some have remarked that they wanted dividers for the drawers, and that they made those. Good idea. My application was that I needed something that I can see the contents at about eye level, so I wanted the fuller-sized drawers. I also like that these are the new plastic that doesn\'t get brittle and split like my older plastic drawers did. I like the all-plastic construction. It\'s heavy duty enough to hold metal parts, but being made of plastic it\'s not as heavy as a metal frame, so you can easily mount it to the wall and still load it up with heavy stuff, or light stuff. No problem there. For the money, you can\'t beat it. Best one of these I\'ve bought to date-- and I\'ve been using some version of these for over forty years.'
+```
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** `Dataset.shuffle()` command မှာ random seed ကို ပြောင်းလဲခြင်းဖြင့် corpus ထဲက အခြား reviews တွေကို လေ့လာကြည့်ပါ။ သင်က Spanish စကားပြောသူဖြစ်တယ်ဆိုရင်၊ `spanish_dataset` ထဲက reviews အချို့ကို ကြည့်ပြီး titles တွေကလည်း သင့်လျော်တဲ့ summaries တွေလို ဖြစ်နေလားဆိုတာ ကြည့်ပါ။
+
+ဒီ sample က online မှာ ပုံမှန်တွေ့ရတဲ့ reviews အမျိုးမျိုးကို ပြသပါတယ်။ positive ကနေ negative အထိ (ပြီးတော့ နှစ်ခုကြားက အားလုံး) ပါဝင်ပါတယ်။ "meh" title ပါတဲ့ ဥပမာက သိပ်အသုံးဝင်တာ မဟုတ်ပေမယ့်၊ ကျန်တဲ့ titles တွေက reviews တွေရဲ့ ကောင်းမွန်တဲ့ summaries တွေလို ဖြစ်နေပါတယ်။ review ၄၀၀,၀၀၀ လုံးပေါ်မှာ summarization model တစ်ခုကို train လုပ်တာက single GPU တစ်ခုတည်းနဲ့ အချိန်အကြာကြီး ယူရမှာဖြစ်တာကြောင့်၊ ကျွန်တော်တို့က ထုတ်ကုန် domain တစ်ခုတည်းအတွက် summaries တွေ ထုတ်လုပ်တာကိုပဲ အာရုံစိုက်ပါမယ်။ ဘယ် domain တွေကို ရွေးချယ်နိုင်မလဲဆိုတာ သိရှိနိုင်ဖို့ `english_dataset` ကို `pandas.DataFrame` သို့ ပြောင်းပြီး product category တစ်ခုစီအတွက် reviews အရေအတွက်ကို တွက်ချက်ကြည့်ရအောင်။
+
+```python
+english_dataset.set_format("pandas")
+english_df = english_dataset["train"][:]
+# ထိပ်ဆုံးထုတ်ကုန် ၂၀ အတွက် အရေအတွက်များကို ပြသသည်
+english_df["product_category"].value_counts()[:20]
+```
+
+```python out
+home                      17679
+apparel                   15951
+wireless                  15717
+other                     13418
+beauty                    12091
+drugstore                 11730
+kitchen                   10382
+toy                        8745
+sports                     8277
+automotive                 7506
+lawn_and_garden            7327
+home_improvement           7136
+pet_products               7082
+digital_ebook_purchase     6749
+pc                         6401
+electronics                6186
+office_product             5521
+shoes                      5197
+grocery                    4730
+book                       3756
+Name: product_category, dtype: int64
+```
+
+English dataset မှာ လူကြိုက်အများဆုံး ထုတ်ကုန်တွေက အိမ်သုံးပစ္စည်းတွေ၊ အဝတ်အထည်တွေနဲ့ wireless electronics တွေ ဖြစ်ပါတယ်။ Amazon theme နဲ့ ဆက်သွားဖို့၊ book reviews တွေကို အနှစ်ချုပ်တာကိုပဲ အာရုံစိုက်ကြရအောင် -- ဘာပဲဖြစ်ဖြစ်၊ ဒါက ကုမ္ပဏီတည်ထောင်ခဲ့တာပါပဲ! ဒီအတွက် သင့်လျော်တဲ့ product categories နှစ်ခု (`book` နဲ့ `digital_ebook_purchase`) ကို ကျွန်တော်တို့ တွေ့ရပါတယ်။ ဒါကြောင့် ဘာသာစကားနှစ်မျိုးလုံးရှိ datasets တွေကနေ ဒီထုတ်ကုန်တွေအတွက်ပဲ filter လုပ်ရအောင်။ [Chapter 5](/course/chapter5) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့အတိုင်း၊ `Dataset.filter()` function က dataset တစ်ခုကို အလွန်ထိရောက်စွာ slice လုပ်နိုင်တာကြောင့်၊ ဒါကိုလုပ်ဖို့ ရိုးရှင်းတဲ့ function တစ်ခုကို ကျွန်တော်တို့ သတ်မှတ်နိုင်ပါတယ်။
+
+```python
+def filter_books(example):
+    return (
+        example["product_category"] == "book"
+        or example["product_category"] == "digital_ebook_purchase"
+    )
+```
+
+အခု ဒီ function ကို `english_dataset` နဲ့ `spanish_dataset` တွေပေါ်မှာ အသုံးပြုတဲ့အခါ၊ ရလဒ်မှာ book categories နဲ့ သက်ဆိုင်တဲ့ rows တွေသာ ပါဝင်ပါလိမ့်မယ်။ filter ကို အသုံးမပြုခင်၊ `english_dataset` ရဲ့ format ကို `"pandas"` ကနေ `"arrow"` ကို ပြန်ပြောင်းရအောင်။
+
+```python
+english_dataset.reset_format()
+```
+
+ပြီးရင် filter function ကို အသုံးပြုနိုင်ပြီး၊ sanity check တစ်ခုအနေနဲ့ reviews တွေရဲ့ sample တစ်ခုကို ကြည့်ပြီး ဒါတွေက စာအုပ်တွေနဲ့ ပတ်သက်တာ ဟုတ်မဟုတ် စစ်ဆေးကြည့်ရအောင်။
+
+```python
+spanish_books = spanish_dataset.filter(filter_books)
+english_books = english_dataset.filter(filter_books)
+show_samples(english_books)
+```
+
+```python out
+'>> Title: I\'m dissapointed.'
+'>> Review: I guess I had higher expectations for this book from the reviews. I really thought I\'d at least like it. The plot idea was great. I loved Ash but, it just didnt go anywhere. Most of the book was about their radio show and talking to callers. I wanted the author to dig deeper so we could really get to know the characters. All we know about Grace is that she is attractive looking, Latino and is kind of a brat. I\'m dissapointed.'
+
+'>> Title: Good art, good price, poor design'
+'>> Review: I had gotten the DC Vintage calendar the past two years, but it was on backorder forever this year and I saw they had shrunk the dimensions for no good reason. This one has good art choices but the design has the fold going through the picture, so it\'s less aesthetically pleasing, especially if you want to keep a picture to hang. For the price, a good calendar'
+
+'>> Title: Helpful'
+'>> Review: Nearly all the tips useful and. I consider myself an intermediate to advanced user of OneNote. I would highly recommend.'
+```
+
+ကောင်းပါပြီ၊ reviews တွေဟာ စာအုပ်တွေနဲ့ တိတိကျကျ ပတ်သက်တာ မဟုတ်ဘဲ calendars တွေနဲ့ OneNote လို electronic applications တွေလို အရာတွေကို ရည်ညွှန်းနိုင်တာကို ကျွန်တော်တို့ တွေ့ရပါတယ်။ သို့သော်လည်း၊ domain က summarization model တစ်ခုကို train လုပ်ဖို့အတွက် သင့်တော်ပုံရပါတယ်။ ဒီ task အတွက် သင့်လျော်တဲ့ models အမျိုးမျိုးကို မကြည့်ခင်၊ ကျွန်တော်တို့မှာ နောက်ဆုံး data preparation အနည်းငယ် လုပ်စရာရှိပါသေးတယ်၊ English နဲ့ Spanish reviews တွေကို single `DatasetDict` object အဖြစ် ပေါင်းစပ်တာပါ။ 🤗 Datasets က အသုံးဝင်တဲ့ `concatenate_datasets()` function တစ်ခုကို ပံ့ပိုးပေးပြီး (နာမည်က ဖော်ပြထားတဲ့အတိုင်း) `Dataset` objects နှစ်ခုကို တစ်ခုပေါ်တစ်ခု ထပ်ပေးပါလိမ့်မယ်။ ဒါကြောင့်၊ ကျွန်တော်တို့ရဲ့ bilingual dataset ကို ဖန်တီးဖို့၊ split တစ်ခုစီကို loop လုပ်ပြီး၊ အဲဒီ split အတွက် datasets တွေကို concatenate လုပ်ကာ၊ model က ဘာသာစကားတစ်ခုတည်းကို overfit မဖြစ်စေဖို့ ရလဒ်ကို shuffle လုပ်ပါမယ်။
+
+```python
+from datasets import concatenate_datasets, DatasetDict
+
+books_dataset = DatasetDict()
+
+for split in english_books.keys():
+    books_dataset[split] = concatenate_datasets(
+        [english_books[split], spanish_books[split]]
+    )
+    books_dataset[split] = books_dataset[split].shuffle(seed=42)
+
+# ဥပမာအချို့ကို ကြည့်ရှုပါ
+show_samples(books_dataset)
+```
+
+```python out
+'>> Title: Easy to follow!!!!'
+'>> Review: I loved The dash diet weight loss Solution. Never hungry. I would recommend this diet. Also the menus are well rounded. Try it. Has lots of the information need thanks.'
+
+'>> Title: PARCIALMENTE DAÑADO'
+'>> Review: Me llegó el día que tocaba, junto a otros libros que pedí, pero la caja llegó en mal estado lo cual dañó las esquinas de los libros porque venían sin protección (forro).'
+
+'>> Title: no lo he podido descargar'
+'>> Review: igual que el anterior'
+```
+
+ဒါက English နဲ့ Spanish reviews တွေ ရောနှောထားတာ သေချာပါတယ်။ အခု training corpus တစ်ခုရပြီဆိုတော့၊ နောက်ဆုံးစစ်ဆေးရမယ့်အရာက reviews နဲ့ titles တွေထဲက စကားလုံးဖြန့်ဝေမှု (distribution) ပါပဲ။ ဒါက summarization tasks တွေအတွက် အထူးအရေးကြီးပါတယ်။ ဘာလို့လဲဆိုတော့ data ထဲက တိုတောင်းတဲ့ reference summaries တွေက model ကို generated summaries တွေမှာ စကားလုံးတစ်လုံး ဒါမှမဟုတ် နှစ်လုံးပဲ ထုတ်လုပ်အောင် ဘက်လိုက်စေနိုင်လို့ပါ။ အောက်ပါ plots တွေက word distributions တွေကို ပြသထားပြီး၊ titles တွေက စကားလုံး ၁ လုံး၊ ၂ လုံးလောက်ပဲ အလွန်အမင်း skewed ဖြစ်နေတာကို ကျွန်တော်တို့ တွေ့မြင်နိုင်ပါတယ်။
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/review-lengths.svg" alt="Word count distributions for the review titles and texts."/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/review-lengths-dark.svg" alt="Word count distributions for the review titles and texts."/>
+</div>
+
+ဒီပြဿနာကို ဖြေရှင်းဖို့၊ အလွန်တိုတောင်းတဲ့ titles တွေနဲ့ ဥပမာတွေကို ကျွန်တော်တို့ filter လုပ်ပါမယ်။ ဒါမှ ကျွန်တော်တို့ရဲ့ model က ပိုမိုစိတ်ဝင်စားစရာကောင်းတဲ့ summaries တွေ ထုတ်လုပ်နိုင်ပါလိမ့်မယ်။ English နဲ့ Spanish texts တွေနဲ့ အလုပ်လုပ်နေတာကြောင့်၊ titles တွေကို whitespace ပေါ်မှာ split လုပ်ဖို့ ကြမ်းတမ်းတဲ့ heuristic တစ်ခုကို အသုံးပြုနိုင်ပြီး၊ ကျွန်တော်တို့ရဲ့ ယုံကြည်ရတဲ့ `Dataset.filter()` method ကို အောက်ပါအတိုင်း အသုံးပြုနိုင်ပါတယ်။
+
+```python
+books_dataset = books_dataset.filter(lambda x: len(x["review_title"].split()) > 2)
+```
+
+ကျွန်တော်တို့ corpus ကို ပြင်ဆင်ပြီးပြီဆိုတော့၊ ဒီ task အတွက် သင့်လျော်တဲ့ Transformer models အချို့ကို ကြည့်ရအောင်။
+
+## Text Summarization အတွက် Models များ[[models-for-text-summarization]]
+
+သင်စဉ်းစားကြည့်မယ်ဆိုရင်၊ text summarization ဟာ machine translation နဲ့ ဆင်တူတဲ့ task တစ်ခုပါ- review တစ်ခုလို body of text တစ်ခုရှိပြီး၊ input ရဲ့ salient features တွေကို ဖော်ပြတဲ့ ပိုတိုတောင်းတဲ့ version တစ်ခုအဖြစ် "translate" လုပ်ချင်ပါတယ်။ ဒါကြောင့်၊ summarization အတွက် Transformer models အများစုက [Chapter 1](/course/chapter1) မှာ ကျွန်တော်တို့ ပထမဆုံး ကြုံတွေ့ခဲ့ရတဲ့ encoder-decoder architecture ကို အသုံးပြုကြပါတယ်။ သို့သော်လည်း၊ few-shot settings မှာ summarization အတွက် အသုံးပြုနိုင်တဲ့ GPT family of models လိုမျိုး ချွင်းချက်အချို့တော့ ရှိပါတယ်။ အောက်ပါဇယားက summarization အတွက် fine-tune လုပ်နိုင်တဲ့ ရေပန်းစားတဲ့ pretrained models အချို့ကို ဖော်ပြထားပါတယ်။
+
+| Transformer model | Description                                                                                                                                                                                                    | Multilingual? |
+| :---------: | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-----------: |
+|    [GPT-2](https://huggingface.co/gpt2-xl)    | auto-regressive language model အဖြစ် train ထားသော်လည်း၊ input text ရဲ့ အဆုံးမှာ "TL;DR" ကို ထည့်သွင်းခြင်းဖြင့် GPT-2 ကို summaries တွေ ထုတ်လုပ်စေနိုင်ပါတယ်။                                                                          |      ❌       |
+|   [PEGASUS](https://huggingface.co/google/pegasus-large)   | multi-sentence texts တွေထဲက masked sentences တွေကို ခန့်မှန်းဖို့ pretraining objective ကို အသုံးပြုပါတယ်။ ဒီ pretraining objective က vanilla language modeling ထက် summarization နဲ့ ပိုနီးစပ်ပြီး ရေပန်းစားတဲ့ benchmarks တွေမှာ မြင့်မားတဲ့ score ရရှိပါတယ်။ |      ❌       |
+|     [T5](https://huggingface.co/t5-base)      | NLP tasks အားလုံးကို text-to-text framework မှာ ပုံဖော်ပေးတဲ့ universal Transformer architecture; ဥပမာ- document တစ်ခုကို summarize လုပ်ဖို့ model အတွက် input format က `summarize: ARTICLE` ဖြစ်ပါတယ်။                              |      ❌       |
+|     [mT5](https://huggingface.co/google/mt5-base)     | T5 ရဲ့ multilingual version တစ်ခုဖြစ်ပြီး multilingual Common Crawl corpus (mC4) ပေါ်မှာ pretrained လုပ်ထားကာ ဘာသာစကား ၁၀၁ မျိုး ပါဝင်ပါတယ်။                                                                                                |      ✅       |
+|    [BART](https://huggingface.co/facebook/bart-base)     | encoder နဲ့ decoder stack နှစ်ခုလုံးပါဝင်ပြီး BERT နဲ့ GPT-2 ရဲ့ pretraining schemes တွေကို ပေါင်းစပ်ထားတဲ့ corrupted input ကို reconstruct လုပ်ဖို့ train ထားတဲ့ novel Transformer architecture။                                    |      ❌       |
+|  [mBART-50](https://huggingface.co/facebook/mbart-large-50)   | BART ရဲ့ multilingual version တစ်ခုဖြစ်ပြီး ဘာသာစကား ၅၀ ပေါ်မှာ pretrained လုပ်ထားပါတယ်။                                                                                                                                                     |      ✅       |
+
+ဒီဇယားကနေ သင်မြင်ရတဲ့အတိုင်း၊ summarization အတွက် Transformer models အများစု (ပြီးတော့ NLP tasks အများစု) ဟာ monolingual ဖြစ်ပါတယ်။ ဒါက English ဒါမှမဟုတ် German လို "high-resource" language တစ်ခုမှာ သင့် task ရှိမယ်ဆိုရင် ကောင်းပါတယ်၊ ဒါပေမယ့် ကမ္ဘာတစ်ဝှမ်းလုံးမှာ အသုံးပြုနေတဲ့ ထောင်နဲ့ချီတဲ့ အခြားဘာသာစကားတွေအတွက်တော့ မကောင်းပါဘူး။ ကံကောင်းစွာနဲ့ပဲ၊ mT5 နဲ့ mBART လိုမျိုး multilingual Transformer models တွေရှိပြီး ဒါတွေက ကူညီကယ်တင်ပေးပါတယ်။ ဒီ models တွေကို language modeling ကို အသုံးပြုပြီး pretrained လုပ်ထားပေမယ့်၊ ကွဲပြားမှုတစ်ခုတော့ ရှိပါတယ်၊ ဘာသာစကားတစ်ခုတည်းရဲ့ corpus ပေါ်မှာ train လုပ်မယ့်အစား၊ ဘာသာစကား ၅၀ ကျော်ရှိတဲ့ texts တွေပေါ်မှာ တစ်ပြိုင်နက်တည်း train လုပ်ထားတာပါ!
+
+ကျွန်တော်တို့ mT5 ကို အာရုံစိုက်ပါမယ်။ T5 ပေါ်မှာ အခြေခံထားတဲ့ စိတ်ဝင်စားစရာ architecture တစ်ခုဖြစ်ပြီး text-to-text framework မှာ pretrained လုပ်ထားပါတယ်။ T5 မှာ၊ NLP task တိုင်းကို `summarize:` လိုမျိုး prompt prefix တစ်ခုရဲ့ ပုံစံနဲ့ ဖော်ပြထားပါတယ်။ ဒါက generated text ကို prompt နဲ့ လိုက်လျောညီထွေဖြစ်အောင် model ကို အခြေအနေပေးပါတယ်။ အောက်ပါပုံမှာ ပြသထားတဲ့အတိုင်း၊ ဒါက T5 ကို အလွန်အမင်း versatility ရှိစေပြီး၊ single model တစ်ခုတည်းနဲ့ tasks များစွာကို ဖြေရှင်းနိုင်ပါတယ်!
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/t5.svg" alt="Different tasks performed by the T5 architecture."/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/t5-dark.svg" alt="Different tasks performed by the T5 architecture."/>
+</div>
+
+mT5 က prefixes တွေကို အသုံးမပြုပေမယ့်၊ T5 ရဲ့ versatility အများစုကို မျှဝေထားပြီး multilingual ဖြစ်တဲ့ အားသာချက်ရှိပါတယ်။ အခု model တစ်ခုကို ရွေးချယ်ပြီးပြီဆိုတော့၊ training အတွက် ကျွန်တော်တို့ရဲ့ data ကို ပြင်ဆင်တာကို ကြည့်ရအောင်။
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** ဒီအပိုင်းကို ပြီးအောင်လုပ်ပြီးတာနဲ့၊ mT5 က mBART နဲ့ ဘယ်လောက်ကွာလဲဆိုတာကို mBART ကို တူညီတဲ့ နည်းလမ်းတွေနဲ့ fine-tuning လုပ်ပြီး ကြည့်ပါ။ bonus အမှတ်များအတွက်၊ English reviews တွေပေါ်မှာ T5 ကို fine-tuning လုပ်ကြည့်နိုင်ပါတယ်။ T5 မှာ special prefix prompt ရှိတာကြောင့်၊ အောက်ပါ preprocessing steps တွေမှာ input examples တွေရဲ့ အရှေ့မှာ `summarize:` ကို ထည့်ဖို့ လိုပါလိမ့်မယ်။
+
+## Data များကို Preprocessing လုပ်ခြင်း[[preprocessing-the-data]]
+
+<Youtube id="1m7BerpSq8A"/>
+
+ကျွန်တော်တို့ရဲ့ နောက်ထပ် task က reviews တွေနဲ့ titles တွေကို tokenize လုပ်ပြီး encode လုပ်ဖို့ပါပဲ။ ပုံမှန်အတိုင်း၊ pretrained model checkpoint နဲ့ ဆက်စပ်နေတဲ့ tokenizer ကို load လုပ်ခြင်းဖြင့် စတင်ပါမယ်။ model ကို သင့်လျော်တဲ့ အချိန်ကာလတစ်ခုအတွင်း fine-tune လုပ်နိုင်ဖို့ `mt5-small` ကို checkpoint အဖြစ် အသုံးပြုပါမယ်။
+
+```python
+from transformers import AutoTokenizer
+
+model_checkpoint = "google/mt5-small"
+tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
+```
+
+> [!TIP]
+> 💡 သင်၏ NLP projects ရဲ့ အစောပိုင်းအဆင့်တွေမှာ၊ "small" models class တစ်ခုကို data sample သေးသေးလေးပေါ်မှာ train လုပ်တာက ကောင်းမွန်တဲ့ လုပ်ဆောင်မှုတစ်ခုပါ။ ဒါက end-to-end workflow တစ်ခုဆီကို ပိုမိုမြန်ဆန်စွာ debug လုပ်ပြီး iterate လုပ်နိုင်စေပါတယ်။ ရလဒ်တွေမှာ သင်ယုံကြည်မှုရှိပြီဆိုတာနဲ့၊ model checkpoint ကို ရိုးရှင်းစွာ ပြောင်းလဲခြင်းဖြင့် model ကို အမြဲတိုးချဲ့နိုင်ပါတယ်။
+
+mT5 tokenizer ကို ဥပမာသေးသေးလေးတစ်ခုပေါ်မှာ စမ်းသပ်ကြည့်ရအောင်။
+
+```python
+inputs = tokenizer("I loved reading the Hunger Games!")
+inputs
+```
+
+```python out
+{'input_ids': [336, 259, 28387, 11807, 287, 62893, 295, 12507, 1], 'attention_mask': [1, 1, 1, 1, 1, 1, 1, 1, 1]}
+```
+
+ဒီနေရာမှာ [Chapter 3](/course/chapter3) မှာ ကျွန်တော်တို့ရဲ့ ပထမဆုံး fine-tuning experiments တွေမှာ ကြုံတွေ့ခဲ့ရတဲ့ ရင်းနှီးတဲ့ `input_ids` နဲ့ `attention_mask` တွေကို ကျွန်တော်တို့ တွေ့မြင်နိုင်ပါတယ်။ ဒီ input IDs တွေကို tokenizer ရဲ့ `convert_ids_to_tokens()` function နဲ့ decode လုပ်ပြီး ဘယ်လို tokenizer အမျိုးအစားနဲ့ အလုပ်လုပ်နေလဲဆိုတာ ကြည့်ရအောင်။
+
+```python
+tokenizer.convert_ids_to_tokens(inputs.input_ids)
+```
+
+```python out
+[' I', ' ', 'loved', ' reading', ' the', ' Hung', 'er', ' Games', '</s>']
+```
+
+အထူး Unicode character ` ` နဲ့ end-of-sequence token `</s>` က ကျွန်တော်တို့ SentencePiece tokenizer နဲ့ အလုပ်လုပ်နေတာကို ဖော်ပြပါတယ်။ ဒါက [Chapter 6](/course/chapter6) မှာ ဆွေးနွေးခဲ့တဲ့ Unigram segmentation algorithm ပေါ် အခြေခံထားပါတယ်။ Unigram က multilingual corpora တွေအတွက် အထူးအသုံးဝင်ပါတယ်။ ဘာလို့လဲဆိုတော့ SentencePiece ကို accents တွေ၊ punctuation တွေနဲ့ Japanese လို ဘာသာစကားများစွာမှာ whitespace characters တွေ မပါဝင်ဘူးဆိုတဲ့ အချက်တွေနဲ့ ပတ်သက်ပြီး agnostic ဖြစ်စေလို့ပါ။
+
+ကျွန်တော်တို့ corpus ကို tokenize လုပ်ဖို့အတွက် summarization နဲ့ ဆက်စပ်နေတဲ့ သိမ်မွေ့မှုတစ်ခုကို ဖြေရှင်းရပါမယ်၊ ကျွန်တော်တို့ရဲ့ labels တွေကလည်း text ဖြစ်တာကြောင့်၊ ၎င်းတို့ဟာ model ရဲ့ maximum context size ကို ကျော်လွန်သွားနိုင်ပါတယ်။ ဒါက reviews တွေနဲ့ titles တွေ နှစ်ခုလုံးကို truncation လုပ်ဖို့ လိုအပ်တယ်လို့ ဆိုလိုပါတယ်။ ဒါမှ ကျွန်တော်တို့ model ကို အလွန်အမင်း ရှည်လျားတဲ့ inputs တွေ ပေးပို့တာကို ရှောင်ရှားနိုင်ပါလိမ့်မယ်။ 🤗 Transformers မှာရှိတဲ့ tokenizers တွေက input တွေနဲ့ ပြိုင်တူ labels တွေကို tokenize လုပ်နိုင်စေမယ့် အသုံးဝင်တဲ့ `text_target` argument ကို ပံ့ပိုးပေးပါတယ်။ mT5 အတွက် inputs နဲ့ targets တွေကို ဘယ်လိုလုပ်ဆောင်လဲဆိုတဲ့ ဥပမာတစ်ခုကတော့ ဒီမှာပါ။
+
+```python
+max_input_length = 512
+max_target_length = 30
+
+
+def preprocess_function(examples):
+    model_inputs = tokenizer(
+        examples["review_body"],
+        max_length=max_input_length,
+        truncation=True,
+    )
+    labels = tokenizer(
+        examples["review_title"], max_length=max_target_length, truncation=True
+    )
+    model_inputs["labels"] = labels["input_ids"]
+    return model_inputs
+```
+
+ဘာတွေဖြစ်နေလဲဆိုတာ နားလည်ဖို့ ဒီ code ကို ကြည့်ရအောင်။ ပထမဆုံး ကျွန်တော်တို့ လုပ်ခဲ့တာက `max_input_length` နဲ့ `max_target_length` အတွက် တန်ဖိုးတွေ သတ်မှတ်ခဲ့တာပါ။ ဒါတွေက ကျွန်တော်တို့ရဲ့ reviews တွေနဲ့ titles တွေ ဘယ်လောက်ရှည်နိုင်လဲဆိုတဲ့ အပေါ်ဆုံးကန့်သတ်ချက်တွေကို သတ်မှတ်ပါတယ်။ review body က title ထက် အများကြီး ပိုကြီးတာကြောင့်၊ ကျွန်တော်တို့ ဒီတန်ဖိုးတွေကို အချိုးကျ ပြောင်းလဲထားပါတယ်။
+
+`preprocess_function()` နဲ့ဆိုရင်၊ ဒီသင်တန်းတစ်လျှောက်လုံး ကျွန်တော်တို့ ကျယ်ကျယ်ပြန့်ပြန့် အသုံးပြုခဲ့တဲ့ အသုံးဝင်တဲ့ `Dataset.map()` function ကို အသုံးပြုပြီး corpus တစ်ခုလုံးကို tokenize လုပ်တာက ရိုးရှင်းတဲ့ ကိစ္စတစ်ခုပါ။
+
+```python
+tokenized_datasets = books_dataset.map(preprocess_function, batched=True)
+```
+
+အခု corpus ကို preprocessed လုပ်ပြီးပြီဆိုတော့၊ summarization အတွက် ပုံမှန်အသုံးပြုတဲ့ metrics အချို့ကို ကြည့်ရအောင်။ ကျွန်တော်တို့ တွေ့မြင်ရမယ့်အတိုင်း၊ machine-generated text ရဲ့ အရည်အသွေးကို တိုင်းတာရာမှာ မှော်ဆန်တဲ့ ဖြေရှင်းနည်းတစ်ခု မရှိပါဘူး။
+
+> [!TIP]
+> 💡 အပေါ်က `Dataset.map()` function မှာ `batched=True` ကို အသုံးပြုခဲ့တာကို သင်သတိထားမိပါလိမ့်မယ်။ ဒါက ဥပမာတွေကို batches of 1,000 (default) နဲ့ encode လုပ်ပြီး 🤗 Transformers မှာရှိတဲ့ fast tokenizers တွေရဲ့ multithreading စွမ်းရည်တွေကို အသုံးပြုနိုင်စေပါတယ်။ ဖြစ်နိုင်ရင်၊ သင့် preprocessing ကနေ အကောင်းဆုံးရရှိဖို့ `batched=True` ကို အသုံးပြုဖို့ ကြိုးစားပါ။
+
+## Text Summarization အတွက် Metrics များ[[metrics-for-text-summarization]]
+
+<Youtube id="TMshhnrEXlg"/>
+
+ဒီသင်တန်းမှာ ကျွန်တော်တို့ ဖော်ပြခဲ့တဲ့ အခြား tasks တွေနဲ့ နှိုင်းယှဉ်ရင်၊ summarization ဒါမှမဟုတ် translation လို text generation tasks တွေရဲ့ စွမ်းဆောင်ရည်ကို တိုင်းတာတာက သိပ်မရိုးရှင်းပါဘူး။ ဥပမာ၊ "I loved reading the Hunger Games" လို review တစ်ခုကို ပေးထားရင်၊ "I loved the Hunger Games" ဒါမှမဟုတ် "Hunger Games is a great read" လိုမျိုး မှန်ကန်တဲ့ summaries များစွာ ရှိနိုင်ပါတယ်။ generated summary နဲ့ label ကြားမှာ တိကျတဲ့ ကိုက်ညီမှုမျိုးကို အသုံးပြုတာက ကောင်းမွန်တဲ့ ဖြေရှင်းနည်း မဟုတ်ဘူးဆိုတာ ရှင်းပါတယ်။ ဘာလို့လဲဆိုတော့ ကျွန်တော်တို့ အားလုံးမှာ ကိုယ်ပိုင်ရေးသားဟန် ရှိကြတာကြောင့် လူသားတွေတောင် ဒီလို metric အောက်မှာ ကောင်းကောင်းလုပ်ဆောင်နိုင်မှာ မဟုတ်ပါဘူး။
+
+Summarization အတွက် အသုံးအများဆုံး metrics တွေထဲက တစ်ခုကတော့ [ROUGE score](https://en.wikipedia.org/wiki/ROUGE_(metric)) (Recall-Oriented Understudy for Gisting Evaluation ရဲ့ အတိုကောက်) ဖြစ်ပါတယ်။ ဒီ metric ရဲ့ အခြေခံစိတ်ကူးက generated summary တစ်ခုကို လူသားတွေ ဖန်တီးထားတဲ့ reference summaries အစုအဝေးတစ်ခုနဲ့ နှိုင်းယှဉ်ဖို့ပါပဲ။ ဒါကို ပိုပြီး တိကျအောင် လုပ်ဖို့၊ အောက်ပါ summaries နှစ်ခုကို နှိုင်းယှဉ်ချင်တယ်လို့ ယူဆပါစို့။
+
+```python
+generated_summary = "I absolutely loved reading the Hunger Games"
+reference_summary = "I loved reading the Hunger Games"
+```
+
+ဒါတွေကို နှိုင်းယှဉ်တဲ့ နည်းလမ်းတစ်ခုက ထပ်နေတဲ့ စကားလုံးအရေအတွက်ကို ရေတွက်တာ ဖြစ်နိုင်ပြီး၊ ဒီကိစ္စမှာ ၆ လုံး ရှိပါလိမ့်မယ်။ သို့သော်လည်း ဒါက အနည်းငယ် ကြမ်းတမ်းတာကြောင့်၊ ROUGE က ထပ်နေမှုအတွက် _precision_ နဲ့ _recall_ scores တွေကို တွက်ချက်ခြင်းပေါ်မှာ အခြေခံထားပါတယ်။
+
+> [!TIP]
+> 🙋 ဒါက precision နဲ့ recall အကြောင်း သင်ပထမဆုံး ကြားဖူးတာဆိုရင် မစိုးရိမ်ပါနဲ့ -- ဒါတွေ အားလုံးကို ရှင်းလင်းအောင် အတူတူ ဥပမာအချို့ကို ကြည့်သွားပါမယ်။ ဒီ metrics တွေကို classification tasks တွေမှာ ပုံမှန်တွေ့ရတာကြောင့်၊ အဲဒီ context မှာ precision နဲ့ recall တွေကို ဘယ်လိုသတ်မှတ်ထားလဲ နားလည်ချင်တယ်ဆိုရင် `scikit-learn` [guides](https://scikit-learn.org/stable/auto_examples/model_selection/plot_precision_recall.html) ကို စစ်ဆေးကြည့်ဖို့ ကျွန်တော်တို့ အကြံပြုပါတယ်။
+
+ROUGE အတွက်၊ recall က generated summary က reference summary ရဲ့ ဘယ်လောက်အတိုင်းအတာအထိ ဖမ်းယူနိုင်သလဲဆိုတာကို တိုင်းတာပါတယ်။ စကားလုံးတွေကိုပဲ နှိုင်းယှဉ်နေမယ်ဆိုရင်၊ recall ကို အောက်ပါ formula နဲ့ တွက်ချက်နိုင်ပါတယ်-
+
+$$ \mathrm{Recall} = \frac{\mathrm{Number\,of\,overlapping\, words}}{\mathrm{Total\, number\, of\, words\, in\, reference\, summary}} $$
+
+ကျွန်တော်တို့ရဲ့ အပေါ်က ရိုးရှင်းတဲ့ ဥပမာအတွက်၊ ဒီ formula က 6/6 = 1 ဆိုတဲ့ perfect recall ကို ပေးပါတယ်၊ ဆိုလိုတာက reference summary ထဲက စကားလုံးအားလုံးကို model က ထုတ်လုပ်ခဲ့ပါတယ်။ ဒါက ကောင်းမွန်တယ်လို့ ထင်ရပေမယ့်၊ ကျွန်တော်တို့ရဲ့ generated summary က "I really really loved reading the Hunger Games all night" ဖြစ်ခဲ့မယ်ဆိုရင် ဘယ်လိုလုပ်မလဲဆိုတာ စဉ်းစားကြည့်ပါ။ ဒါကလည်း perfect recall ရမှာဖြစ်ပေမယ့်၊ verbose ဖြစ်တာကြောင့် ပိုဆိုးတဲ့ summary ဖြစ်တယ်လို့ ငြင်းဆိုနိုင်ပါတယ်။ ဒီလိုအခြေအနေတွေကို ဖြေရှင်းဖို့ precision ကိုလည်း ကျွန်တော်တို့ တွက်ချက်ပါတယ်။ ROUGE context မှာ precision က generated summary ရဲ့ ဘယ်လောက်အတိုင်းအတာအထိ relevant ဖြစ်လဲဆိုတာကို တိုင်းတာပါတယ်။
+
+$$ \mathrm{Precision} = \frac{\mathrm{Number\,of\,overlapping\, words}}{\mathrm{Total\, number\, of\, words\, in\, generated\, summary}} $$
+
+ဒါကို ကျွန်တော်တို့ရဲ့ verbose summary ပေါ်မှာ အသုံးပြုတဲ့အခါ 6/10 = 0.6 ဆိုတဲ့ precision ကို ပေးပါတယ်။ ဒါက ကျွန်တော်တို့ရဲ့ ပိုတိုတဲ့ summary က ရရှိခဲ့တဲ့ 6/7 = 0.86 precision ထက် သိသိသာသာ ဆိုးပါတယ်။ လက်တွေ့မှာတော့ precision နဲ့ recall နှစ်ခုလုံးကို ပုံမှန်တွက်ချက်ပြီး၊ F1-score (precision နဲ့ recall ရဲ့ harmonic mean) ကို ဖော်ပြပါတယ်။ ဒါကို 🤗 Datasets မှာ `rouge_score` package ကို အရင် install လုပ်ခြင်းဖြင့် လွယ်လွယ်ကူကူ လုပ်ဆောင်နိုင်ပါတယ်။
+
+```py
+!pip install rouge_score
+```
+
+ပြီးရင် ROUGE metric ကို အောက်ပါအတိုင်း load လုပ်ပါ။
+
+```python
+import evaluate
+
+rouge_score = evaluate.load("rouge")
+```
+
+ပြီးရင် `rouge_score.compute()` function ကို အသုံးပြုပြီး metrics အားလုံးကို တစ်ပြိုင်နက်တည်း တွက်ချက်နိုင်ပါတယ်။
+
+```python
+scores = rouge_score.compute(
+    predictions=[generated_summary], references=[reference_summary]
+)
+scores
+```
+
+```python out
+{'rouge1': AggregateScore(low=Score(precision=0.86, recall=1.0, fmeasure=0.92), mid=Score(precision=0.86, recall=1.0, fmeasure=0.92), high=Score(precision=0.86, recall=1.0, fmeasure=0.92)),
+ 'rouge2': AggregateScore(low=Score(precision=0.67, recall=0.8, fmeasure=0.73), mid=Score(precision=0.67, recall=0.8, fmeasure=0.73), high=Score(precision=0.67, recall=0.8, fmeasure=0.73)),
+ 'rougeL': AggregateScore(low=Score(precision=0.86, recall=1.0, fmeasure=0.92), mid=Score(precision=0.86, recall=1.0, fmeasure=0.92), high=Score(precision=0.86, recall=1.0, fmeasure=0.92)),
+ 'rougeLsum': AggregateScore(low=Score(precision=0.86, recall=1.0, fmeasure=0.92), mid=Score(precision=0.86, recall=1.0, fmeasure=0.92), high=Score(precision=0.86, recall=1.0, fmeasure=0.92))}
+```
+
+ဒီ output ထဲမှာ အချက်အလက်တွေ အများကြီးရှိနေတယ် — ဒါတွေအားလုံးက ဘာကိုဆိုလိုတာလဲ။ ပထမဆုံး၊ 🤗 Datasets က precision, recall နဲ့ F1-score အတွက် confidence intervals တွေကို တကယ်တွက်ချက်ပါတယ်၊ ဒါတွေက သင်ဒီနေရာမှာ မြင်နိုင်တဲ့ `low`, `mid`, နဲ့ `high` attributes တွေပါ။ ဒါ့အပြင်၊ 🤗 Datasets က generated နဲ့ reference summaries တွေကို နှိုင်းယှဉ်တဲ့အခါ မတူညီတဲ့ text granularity အမျိုးအစားတွေပေါ်မှာ အခြေခံထားတဲ့ ROUGE scores အမျိုးမျိုးကို တွက်ချက်ပါတယ်။ `rouge1` variant က unigrams တွေရဲ့ ထပ်နေမှုဖြစ်ပါတယ် — ဒါက စကားလုံးတွေရဲ့ ထပ်နေမှုကို ဖော်ပြတဲ့ လှပတဲ့ နည်းလမ်းတစ်ခုဖြစ်ပြီး၊ ကျွန်တော်တို့ အပေါ်မှာ ဆွေးနွေးခဲ့တဲ့ metric နဲ့ အတိအကျတူညီပါတယ်။ ဒါကို စစ်ဆေးဖို့၊ ကျွန်တော်တို့ scores ရဲ့ `mid` value ကို ထုတ်ယူကြည့်ရအောင်။
+
+```python
+scores["rouge1"].mid
+```
+
+```python out
+Score(precision=0.86, recall=1.0, fmeasure=0.92)
+```
+
+ကောင်းပါပြီ၊ precision နဲ့ recall numbers တွေက ကိုက်ညီပါတယ်။ အခု ကျန်တဲ့ ROUGE scores တွေက ဘာတွေလဲ။ `rouge2` က bigrams တွေရဲ့ ထပ်နေမှုကို တိုင်းတာပါတယ် (စကားလုံးအတွဲတွေရဲ့ ထပ်နေမှုကို စဉ်းစားပါ)၊ `rougeL` နဲ့ `rougeLsum` က generated နဲ့ reference summaries တွေမှာ အရှည်ဆုံး common substrings တွေကို ရှာဖွေခြင်းဖြင့် အရှည်ဆုံး ကိုက်ညီတဲ့ စကားလုံး sequence တွေကို တိုင်းတာပါတယ်။ `rougeLsum` ထဲက "sum" ဆိုတာက ဒီ metric ကို summary တစ်ခုလုံးပေါ်မှာ တွက်ချက်တယ်ဆိုတာကို ရည်ညွှန်းပြီး၊ `rougeL` ကတော့ တစ်ဦးချင်းစီ sentence တွေရဲ့ ပျမ်းမျှအဖြစ် တွက်ချက်ပါတယ်။
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** generated နဲ့ reference summary ရဲ့ သင့်ကိုယ်ပိုင် ဥပမာတစ်ခုကို ဖန်တီးပြီး ရလဒ် ROUGE scores တွေက precision နဲ့ recall အတွက် formulas တွေပေါ် အခြေခံထားတဲ့ manual calculation နဲ့ ကိုက်ညီခြင်းရှိမရှိ ကြည့်ပါ။ bonus အမှတ်များအတွက်၊ text ကို bigrams တွေအဖြစ် ခွဲပြီး `rouge2` metric အတွက် precision နဲ့ recall ကို နှိုင်းယှဉ်ပါ။
+
+ဒီ ROUGE scores တွေကို ကျွန်တော်တို့ model ရဲ့ စွမ်းဆောင်ရည်ကို ခြေရာခံဖို့ အသုံးပြုပါမယ်၊ ဒါပေမယ့် ဒါကို မလုပ်ဆောင်ခင်၊ ကောင်းမွန်တဲ့ NLP practitioners တိုင်း လုပ်ဆောင်သင့်တဲ့အရာတစ်ခုကို လုပ်ကြရအောင်- strong, yet simple baseline တစ်ခုကို ဖန်တီးတာပါ။
+
+### Strong Baseline တစ်ခုကို ဖန်တီးခြင်း[[creating-a-strong-baseline]]
+
+Text summarization အတွက် common baseline တစ်ခုကတော့ article တစ်ခုရဲ့ ပထမဆုံး sentences သုံးခုကို ရိုးရှင်းစွာ ယူတာပါပဲ၊ ဒါကို မကြာခဏ _lead-3_ baseline လို့ ခေါ်ပါတယ်။ Sentence boundaries တွေကို ခြေရာခံဖို့ full stops တွေကို ကျွန်တော်တို့ အသုံးပြုနိုင်ပေမယ့်၊ "U.S." ဒါမှမဟုတ် "U.N." လို acronyms တွေမှာ ဒါက အဆင်မပြေနိုင်ပါဘူး -- ဒါကြောင့် ဒါတွေလို အခြေအနေတွေကို ပိုကောင်းကောင်း ကိုင်တွယ်နိုင်မယ့် algorithm ပါဝင်တဲ့ `nltk` library ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။ ဒီ package ကို `pip` ကို အသုံးပြုပြီး အောက်ပါအတိုင်း install လုပ်နိုင်ပါတယ်။
+
+```python
+!pip install nltk
+```
+
+ပြီးရင် punctuation rules တွေကို download လုပ်ပါ။
+
+```python
+import nltk
+
+nltk.download("punkt")
+```
+
+နောက်တစ်ဆင့်အနေနဲ့၊ `nltk` ကနေ sentence tokenizer ကို import လုပ်ပြီး review တစ်ခုထဲက ပထမဆုံး sentences သုံးခုကို ထုတ်ယူဖို့ ရိုးရှင်းတဲ့ function တစ်ခုကို ဖန်တီးပါမယ်။ text summarization မှာ convention က summary တစ်ခုစီကို newline နဲ့ ခွဲခြားဖို့ပါပဲ၊ ဒါကြောင့် ဒါကို ထည့်သွင်းပြီး training example တစ်ခုပေါ်မှာ စမ်းသပ်ကြည့်ရအောင်။
+
+```python
+from nltk.tokenize import sent_tokenize
+
+
+def three_sentence_summary(text):
+    return "\n".join(sent_tokenize(text)[:3])
+
+
+print(three_sentence_summary(books_dataset["train"][1]["review_body"]))
+```
+
+```python out
+'I grew up reading Koontz, and years ago, I stopped,convinced i had "outgrown" him.'
+'Still,when a friend was looking for something suspenseful too read, I suggested Koontz.'
+'She found Strangers.'
+```
+
+ဒါက အလုပ်ဖြစ်ပုံရပါတယ်။ ဒါကြောင့် အခု ဒီ "summaries" တွေကို dataset တစ်ခုကနေ ထုတ်ယူပြီး baseline အတွက် ROUGE scores တွေကို တွက်ချက်ပေးမယ့် function တစ်ခုကို implement လုပ်ရအောင်။
+
+```python
+def evaluate_baseline(dataset, metric):
+    summaries = [three_sentence_summary(text) for text in dataset["review_body"]]
+    return metric.compute(predictions=summaries, references=dataset["review_title"])
+```
+
+ပြီးရင် ဒီ function ကို အသုံးပြုပြီး validation set ပေါ်မှာ ROUGE scores တွေကို တွက်ချက်နိုင်ပြီး Pandas ကို အသုံးပြုပြီး အနည်းငယ် ပိုကောင်းအောင် ပြင်ဆင်နိုင်ပါတယ်။
+
+```python
+import pandas as pd
+
+score = evaluate_baseline(books_dataset["validation"], rouge_score)
+rouge_names = ["rouge1", "rouge2", "rougeL", "rougeLsum"]
+rouge_dict = dict((rn, round(score[rn].mid.fmeasure * 100, 2)) for rn in rouge_names)
+rouge_dict
+```
+
+```python out
+{'rouge1': 16.74, 'rouge2': 8.83, 'rougeL': 15.6, 'rougeLsum': 15.96}
+```
+
+`rouge2` score က ကျန်တာတွေထက် သိသိသာသာ နိမ့်နေတာကို ကျွန်တော်တို့ တွေ့မြင်နိုင်ပါတယ်။ ဒါက review titles တွေဟာ ပုံမှန်အားဖြင့် တိုတောင်းပြီး lead-3 baseline ကတော့ အလွန် verbose ဖြစ်တာကို ရောင်ပြန်ဟပ်နေတာ ဖြစ်နိုင်ပါတယ်။ အခု ကျွန်တော်တို့မှာ အလုပ်လုပ်ဖို့ ကောင်းမွန်တဲ့ baseline တစ်ခုရပြီဆိုတော့၊ mT5 ကို fine-tuning လုပ်တာကို ကျွန်တော်တို့ အာရုံစိုက်ရအောင်။
+
+{#if fw === 'pt'}
+
+## `Trainer` API ဖြင့် mT5 ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-mt5-with-the-trainer-api]]
+
+Summarization အတွက် model တစ်ခုကို fine-tuning လုပ်တာက ဒီအခန်းမှာ ကျွန်တော်တို့ ဖော်ပြခဲ့တဲ့ အခြား tasks တွေနဲ့ အလွန်ဆင်တူပါတယ်။ ပထမဆုံး လုပ်ရမှာက `mt5-small` checkpoint ကနေ pretrained model ကို load လုပ်ဖို့ပါပဲ။ Summarization က sequence-to-sequence task ဖြစ်တာကြောင့်၊ `AutoModelForSeq2SeqLM` class နဲ့ model ကို load လုပ်နိုင်ပြီး၊ ဒါက weights တွေကို အလိုအလျောက် download လုပ်ပြီး cache လုပ်ပါလိမ့်မယ်။
+
+```python
+from transformers import AutoModelForSeq2SeqLM
+
+model = AutoModelForSeq2SeqLM.from_pretrained(model_checkpoint)
+```
+
+{:else}
+
+## Keras ဖြင့် mT5 ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-mt5-with-keras]]
+
+Summarization အတွက် model တစ်ခုကို fine-tuning လုပ်တာက ဒီအခန်းမှာ ကျွန်တော်တို့ ဖော်ပြခဲ့တဲ့ အခြား tasks တွေနဲ့ အလွန်ဆင်တူပါတယ်။ ပထမဆုံး လုပ်ရမှာက `mt5-small` checkpoint ကနေ pretrained model ကို load လုပ်ဖို့ပါပဲ။ Summarization က sequence-to-sequence task ဖြစ်တာကြောင့်၊ `TFAutoModelForSeq2SeqLM` class နဲ့ model ကို load လုပ်နိုင်ပြီး၊ ဒါက weights တွေကို အလိုအလျောက် download လုပ်ပြီး cache လုပ်ပါလိမ့်မယ်။ 
+
+```python
+from transformers import TFAutoModelForSeq2SeqLM
+
+model = TFAutoModelForSeq2SeqLM.from_pretrained(model_checkpoint)
+```
+
+{/if}
+
+> [!TIP]
+> 💡 downstream task တစ်ခုပေါ်မှာ model ကို fine-tuning လုပ်တာနဲ့ ပတ်သက်တဲ့ warnings တွေ ဘာကြောင့် မတွေ့ရလဲဆိုတာ သင်တွေးနေမယ်ဆိုရင်၊ ဒါက sequence-to-sequence tasks တွေအတွက် network ရဲ့ weights အားလုံးကို ကျွန်တော်တို့ ထိန်းသိမ်းထားလို့ပါပဲ။ [Chapter 3](/course/chapter3) မှာရှိတဲ့ ကျွန်တော်တို့ရဲ့ text classification model နဲ့ နှိုင်းယှဉ်ကြည့်ပါ။ အဲဒီမှာ pretrained model ရဲ့ head ကို randomly initialized network တစ်ခုနဲ့ အစားထိုးခဲ့ပါတယ်။
+
+နောက်တစ်ဆင့်အနေနဲ့၊ Hugging Face Hub ကို log in လုပ်ဖို့ လိုပါတယ်။ သင် ဒီ code ကို notebook ထဲမှာ run နေတယ်ဆိုရင်၊ အောက်ပါ utility function နဲ့ လုပ်ဆောင်နိုင်ပါတယ်-
+
+```python
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+ဒါက သင်၏ credentials တွေကို ထည့်သွင်းနိုင်မယ့် widget တစ်ခုကို ပြသပါလိမ့်မယ်။ ဒါမှမဟုတ်၊ ဒီ command ကို သင့် terminal မှာ run ပြီး အဲဒီမှာ log in လုပ်နိုင်ပါတယ်။
+
+```
+huggingface-cli login
+```
+
+{#if fw === 'pt'}
+
+training လုပ်နေစဉ် ROUGE scores တွေ တွက်ချက်နိုင်ဖို့ summaries တွေ ထုတ်လုပ်ဖို့ ကျွန်တော်တို့ လိုအပ်ပါလိမ့်မယ်။ ကံကောင်းစွာနဲ့ပဲ၊ 🤗 Transformers က ဒါကို ကျွန်တော်တို့အတွက် အလိုအလျောက် လုပ်ဆောင်ပေးနိုင်တဲ့ dedicated `Seq2SeqTrainingArguments` နဲ့ `Seq2SeqTrainer` classes တွေကို ပံ့ပိုးပေးပါတယ်။ ဒါက ဘယ်လိုအလုပ်လုပ်လဲဆိုတာ ကြည့်ဖို့၊ ကျွန်တော်တို့ရဲ့ experiments တွေအတွက် hyperparameters တွေနဲ့ အခြား arguments တွေကို အရင်ဆုံး သတ်မှတ်ရအောင်။
+
+```python
+from transformers import Seq2SeqTrainingArguments
+
+batch_size = 8
+num_train_epochs = 8
+# epoch တိုင်းမှာ training loss ကို ပြသပါ
+logging_steps = len(tokenized_datasets["train"]) // batch_size
+model_name = model_checkpoint.split("/")[-1]
+
+args = Seq2SeqTrainingArguments(
+    output_dir=f"{model_name}-finetuned-amazon-en-es",
+    evaluation_strategy="epoch",
+    learning_rate=5.6e-5,
+    per_device_train_batch_size=batch_size,
+    per_device_eval_batch_size=batch_size,
+    weight_decay=0.01,
+    save_total_limit=3,
+    num_train_epochs=num_train_epochs,
+    predict_with_generate=True,
+    logging_steps=logging_steps,
+    push_to_hub=True,
+)
+```
+
+ဒီနေရာမှာ၊ `predict_with_generate` argument ကို evaluation လုပ်နေစဉ် summaries တွေ ထုတ်လုပ်သင့်တယ်ဆိုတာကို ဖော်ပြဖို့ သတ်မှတ်ထားတာကြောင့်၊ epoch တစ်ခုစီအတွက် ROUGE scores တွေကို ကျွန်တော်တို့ တွက်ချက်နိုင်ပါတယ်။ [Chapter 1](/course/chapter1) မှာ ဆွေးနွေးခဲ့တဲ့အတိုင်း၊ decoder က tokens တွေကို တစ်ခုပြီးတစ်ခု ခန့်မှန်းခြင်းဖြင့် inference ကို လုပ်ဆောင်ပါတယ်၊ ဒါကို model ရဲ့ `generate()` method နဲ့ implement လုပ်ထားပါတယ်။ `predict_with_generate=True` လို့ သတ်မှတ်ခြင်းက `Seq2SeqTrainer` ကို evaluation အတွက် အဲဒီ method ကို အသုံးပြုဖို့ ပြောတာပါ။ ကျွန်တော်တို့က learning rate၊ epochs အရေအတွက်နဲ့ weight decay လိုမျိုး default hyperparameters အချို့ကိုလည်း ချိန်ညှိထားပြီး၊ training လုပ်နေစဉ် checkpoints ၃ ခုအထိသာ save လုပ်ဖို့ `save_total_limit` option ကို သတ်မှတ်ထားပါတယ် — ဒါက mT5 ရဲ့ "small" version ကတောင် hard drive space တစ် GB လောက် အသုံးပြုတာကြောင့်၊ ကျွန်တော်တို့ save လုပ်တဲ့ copies အရေအတွက်ကို ကန့်သတ်ခြင်းဖြင့် နေရာအနည်းငယ် ချွေတာနိုင်လို့ပါပဲ။
+
+`push_to_hub=True` argument က training ပြီးတာနဲ့ model ကို Hub ကို push လုပ်နိုင်စေပါလိမ့်မယ်၊ repository ကို သင့် user profile အောက်မှာ `output_dir` က သတ်မှတ်ထားတဲ့ နေရာမှာ တွေ့ရပါလိမ့်မယ်။ သင် push လုပ်ချင်တဲ့ repository ရဲ့ နာမည်ကို `hub_model_id` argument နဲ့ သတ်မှတ်နိုင်တယ်ဆိုတာ သတိပြုပါ (အထူးသဖြင့်၊ organization တစ်ခုသို့ push လုပ်ဖို့ ဒီ argument ကို အသုံးပြုရပါလိမ့်မယ်)။ ဥပမာ၊ ကျွန်တော်တို့ model ကို [`huggingface-course` organization](https://huggingface.co/huggingface-course) ကို push လုပ်တဲ့အခါ၊ `Seq2SeqTrainingArguments` မှာ `hub_model_id="huggingface-course/mt5-finetuned-amazon-en-es"` ကို ထည့်သွင်းခဲ့ပါတယ်။
+
+နောက်တစ်ဆင့်အနေနဲ့ trainer ကို `compute_metrics()` function တစ်ခု ပေးဖို့ လိုအပ်ပါတယ်။ ဒါမှ training လုပ်နေစဉ် ကျွန်တော်တို့ model ကို evaluate လုပ်နိုင်မှာပါ။ summarization အတွက် ဒါက model ရဲ့ predictions တွေပေါ်မှာ `rouge_score.compute()` ကို ရိုးရှင်းစွာ ခေါ်တာထက် အနည်းငယ် ပိုရှုပ်ထွေးပါတယ်။ ဘာလို့လဲဆိုတော့ ROUGE scores တွေ တွက်ချက်နိုင်ဖို့အတွက် outputs တွေနဲ့ labels တွေကို text အဖြစ် _decode_ လုပ်ဖို့ လိုအပ်လို့ပါပဲ။ အောက်ပါ function က ဒါကို အတိအကျ လုပ်ဆောင်ပေးပြီး၊ summary sentences တွေကို newlines တွေနဲ့ ခွဲခြားဖို့ `nltk` က `sent_tokenize()` function ကိုလည်း အသုံးပြုပါတယ်။
+
+```python
+import numpy as np
+
+
+def compute_metrics(eval_pred):
+    predictions, labels = eval_pred
+    # Generated summaries တွေကို text အဖြစ် Decode လုပ်ပါ
+    decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
+    # labels တွေထဲက -100 တွေကို ကျွန်တော်တို့ decode လုပ်လို့မရတာကြောင့် အစားထိုးပါ
+    labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+    # Reference summaries တွေကို text အဖြစ် Decode လုပ်ပါ
+    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+    # ROUGE က sentence တိုင်းနောက်မှာ newline တစ်ခု လိုအပ်ပါတယ်
+    decoded_preds = ["\n".join(sent_tokenize(pred.strip())) for pred in decoded_preds]
+    decoded_labels = ["\n".join(sent_tokenize(label.strip())) for label in decoded_labels]
+    # ROUGE scores တွေကို တွက်ချက်ပါ
+    result = rouge_score.compute(
+        predictions=decoded_preds, references=decoded_labels, use_stemmer=True
+    )
+    # Median scores တွေကို ထုတ်ယူပါ
+    result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
+    return {k: round(v, 4) for k, v in result.items()}
+```
+
+{/if}
+
+နောက်တစ်ဆင့်အနေနဲ့၊ ကျွန်တော်တို့ရဲ့ sequence-to-sequence task အတွက် data collator တစ်ခုကို သတ်မှတ်ဖို့ လိုပါတယ်။ mT5 က encoder-decoder Transformer model ဖြစ်တာကြောင့်၊ ကျွန်တော်တို့ရဲ့ batches တွေကို ပြင်ဆင်ရာမှာ သိမ်မွေ့မှုတစ်ခု ရှိပါတယ်၊ decoding လုပ်နေစဉ် labels တွေကို ညာဘက်သို့ တစ်နေရာရွှေ့ဖို့ လိုအပ်ပါတယ်။ ဒါက decoder က ယခင် ground truth labels တွေကိုသာ မြင်ရပြီး၊ လက်ရှိ ဒါမှမဟုတ် အနာဂတ် labels တွေကို မမြင်ရဖို့ သေချာစေဖို့အတွက် လိုအပ်ပါတယ်။ အဲဒါတွေက model က မှတ်မိဖို့ လွယ်ကူမှာဖြစ်ပါတယ်။ ဒါက [causal language modeling](/course/chapter7/6) လို task တစ်ခုမှာ inputs တွေပေါ်မှာ masked self-attention ဘယ်လိုအသုံးပြုလဲဆိုတာနဲ့ ဆင်တူပါတယ်။
+
+ကံကောင်းစွာနဲ့ပဲ၊ 🤗 Transformers က inputs တွေနဲ့ labels တွေကို dynamically pad လုပ်ပေးမယ့် `DataCollatorForSeq2Seq` collator တစ်ခုကို ပံ့ပိုးပေးပါတယ်။ ဒီ collator ကို instantiate လုပ်ဖို့၊ ကျွန်တော်တို့ `tokenizer` နဲ့ `model` ကို ပေးဖို့ပဲ လိုအပ်ပါတယ်။
+
+{#if fw === 'pt'}
+
+```python
+from transformers import DataCollatorForSeq2Seq
+
+data_collator = DataCollatorForSeq2Seq(tokenizer, model=model)
+```
+
+{:else}
+
+```python
+from transformers import DataCollatorForSeq2Seq
+
+data_collator = DataCollatorForSeq2Seq(tokenizer, model=model, return_tensors="tf")
+```
+
+{/if}
+
+collator က ဥပမာအနည်းငယ်ကို ပေးလိုက်တဲ့အခါ ဘာတွေ ထုတ်လုပ်ပေးလဲဆိုတာ ကြည့်ရအောင်။ ပထမဆုံး၊ string တွေပါဝင်တဲ့ columns တွေကို ကျွန်တော်တို့ ဖယ်ရှားဖို့ လိုအပ်ပါတယ်။ ဘာလို့လဲဆိုတော့ collator က ဒီ elements တွေကို ဘယ်လို pad လုပ်ရမလဲဆိုတာ သိမှာ မဟုတ်လို့ပါပဲ။
+
+```python
+tokenized_datasets = tokenized_datasets.remove_columns(
+    books_dataset["train"].column_names
+)
+```
+
+collator က `dict` တွေရဲ့ list ကို မျှော်လင့်ထားတာကြောင့် (dict တစ်ခုစီက dataset ထဲက single example ကို ကိုယ်စားပြုပါတယ်)၊ data ကို collator ကို မပေးပို့ခင် မျှော်လင့်ထားတဲ့ format အဖြစ် wrangle လုပ်ဖို့လည်း ကျွန်တော်တို့ လိုအပ်ပါတယ်။
+
+```python
+features = [tokenized_datasets["train"][i] for i in range(2)]
+data_collator(features)
+```
+
+```python out
+{'attention_mask': tensor([[1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+         1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+        [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]]), 'input_ids': tensor([[  1494,    259,   8622,    390,    259,    262,   2316,   3435,    955,
+            772,    281,    772,   1617,    263,    305,  14701,    260,   1385,
+           3031,    259,  24146,    332,   1037,    259,  43906,    305,    336,
+            260,      1,      0,      0,      0,      0,      0,      0],
+        [   259,  27531,  13483,    259,   7505,    260, 112240,  15192,    305,
+          53198,    276,    259,  74060,    263,    260,    459,  25640,    776,
+           2119,    336,    259,   2220,    259,  18896,    288,   4906,    288,
+           1037,   3931,    260,   7083, 101476,   1143,    260,      1]]), 'labels': tensor([[ 7483,   259,  2364, 15695,     1,  -100],
+        [  259, 27531, 13483,   259,  7505,     1]]), 'decoder_input_ids': tensor([[    0,  7483,   259,  2364, 15695,     1],
+        [    0,   259, 27531, 13483,   259,  7505]])}
+```
+
+ဒီနေရာမှာ သတိထားရမယ့် အဓိကအချက်က ပထမဥပမာက ဒုတိယဥပမာထက် ပိုရှည်တာကြောင့်၊ ဒုတိယဥပမာရဲ့ `input_ids` နဲ့ `attention_mask` တွေကို ညာဘက်မှာ `[PAD]` token (၎င်းရဲ့ ID က `0` ဖြစ်ပါတယ်) နဲ့ padding လုပ်ထားပါတယ်။ အလားတူပဲ၊ `labels` တွေကို `-100` တွေနဲ့ padding လုပ်ထားတာကို တွေ့ရပါတယ်။ ဒါမှ padding tokens တွေကို loss function က လျစ်လျူရှုစေမှာပါ။ နောက်ဆုံးအနေနဲ့၊ `decoder_input_ids` အသစ်တစ်ခုကို ကျွန်တော်တို့ တွေ့မြင်နိုင်ပါတယ်။ ဒါက ပထမ entry မှာ `[PAD]` token တစ်ခု ထည့်သွင်းခြင်းဖြင့် labels တွေကို ညာဘက်သို့ ရွှေ့ထားပါတယ်။
+
+{#if fw === 'pt'}
+
+ကျွန်တော်တို့ training လုပ်ဖို့ လိုအပ်တဲ့ ingredients အားလုံးကို နောက်ဆုံးတော့ ရရှိပါပြီ! အခု ကျွန်တော်တို့က trainer ကို standard arguments တွေနဲ့ instantiate လုပ်ဖို့ပဲ လိုအပ်ပါတယ်။
+
+```python
+from transformers import Seq2SeqTrainer
+
+trainer = Seq2SeqTrainer(
+    model,
+    args,
+    train_dataset=tokenized_datasets["train"],
+    eval_dataset=tokenized_datasets["validation"],
+    data_collator=data_collator,
+    tokenizer=tokenizer,
+    compute_metrics=compute_metrics,
+)
+```
+
+ပြီးရင် training run ကို စတင်ပါ။
+
+```python
+trainer.train()
+```
+
+training လုပ်နေစဉ်၊ epoch တိုင်းမှာ training loss ကျဆင်းပြီး ROUGE scores တိုးလာတာကို သင်တွေ့ရပါလိမ့်မယ်။ training ပြီးတာနဲ့ `Trainer.evaluate()` ကို run ခြင်းဖြင့် နောက်ဆုံး ROUGE scores တွေကို ကြည့်နိုင်ပါတယ်။
+
+```python
+trainer.evaluate()
+```
+
+```python out
+{'eval_loss': 3.028524398803711,
+ 'eval_rouge1': 16.9728,
+ 'eval_rouge2': 8.2969,
+ 'eval_rougeL': 16.8366,
+ 'eval_rougeLsum': 16.851,
+ 'eval_gen_len': 10.1597,
+ 'eval_runtime': 6.1054,
+ 'eval_samples_per_second': 38.982,
+ 'eval_steps_per_second': 4.914}
+```
+
+scores တွေကနေ ကျွန်တော်တို့ model ဟာ ကျွန်တော်တို့ရဲ့ lead-3 baseline ကို ကောင်းကောင်းကျော်ဖြတ်နိုင်ခဲ့တာကို တွေ့မြင်နိုင်ပါတယ် — ကောင်းလိုက်တာ! နောက်ဆုံးလုပ်ဆောင်ရမယ့်အရာက model weights တွေကို Hub ကို push လုပ်ဖို့ပါပဲ၊ အောက်ပါအတိုင်း လုပ်ဆောင်ပါ။
+
+```
+trainer.push_to_hub(commit_message="Training complete", tags="summarization")
+```
+
+```python out
+'https://huggingface.co/huggingface-course/mt5-small-finetuned-amazon-en-es/commit/aa0536b829b28e73e1e4b94b8a5aacec420d40e0'
+```
+
+ဒါက checkpoint နဲ့ configuration files တွေကို `output_dir` မှာ သိမ်းဆည်းပေးပြီး၊ ဖိုင်အားလုံးကို Hub ကို upload လုပ်ပါလိမ့်မယ်။ `tags` argument ကို သတ်မှတ်ခြင်းဖြင့်၊ Hub ပေါ်က widget က mT5 architecture နဲ့ ဆက်စပ်နေတဲ့ default text generation pipeline အစား summarization pipeline အတွက် ဖြစ်နေဖို့လည်း ကျွန်တော်တို့ သေချာစေပါတယ် (model tags တွေအကြောင်း အသေးစိတ်အချက်အလက်တွေအတွက် [🤗 Hub documentation](https://huggingface.co/docs/hub/main#how-is-a-models-type-of-inference-api-and-widget-determined) ကို ကြည့်ပါ)။ `trainer.push_to_hub()` ကနေ ထွက်လာတဲ့ output က Git commit hash ရဲ့ URL ဖြစ်တာကြောင့်၊ model repository မှာ ပြုလုပ်ခဲ့တဲ့ ပြောင်းလဲမှုတွေကို သင်အလွယ်တကူ မြင်နိုင်ပါလိမ့်မယ်!
+
+ဒီအပိုင်းကို နိဂုံးချုပ်အနေနဲ့၊ 🤗 Accelerate က ပံ့ပိုးပေးတဲ့ low-level features တွေကို အသုံးပြုပြီး mT5 ကို ဘယ်လို fine-tune လုပ်နိုင်လဲဆိုတာ ကြည့်ရအောင်။
+
+{:else}
+
+ကျွန်တော်တို့ training လုပ်ဖို့ နီးပါး အဆင်သင့်ဖြစ်ပါပြီ! ကျွန်တော်တို့ dataset တွေကို အပေါ်မှာ သတ်မှတ်ထားတဲ့ data collator ကို အသုံးပြုပြီး `tf.data.Dataset`s တွေအဖြစ် ပြောင်းလဲဖို့ပဲ လိုအပ်ပြီး၊ ပြီးရင် model ကို `compile()` နဲ့ `fit()` လုပ်ရပါမယ်။ ပထမဆုံး datasets တွေကို ကြည့်ရအောင်။
+
+```python
+tf_train_dataset = model.prepare_tf_dataset(
+    tokenized_datasets["train"],
+    collate_fn=data_collator,
+    shuffle=True,
+    batch_size=8,
+)
+tf_eval_dataset = model.prepare_tf_dataset(
+    tokenized_datasets["validation"],
+    collate_fn=data_collator,
+    shuffle=False,
+    batch_size=8,
+)
+```
+
+အခု training hyperparameters တွေကို သတ်မှတ်ပြီး compile လုပ်ပါ။
+
+```python
+from transformers import create_optimizer
+import tensorflow as tf
+
+# Training steps အရေအတွက်က dataset ထဲက samples အရေအတွက်ကို batch size နဲ့ စားပြီး၊
+# စုစုပေါင်း epochs အရေအတွက်နဲ့ မြှောက်ထားတာဖြစ်ပါတယ်။
+# ဒီနေရာမှာ tf_train_dataset က batched tf.data.Dataset ဖြစ်ပြီး၊
+# မူရင်း Hugging Face Dataset မဟုတ်တာကြောင့်၊ ၎င်းရဲ့ len() က num_samples // batch_size ဖြစ်နေပါပြီ။
+num_train_epochs = 8
+num_train_steps = len(tf_train_dataset) * num_train_epochs
+model_name = model_checkpoint.split("/")[-1]
+
+optimizer, schedule = create_optimizer(
+    init_lr=5.6e-5,
+    num_warmup_steps=0,
+    num_train_steps=num_train_steps,
+    weight_decay_rate=0.01,
+)
+
+model.compile(optimizer=optimizer)
+
+# mixed-precision float16 နဲ့ Train လုပ်ပါ
+tf.keras.mixed_precision.set_global_policy("mixed_float16")
+```
+
+နောက်ဆုံးအနေနဲ့ model ကို fit လုပ်ပါတယ်။ epoch တိုင်းပြီးတာနဲ့ model ကို Hub ကို save လုပ်ဖို့ `PushToHubCallback` ကို အသုံးပြုပါတယ်။ ဒါက ကျွန်တော်တို့ကို နောက်ပိုင်းမှာ inference လုပ်ဖို့ အသုံးပြုနိုင်စေပါလိမ့်မယ်။
+
+```python
+from transformers.keras_callbacks import PushToHubCallback
+
+callback = PushToHubCallback(
+    output_dir=f"{model_name}-finetuned-amazon-en-es", tokenizer=tokenizer
+)
+
+model.fit(
+    tf_train_dataset, validation_data=tf_eval_dataset, callbacks=[callback], epochs=8
+)
+```
+
+training လုပ်နေစဉ် loss values အချို့ကို ကျွန်တော်တို့ ရရှိခဲ့ပေမယ့်၊ အစောပိုင်းက တွက်ချက်ခဲ့တဲ့ ROUGE metrics တွေကို တကယ်မြင်ချင်ပါတယ်။ အဲဒီ metrics တွေကို ရရှိဖို့၊ model ကနေ outputs တွေ ထုတ်လုပ်ပြီး ၎င်းတို့ကို strings တွေအဖြစ် ပြောင်းလဲဖို့ လိုအပ်ပါလိမ့်မယ် (ဒီအပိုင်းအတွက် import errors တွေရရင် `!pip install tqdm` ကို လုပ်ဖို့ လိုအပ်နိုင်ပါတယ်)။ ကျွန်တော်တို့ စွမ်းဆောင်ရည်ကို သိသိသာသာ တိုးမြှင့်ပေးမယ့် trick တစ်ခုကိုလည်း အသုံးပြုပါမယ်၊ TensorFlow ရဲ့ accelerated linear algebra compiler ဖြစ်တဲ့ [XLA](https://www.tensorflow.org/xla) နဲ့ ကျွန်တော်တို့ရဲ့ generation code ကို compile လုပ်တာပါ။ XLA က model ရဲ့ computation graph ကို optimizations အမျိုးမျိုး ပြုလုပ်ပေးပြီး speed နဲ့ memory usage မှာ သိသာထင်ရှားတဲ့ တိုးတက်မှုတွေကို ရရှိစေပါတယ်။ Hugging Face [blog](https://huggingface.co/blog/tf-xla-generate) မှာ ဖော်ပြထားတဲ့အတိုင်း၊ XLA က ကျွန်တော်တို့ရဲ့ input shapes တွေ သိပ်မကွာခြားတဲ့အခါ အကောင်းဆုံး အလုပ်လုပ်ပါတယ်။ ဒါကို ကိုင်တွယ်ဖို့၊ ကျွန်တော်တို့ inputs တွေကို 128 ရဲ့ multiples တွေအထိ pad လုပ်ပြီး၊ padding collator နဲ့ dataset အသစ်တစ်ခု ဖန်တီးပါမယ်။ ပြီးရင် `generate_with_xla` function ကို `@tf.function(jit_compile=True)` decorator ကို အသုံးပြုပြီး အဲဒီ function တစ်ခုလုံးကို XLA နဲ့ compilation အတွက် မှတ်သားပါမယ်။
+
+```python
+from tqdm import tqdm
+import numpy as np
+
+generation_data_collator = DataCollatorForSeq2Seq(
+    tokenizer, model=model, return_tensors="tf", pad_to_multiple_of=320
+)
+
+tf_generate_dataset = model.prepare_tf_dataset(
+    tokenized_datasets["validation"],
+    collate_fn=generation_data_collator,
+    shuffle=False,
+    batch_size=8,
+    drop_remainder=True,
+)
+
+
+@tf.function(jit_compile=True)
+def generate_with_xla(batch):
+    return model.generate(
+        input_ids=batch["input_ids"],
+        attention_mask=batch["attention_mask"],
+        max_new_tokens=32,
+    )
+
+
+all_preds = []
+all_labels = []
+for batch, labels in tqdm(tf_generate_dataset):
+    predictions = generate_with_xla(batch)
+    decoded_preds = tokenizer.batch_decode(predictions, skip_special_tokens=True)
+    labels = labels.numpy()
+    labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+    decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+    decoded_preds = ["\n".join(sent_tokenize(pred.strip())) for pred in decoded_preds]
+    decoded_labels = ["\n".join(sent_tokenize(label.strip())) for label in decoded_labels]
+    all_preds.extend(decoded_preds)
+    all_labels.extend(decoded_labels)
+```
+
+label နဲ့ prediction strings တွေရဲ့ lists တွေကို ရရှိပြီဆိုတာနဲ့၊ ROUGE score တွက်ချက်တာက လွယ်ကူပါတယ်-
+
+```python
+result = rouge_score.compute(
+    predictions=decoded_preds, references=decoded_labels, use_stemmer=True
+)
+result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
+{k: round(v, 4) for k, v in result.items()}
+```
+
+```
+{'rouge1': 31.4815, 'rouge2': 25.4386, 'rougeL': 31.4815, 'rougeLsum': 31.4815}
+```
+
+{/if}
+
+{#if fw === 'pt'}
+
+## 🤗 Accelerate ဖြင့် mT5 ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-mt5-with-accelerate]]
+
+🤗 Accelerate ဖြင့် ကျွန်တော်တို့ model ကို fine-tuning လုပ်တာက [Chapter 3](/course/chapter3) မှာ ကြုံတွေ့ခဲ့ရတဲ့ text classification ဥပမာနဲ့ အလွန်ဆင်တူပါတယ်။ အဓိကကွာခြားချက်တွေက training လုပ်နေစဉ် ကျွန်တော်တို့ summaries တွေကို ရှင်းရှင်းလင်းလင်း ထုတ်လုပ်ဖို့ လိုအပ်ပြီး ROUGE scores တွေကို ဘယ်လိုတွက်ချက်မလဲဆိုတာ သတ်မှတ်ဖို့ လိုအပ်မှာပါ (recall လုပ်ကြည့်ပါ၊ `Seq2SeqTrainer` က ကျွန်တော်တို့အတွက် generation ကို ဂရုစိုက်ပေးခဲ့ပါတယ်)။ 🤗 Accelerate ထဲမှာ ဒီလိုအပ်ချက်နှစ်ခုကို ဘယ်လို implement လုပ်နိုင်လဲဆိုတာ ကြည့်ရအောင်!
+
+### Training အတွက် အရာအားလုံးကို ပြင်ဆင်ခြင်း[[preparing-everything-for-training]]
+
+ပထမဆုံး ကျွန်တော်တို့ လုပ်ရမှာက ကျွန်တော်တို့ splits တစ်ခုစီအတွက် `DataLoader` တစ်ခု ဖန်တီးဖို့ပါပဲ။ PyTorch dataloaders တွေက batches of tensors တွေကို မျှော်လင့်ထားတာကြောင့်၊ ကျွန်တော်တို့ datasets တွေမှာ format ကို `"torch"` လို့ သတ်မှတ်ဖို့ လိုအပ်ပါတယ်။
+
+```python
+tokenized_datasets.set_format("torch")
+```
+
+အခု tensors တွေသာ ပါဝင်တဲ့ datasets တွေရပြီဆိုတော့၊ နောက်တစ်ဆင့်အနေနဲ့ `DataCollatorForSeq2Seq` ကို ထပ်မံ instantiate လုပ်ဖို့ပါပဲ။ ဒီအတွက် model ရဲ့ version အသစ်တစ်ခုကို ပေးဖို့ လိုအပ်တာကြောင့်၊ ကျွန်တော်တို့ cache ကနေ ဒါကို ထပ် load လုပ်ရအောင်။
+
+```python
+model = AutoModelForSeq2SeqLM.from_pretrained(model_checkpoint)
+```
+
+ပြီးရင် data collator ကို instantiate လုပ်ပြီး ဒါကို ကျွန်တော်တို့ dataloaders တွေကို သတ်မှတ်ဖို့ အသုံးပြုနိုင်ပါတယ်။
+
+```python
+from torch.utils.data import DataLoader
+
+batch_size = 8
+train_dataloader = DataLoader(
+    tokenized_datasets["train"],
+    shuffle=True,
+    collate_fn=data_collator,
+    batch_size=batch_size,
+)
+eval_dataloader = DataLoader(
+    tokenized_datasets["validation"], collate_fn=data_collator, batch_size=batch_size
+)
+```
+
+နောက်တစ်ဆင့်အနေနဲ့ အသုံးပြုချင်တဲ့ optimizer ကို သတ်မှတ်ဖို့ပါပဲ။ ကျွန်တော်တို့ရဲ့ အခြားဥပမာတွေမှာလိုပဲ၊ ပြဿနာအများစုအတွက် ကောင်းကောင်းအလုပ်လုပ်တဲ့ `AdamW` ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။
+
+```python
+from torch.optim import AdamW
+
+optimizer = AdamW(model.parameters(), lr=2e-5)
+```
+
+နောက်ဆုံးအနေနဲ့၊ ကျွန်တော်တို့ model၊ optimizer နဲ့ dataloaders တွေကို `accelerator.prepare()` method ကို ပေးရပါမယ်။
+
+```python
+from accelerate import Accelerator
+
+accelerator = Accelerator()
+model, optimizer, train_dataloader, eval_dataloader = accelerator.prepare(
+    model, optimizer, train_dataloader, eval_dataloader
+)
+```
+
+> [!TIP]
+> 🚨 သင် TPU ပေါ်မှာ train လုပ်နေတယ်ဆိုရင်၊ အပေါ်က code အားလုံးကို dedicated training function တစ်ခုထဲကို ရွှေ့ဖို့ လိုပါလိမ့်မယ်။ အသေးစိတ်အချက်အလက်တွေအတွက် [Chapter 3](/course/chapter3) ကို ကြည့်ပါ။
+
+အခု ကျွန်တော်တို့ objects တွေကို ပြင်ဆင်ပြီးပြီဆိုတော့၊ ကျန်ရှိတဲ့ လုပ်စရာသုံးခု ရှိပါသေးတယ်။
+
+*   Learning rate schedule ကို သတ်မှတ်ပါ။
+*   Evaluation အတွက် summaries တွေကို post-process လုပ်ဖို့ function တစ်ခုကို implement လုပ်ပါ။
+*   ကျွန်တော်တို့ model ကို push လုပ်နိုင်မယ့် Hub ပေါ်မှာ repository တစ်ခု ဖန်တီးပါ။
+
+learning rate schedule အတွက်၊ ယခင်အပိုင်းတွေက standard linear schedule ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။
+
+```python
+from transformers import get_scheduler
+
+num_train_epochs = 10
+num_update_steps_per_epoch = len(train_dataloader)
+num_training_steps = num_train_epochs * num_update_steps_per_epoch
+
+lr_scheduler = get_scheduler(
+    "linear",
+    optimizer=optimizer,
+    num_warmup_steps=0,
+    num_training_steps=num_training_steps,
+)
+```
+
+Post-processing အတွက်၊ generated summaries တွေကို newlines တွေနဲ့ ခွဲထားတဲ့ sentences တွေအဖြစ် ခွဲထုတ်ပေးမယ့် function တစ်ခု လိုအပ်ပါတယ်။ ဒါက ROUGE metric မျှော်လင့်ထားတဲ့ format ဖြစ်ပြီး၊ အောက်ပါ code snippet နဲ့ ဒါကို အောင်မြင်အောင် လုပ်ဆောင်နိုင်ပါတယ်။
+
+```python
+def postprocess_text(preds, labels):
+    preds = [pred.strip() for pred in preds]
+    labels = [label.strip() for label in labels]
+
+    # ROUGE က sentence တိုင်းနောက်မှာ newline တစ်ခု လိုအပ်ပါတယ်
+    preds = ["\n".join(nltk.sent_tokenize(pred)) for pred in preds]
+    labels = ["\n".join(nltk.sent_tokenize(label)) for label in labels]
+
+    return preds, labels
+```
+
+`Seq2SeqTrainer` ရဲ့ `compute_metrics()` function ကို ဘယ်လိုသတ်မှတ်ခဲ့လဲဆိုတာ သင်မှတ်မိတယ်ဆိုရင် ဒါက သင့်အတွက် ရင်းနှီးနေမှာပါ။
+
+နောက်ဆုံးအနေနဲ့၊ Hugging Face Hub ပေါ်မှာ model repository တစ်ခု ဖန်တီးဖို့ လိုအပ်ပါတယ်။ ဒီအတွက်၊ သင့်လျော်တဲ့ခေါင်းစဉ်ရှိတဲ့ 🤗 Hub library ကို ကျွန်တော်တို့ အသုံးပြုနိုင်ပါတယ်။ ကျွန်တော်တို့ repository အတွက် နာမည်တစ်ခု သတ်မှတ်ဖို့ပဲ လိုအပ်ပြီး၊ library မှာ repository ID ကို user profile နဲ့ ပေါင်းစပ်ဖို့ utility function တစ်ခုရှိပါတယ်။
+
+```python
+from huggingface_hub import get_full_repo_name
+
+model_name = "test-bert-finetuned-squad-accelerate"
+repo_name = get_full_repo_name(model_name)
+repo_name
+```
+
+```python out
+'lewtun/mt5-finetuned-amazon-en-es-accelerate'
+```
+
+အခု ဒီ repository name ကို အသုံးပြုပြီး ကျွန်တော်တို့ရဲ့ results directory ထဲကို local version တစ်ခုကို clone လုပ်နိုင်ပါတယ်။ အဲဒီ directory က training artifacts တွေကို သိမ်းဆည်းထားပါလိမ့်မယ်။
+
+```python
+from huggingface_hub import Repository
+
+output_dir = "results-mt5-finetuned-squad-accelerate"
+repo = Repository(output_dir, clone_from=repo_name)
+```
+
+ဒါက training လုပ်နေစဉ် `repo.push_to_hub()` method ကို ခေါ်ခြင်းဖြင့် artifacts တွေကို Hub ကို ပြန် push လုပ်နိုင်စေပါလိမ့်မယ်! အခု ကျွန်တော်တို့ရဲ့ analysis ကို training loop ကို ရေးသားခြင်းဖြင့် နိဂုံးချုပ်လိုက်ရအောင်။
+
+### Training Loop[[training-loop]]
+
+Summarization အတွက် training loop က ကျွန်တော်တို့ ကြုံတွေ့ခဲ့ရတဲ့ အခြား 🤗 Accelerate ဥပမာတွေနဲ့ အတော်လေး ဆင်တူပြီး အကြမ်းဖျင်းအားဖြင့် အဓိကအဆင့်လေးဆင့် ခွဲထားပါတယ်။
+
+၁။ epoch တစ်ခုစီအတွက် `train_dataloader` ထဲက ဥပမာအားလုံးကို iterate လုပ်ခြင်းဖြင့် model ကို train လုပ်ပါ။
+၂။ epoch တစ်ခုစီရဲ့ အဆုံးမှာ model summaries တွေ ထုတ်လုပ်ပါ။ ဒါက tokens တွေကို အရင်ထုတ်လုပ်ပြီး ပြီးရင် ၎င်းတို့ (နဲ့ reference summaries) တွေကို text အဖြစ် decode လုပ်ခြင်းဖြင့် လုပ်ဆောင်ပါတယ်။
+၃။ အစောပိုင်းက ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့ နည်းလမ်းတွေ တူတူကို အသုံးပြုပြီး ROUGE scores တွေကို တွက်ချက်ပါ။
+၄။ checkpoints တွေကို save လုပ်ပြီး အရာအားလုံးကို Hub ကို push လုပ်ပါ။ ဒီနေရာမှာ ကျွန်တော်တို့ `Repository` object ရဲ့ အသုံးဝင်တဲ့ `blocking=False` argument ကို အားကိုးပါတယ်။ ဒါက epoch တစ်ခုစီအတွက် checkpoints တွေကို _asynchronously_ push လုပ်နိုင်စေပါတယ်။ ဒါက GB အရွယ်အစားရှိတဲ့ model နဲ့ ဆက်စပ်နေတဲ့ အနည်းငယ်နှေးကွေးတဲ့ upload ကို စောင့်စရာမလိုဘဲ training ကို ဆက်လက်လုပ်ဆောင်နိုင်စေပါတယ်။
+
+ဒီအဆင့်တွေကို အောက်ပါ code block မှာ တွေ့မြင်နိုင်ပါတယ်။
+
+```python
+from tqdm.auto import tqdm
+import torch
+import numpy as np
+
+progress_bar = tqdm(range(num_training_steps))
+
+for epoch in range(num_train_epochs):
+    # Training
+    model.train()
+    for step, batch in enumerate(train_dataloader):
+        outputs = model(**batch)
+        loss = outputs.loss
+        accelerator.backward(loss)
+
+        optimizer.step()
+        lr_scheduler.step()
+        optimizer.zero_grad()
+        progress_bar.update(1)
+
+    # Evaluation
+    model.eval()
+    for step, batch in enumerate(eval_dataloader):
+        with torch.no_grad():
+            generated_tokens = accelerator.unwrap_model(model).generate(
+                batch["input_ids"],
+                attention_mask=batch["attention_mask"],
+            )
+
+            generated_tokens = accelerator.pad_across_processes(
+                generated_tokens, dim=1, pad_index=tokenizer.pad_token_id
+            )
+            labels = batch["labels"]
+
+            # အကယ်၍ ကျွန်တော်တို့ max length အထိ padding မလုပ်ခဲ့ရင်၊ labels တွေကိုလည်း pad လုပ်ဖို့ လိုအပ်ပါတယ်
+            labels = accelerator.pad_across_processes(
+                batch["labels"], dim=1, pad_index=tokenizer.pad_token_id
+            )
+
+            generated_tokens = accelerator.gather(generated_tokens).cpu().numpy()
+            labels = accelerator.gather(labels).cpu().numpy()
+
+            # labels တွေထဲက -100 တွေကို ကျွန်တော်တို့ decode လုပ်လို့မရတာကြောင့် အစားထိုးပါ
+            labels = np.where(labels != -100, labels, tokenizer.pad_token_id)
+            if isinstance(generated_tokens, tuple):
+                generated_tokens = generated_tokens[0]
+            decoded_preds = tokenizer.batch_decode(
+                generated_tokens, skip_special_tokens=True
+            )
+            decoded_labels = tokenizer.batch_decode(labels, skip_special_tokens=True)
+
+            decoded_preds, decoded_labels = postprocess_text(
+                decoded_preds, decoded_labels
+            )
+
+            rouge_score.add_batch(predictions=decoded_preds, references=decoded_labels)
+
+    # Metrics တွေကို တွက်ချက်ပါ
+    result = rouge_score.compute()
+    # Median ROUGE scores တွေကို ထုတ်ယူပါ
+    result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
+    result = {k: round(v, 4) for k, v in result.items()}
+    print(f"Epoch {epoch}:", result)
+
+    # Save လုပ်ပြီး upload လုပ်ပါ
+    accelerator.wait_for_everyone()
+    unwrapped_model = accelerator.unwrap_model(model)
+    unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)
+    if accelerator.is_main_process:
+        tokenizer.save_pretrained(output_dir)
+        repo.push_to_hub(
+            commit_message=f"Training in progress epoch {epoch}", blocking=False
+        )
+```
+
+```python out
+Epoch 0: {'rouge1': 5.6351, 'rouge2': 1.1625, 'rougeL': 5.4866, 'rougeLsum': 5.5005}
+Epoch 1: {'rouge1': 9.8646, 'rouge2': 3.4106, 'rougeL': 9.9439, 'rougeLsum': 9.9306}
+Epoch 2: {'rouge1': 11.0872, 'rouge2': 3.3273, 'rougeL': 11.0508, 'rougeLsum': 10.9468}
+Epoch 3: {'rouge1': 11.8587, 'rouge2': 4.8167, 'rougeL': 11.7986, 'rougeLsum': 11.7518}
+Epoch 4: {'rouge1': 12.9842, 'rouge2': 5.5887, 'rougeL': 12.7546, 'rougeLsum': 12.7029}
+Epoch 5: {'rouge1': 13.4628, 'rouge2': 6.4598, 'rougeL': 13.312, 'rougeLsum': 13.2913}
+Epoch 6: {'rouge1': 12.9131, 'rouge2': 5.8914, 'rougeL': 12.6896, 'rougeLsum': 12.5701}
+Epoch 7: {'rouge1': 13.3079, 'rouge2': 6.2994, 'rougeL': 13.1536, 'rougeLsum': 13.1194}
+Epoch 8: {'rouge1': 13.96, 'rouge2': 6.5998, 'rougeL': 13.9123, 'rougeLsum': 13.7744}
+Epoch 9: {'rouge1': 14.1192, 'rouge2': 7.0059, 'rougeL': 14.1172, 'rougeLsum': 13.9509}
+```
+
+ဒါပါပဲ! ဒါကို run လိုက်တာနဲ့၊ `Trainer` နဲ့ ကျွန်တော်တို့ ရရှိခဲ့တဲ့ ရလဒ်တွေနဲ့ အတော်လေး ဆင်တူတဲ့ model နဲ့ results တွေ သင်ရရှိပါလိမ့်မယ်။
+
+{/if}
+
+## သင် Fine-tuned လုပ်ထားသော Model ကို အသုံးပြုခြင်း[[using-your-fine-tuned-model]]
+
+Model ကို Hub ကို push လုပ်ပြီးတာနဲ့၊ inference widget ဒါမှမဟုတ် `pipeline` object ကို အသုံးပြုပြီး ဒါနဲ့ ကစားနိုင်ပါတယ်၊ အောက်ပါအတိုင်းပါ...
+
+```python
+from transformers import pipeline
+
+hub_model_id = "huggingface-course/mt5-small-finetuned-amazon-en-es"
+summarizer = pipeline("summarization", model=hub_model_id)
+```
+
+test set (model က မမြင်ဖူးသေးသော) က ဥပမာအချို့ကို ကျွန်တော်တို့ရဲ့ pipeline ကို ပေးပို့ခြင်းဖြင့် summaries တွေရဲ့ အရည်အသွေးကို ခံစားကြည့်နိုင်ပါတယ်။ ပထမဆုံး review၊ title နဲ့ generated summary တွေကို အတူတကွ ပြသဖို့ ရိုးရှင်းတဲ့ function တစ်ခုကို implement လုပ်ရအောင်။
+
+```python
+def print_summary(idx):
+    review = books_dataset["test"][idx]["review_body"]
+    title = books_dataset["test"][idx]["review_title"]
+    summary = summarizer(books_dataset["test"][idx]["review_body"])[0]["summary_text"]
+    print(f"'>>> Review: {review}'")
+    print(f"\n'>>> Title: {title}'")
+    print(f"\n'>>> Summary: {summary}'")
+```
+
+ကျွန်တော်တို့ ရရှိတဲ့ English ဥပမာတွေထဲက တစ်ခုကို ကြည့်ရအောင်...
+
+```python
+print_summary(100)
+```
+
+```python out
+'>>> Review: Nothing special at all about this product... the book is too small and stiff and hard to write in. The huge sticker on the back doesn’t come off and looks super tacky. I would not purchase this again. I could have just bought a journal from the dollar store and it would be basically the same thing. It’s also really expensive for what it is.'
+
+'>>> Title: Not impressed at all... buy something else'
+
+'>>> Summary: Nothing special at all about this product'
+```
+
+ဒါက သိပ်မဆိုးပါဘူး! ကျွန်တော်တို့ model ဟာ review ရဲ့ အစိတ်အပိုင်းတွေကို စကားလုံးအသစ်တွေနဲ့ ဖြည့်စွက်ခြင်းဖြင့် _abstractive_ summarization ကို တကယ်လုပ်ဆောင်နိုင်ခဲ့တာကို တွေ့မြင်နိုင်ပါတယ်။ ပြီးတော့ ကျွန်တော်တို့ model ရဲ့ အမိုက်ဆုံး ကဏ္ဍကတော့ ဒါက bilingual ဖြစ်တာကြောင့် Spanish reviews တွေကိုလည်း summaries တွေ ထုတ်လုပ်နိုင်ပါတယ်။
+
+```python
+print_summary(0)
+```
+
+```python out
+'>>> Review: Es una trilogia que se hace muy facil de leer. Me ha gustado, no me esperaba el final para nada'
+
+'>>> Title: Buena literatura para adolescentes'
+
+'>>> Summary: Muy facil de leer'
+```
+
+summary ကို English လို "Very easy to read" လို့ ဘာသာပြန်နိုင်ပြီး၊ ဒီကိစ္စမှာ review ကနေ တိုက်ရိုက်ထုတ်ယူထားတာကို ကျွန်တော်တို့ တွေ့မြင်နိုင်ပါတယ်။ သို့သော်လည်း၊ ဒါက mT5 model ရဲ့ versatility ကို ပြသပြီး multilingual corpus နဲ့ အလုပ်လုပ်တာ ဘယ်လိုလဲဆိုတာကို သင့်ကို ခံစားကြည့်ခွင့် ပေးခဲ့ပါတယ်။
+
+နောက်တစ်ဆင့်အနေနဲ့၊ အနည်းငယ် ပိုရှုပ်ထွေးတဲ့ task တစ်ခုကို ကျွန်တော်တို့ အာရုံစိုက်ပါမယ်၊ language model တစ်ခုကို အစကနေ train လုပ်တာပါ။
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **Transformer Models**: Natural Language Processing (NLP) မှာ အောင်မြင်မှုများစွာရရှိခဲ့တဲ့ deep learning architecture တစ်မျိုးပါ။
+*   **Text Summarization**: ရှည်လျားသော စာသားတစ်ခုကို အဓိကအချက်အလက်များပါဝင်သည့် ပိုတိုတောင်းသော version တစ်ခုအဖြစ် ပြောင်းလဲခြင်း။
+*   **NLP Tasks**: ကွန်ပျူတာတွေ လူသားဘာသာစကားကို နားလည်၊ အဓိပ္ပာယ်ဖော်ပြီး၊ ဖန်တီးနိုင်အောင် လုပ်ဆောင်ပေးတဲ့ အလုပ်တွေ။
+*   **Coherent Text**: အဓိပ္ပာယ်ပြည့်စုံပြီး စနစ်တကျရှိသော စာသား။
+*   **Domain Experts**: သီးခြားနယ်ပယ်တစ်ခုတွင် ကျွမ်းကျင်သူများ။
+*   **Hugging Face Hub**: AI မော်ဒယ်တွေ၊ datasets တွေနဲ့ demo တွေကို အခြားသူတွေနဲ့ မျှဝေဖို့၊ ရှာဖွေဖို့နဲ့ ပြန်လည်အသုံးပြုဖို့အတွက် အွန်လိုင်း platform တစ်ခု ဖြစ်ပါတယ်။
+*   **Pipeline Tag**: Hugging Face Hub တွင် models များကို pipeline အမျိုးအစားအလိုက် စစ်ထုတ်ရန် အသုံးပြုသော tag။
+*   **Bilingual Model**: ဘာသာစကားနှစ်မျိုး (ဤနေရာတွင် အင်္ဂလိပ်နှင့် စပိန်) ဖြင့် လုပ်ဆောင်နိုင်သော model။
+*   **Customer Reviews**: ထုတ်ကုန်များ သို့မဟုတ် ဝန်ဆောင်မှုများနှင့် ပတ်သက်သော သုံးစွဲသူများ၏ ထင်မြင်ယူဆချက်များ။
+*   **Corpus**: စာသား (သို့မဟုတ် အခြားဒေတာ) အစုအဝေးကြီးတစ်ခု။
+*   **Multilingual Amazon Reviews Corpus**: Amazon ထုတ်ကုန် reviews များ ပါဝင်သည့် ဘာသာစကားမျိုးစုံသုံး dataset။
+*   **Multilingual Classifiers**: ဘာသာစကားမျိုးစုံရှိ စာသားများကို အမျိုးအစားခွဲခြားနိုင်သော model များ။
+*   **Benchmark**: Model များ၏ စွမ်းဆောင်ရည်ကို တိုင်းတာရန်အတွက် စံသတ်မှတ်ထားသော datasets နှင့် metrics များ။
+*   **Target Summaries**: Model က ထုတ်လုပ်ရန် ရည်ရွယ်ထားသော အနှစ်ချုပ်စာသားများ (ဤနေရာတွင် review titles များ)။
+*   **Subsets**: ပိုကြီးသော dataset တစ်ခုမှ ရွေးထုတ်ထားသော အစိတ်အပိုင်းများ။
+*   **`load_dataset()` Function**: Hugging Face Datasets library မှ dataset များကို download လုပ်ပြီး cache လုပ်ရန် အသုံးပြုသော function။
+*   **`DatasetDict` Object**: Training set, validation set, နှင့် test set ကဲ့သို့သော dataset အများအပြားကို dictionary ပုံစံဖြင့် သိမ်းဆည်းထားသော object။
+*   **`train` Split**: Model ကို လေ့ကျင့်ရန်အတွက် အသုံးပြုသော dataset အပိုင်း။
+*   **`validation` Split**: Training လုပ်နေစဉ် model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် အသုံးပြုသော dataset အပိုင်း။
+*   **`test` Split**: Model ၏ နောက်ဆုံး စွမ်းဆောင်ရည်ကို တိုင်းတာရန် အသုံးပြုသော dataset အပိုင်း။
+*   **`review_body` Column**: review ၏ အဓိက စာသားပါဝင်သော column။
+*   **`review_title` Column**: review ၏ ခေါင်းစဉ်ပါဝင်သော column။
+*   **Random Sample**: dataset တစ်ခုမှ ကျပန်းရွေးချယ်ထားသော elements များ။
+*   **`Dataset.shuffle()` Method**: dataset အတွင်းရှိ elements များကို ကျပန်းရောနှော (shuffle) ရန် အသုံးပြုသော method။
+*   **`Dataset.select()` Method**: dataset ၏ သီးခြား elements များကို index များဖြင့် ရွေးထုတ်ရန် အသုံးပြုသော method။
+*   **Random Seed**: ကျပန်းနံပါတ်များ ထုတ်လုပ်ခြင်းကို ထိန်းချုပ်ရန် အသုံးပြုသော ကနဦးတန်ဖိုး။
+*   **Overfit**: Model တစ်ခုသည် training data ကို ကောင်းမွန်စွာ သင်ယူထားသော်လည်း မမြင်ဖူးသော data အပေါ်တွင် စွမ်းဆောင်ရည် နည်းပါးခြင်း။
+*   **`pandas.DataFrame`**: Pandas library ၏ data structure တစ်ခုဖြစ်ပြီး tabular data များကို သိမ်းဆည်းရန် အသုံးပြုသည်။
+*   **`value_counts()` Method**: DataFrame column တစ်ခုအတွင်းရှိ ထူးခြားသော တန်ဖိုးတစ်ခုစီ၏ အရေအတွက်ကို ရေတွက်သော Pandas method။
+*   **Product Category**: ထုတ်ကုန်များ၏ အမျိုးအစား။
+*   **`Dataset.filter()` Function**: 🤗 Datasets library မှာ ပါဝင်တဲ့ method တစ်ခုဖြစ်ပြီး သတ်မှတ်ထားသော အခြေအနေများနှင့် ကိုက်ညီသော ဒေတာများကိုသာ dataset မှ ရွေးထုတ်ရန် အသုံးပြုသည်။
+*   **Heuristic**: ပြဿနာတစ်ခုကို ဖြေရှင်းရန်အတွက် လက်တွေ့ကျသော သို့မဟုတ် rule-of-thumb နည်းလမ်း။
+*   **Whitespace**: စာသားများအတွင်းရှိ နေရာလွတ်များ (space, tab, newline)။
+*   **`split()` Method**: string တစ်ခုကို သတ်မှတ်ထားသော delimiter (ဥပမာ- whitespace) ဖြင့် ပိုင်းခြားပြီး list တစ်ခုအဖြစ် ပြန်ပေးသော Python string method။
+*   **`concatenate_datasets()` Function**: 🤗 Datasets library မှ `Dataset` objects နှစ်ခု သို့မဟုတ် နှစ်ခုထက်ပိုသော objects များကို ပေါင်းစပ်ရန် အသုံးပြုသော function။
+*   **Skewed**: data ၏ ဖြန့်ဝေမှု (distribution) သည် တစ်ဖက်သို့ စောင်းနေခြင်း။
+*   **Encoder-Decoder Architecture**: Transformer architecture တစ်မျိုးဖြစ်ပြီး input sequence ကို encode လုပ်ရန် encoder နှင့် output sequence ကို decode လုပ်ရန် decoder နှစ်ခုပါဝင်သည်။
+*   **GPT Family of Models**: OpenAI မှ ထုတ်လုပ်ထားသော Generative Pretrained Transformer (GPT) models များ။ auto-regressive language models များဖြစ်သည်။
+*   **Few-shot Settings**: လေ့ကျင့်မှုအတွက် data ဥပမာအနည်းငယ်သာ ရရှိနိုင်သော အခြေအနေ။
+*   **GPT-2**: auto-regressive language model တစ်ခု။
+*   **Auto-regressive Language Model**: ယခင် token များကို အခြေခံ၍ နောက် token ကို ခန့်မှန်းသော language model။
+*   **TL;DR (Too Long; Didn't Read)**: ရှည်လျားသော စာသားတစ်ခု၏ အနှစ်ချုပ်ကို ဖော်ပြရန် အင်တာနက်တွင် အသုံးပြုသော အတိုကောက်။
+*   **PEGASUS**: Masked sentences များကို ခန့်မှန်းခြင်းဖြင့် pretraining လုပ်ထားသော summarization model။
+*   **T5 (Text-to-Text Transfer Transformer)**: NLP tasks အားလုံးကို text-to-text format ဖြင့် ကိုင်တွယ်သော universal Transformer architecture။
+*   **`summarize: ARTICLE`**: T5 model တွင် summarization task အတွက် အသုံးပြုသော prompt prefix format။
+*   **mT5**: T5 model ၏ multilingual version။
+*   **Multilingual Common Crawl Corpus (mC4)**: ဘာသာစကားမျိုးစုံဖြင့် အင်တာနက်မှ စုဆောင်းထားသော large-scale corpus။
+*   **BART**: Encoder-decoder architecture ပါဝင်သော Transformer model တစ်မျိုးဖြစ်ပြီး corrupted input များကို reconstruct လုပ်ရန် လေ့ကျင့်ထားသည်။
+*   **mBART-50**: BART model ၏ multilingual version။
+*   **Monolingual**: ဘာသာစကားတစ်ခုတည်းဖြင့်သာ လုပ်ဆောင်နိုင်သော။
+*   **High-resource Language**: ဒေတာအမြောက်အမြားနှင့် ကိရိယာများစွာ ရရှိနိုင်သော ဘာသာစကား။
+*   **Jointly Trained**: မော်ဒယ်တစ်ခုကို ဒေတာအမျိုးအစားမျိုးစုံ သို့မဟုတ် ဘာသာစကားမျိုးစုံဖြင့် တစ်ပြိုင်နက်တည်း လေ့ကျင့်ခြင်း။
+*   **Prefix**: စာသား၏ အစပိုင်းတွင် ထည့်သွင်းထားသော စကားလုံး သို့မဟုတ် စာကြောင်း။
+*   **Condition**: Model ၏ output ကို ထိန်းချုပ်ခြင်း သို့မဟုတ် သတ်မှတ်ခြင်း။
+*   **Versatile**: ကိစ္စရပ်မျိုးစုံတွင် အသုံးပြုနိုင်သော။
+*   **Tokenize**: စာသား (သို့မဟုတ် အခြားဒေတာ) ကို AI မော်ဒယ်များ စီမံဆောင်ရွက်နိုင်ရန် tokens တွေအဖြစ် ပိုင်းခြားပေးသည့် လုပ်ငန်းစဉ်။
+*   **Encode**: ဒေတာများကို ဂဏန်းဆိုင်ရာ ကိုယ်စားပြုမှုအဖြစ် ပြောင်းလဲခြင်း။
+*   **`AutoTokenizer`**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး မော်ဒယ်အမည်ကို အသုံးပြုပြီး သက်ဆိုင်ရာ tokenizer ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **`mt5-small`**: mT5 model ၏ small version အတွက် checkpoint identifier။
+*   **Checkpoint**: မော်ဒယ်၏ weights များနှင့် အခြားဖွဲ့စည်းပုံများ (configuration) ကို သတ်မှတ်ထားသော အချိန်တစ်ခုတွင် သိမ်းဆည်းထားခြင်း။
+*   **Debug**: code ထဲက အမှားတွေကို ရှာဖွေပြီး ပြင်ဆင်ခြင်း။
+*   **Iterate**: ပြဿနာတစ်ခုကို ဖြေရှင်းရန်အတွက် အဆင့်များစွာကို ထပ်ခါတလဲလဲ လုပ်ဆောင်ခြင်း။
+*   **End-to-end Workflow**: အစမှအဆုံးအထိ ပြည့်စုံသော လုပ်ငန်းစီးဆင်းမှု။
+*   **Scale Up**: Model ၏ အရွယ်အစား သို့မဟုတ် training data ပမာဏကို တိုးမြှင့်ခြင်း။
+*   **`input_ids`**: Tokenizer မှ ထုတ်ပေးသော tokens တစ်ခုစီ၏ ထူးခြားသော ဂဏန်းဆိုင်ရာ ID များ။
+*   **`attention_mask`**: မော်ဒယ်ကို အာရုံစိုက်သင့်သည့် tokens များနှင့် လျစ်လျူရှုသင့်သည့် (padding) tokens များကို ခွဲခြားပေးသည့် binary mask။
+*   **Decode**: ဂဏန်းဆိုင်ရာ ကိုယ်စားပြုမှု (ဥပမာ- input IDs) ကို လူသားဖတ်နိုင်သော စာသားအဖြစ် ပြန်ပြောင်းခြင်း။
+*   **`convert_ids_to_tokens()` Function**: input IDs များကို tokens များအဖြစ် ပြန်ပြောင်းပေးသော tokenizer method။
+*   **Unicode Character ` `**: SentencePiece tokenizer တွင် word piece ၏ အစကို ဖော်ပြရန် အသုံးပြုသော အထူး character။
+*   **End-of-sequence Token `</s>`**: Sequence တစ်ခု၏ အဆုံးကို ဖော်ပြသော special token။
+*   **SentencePiece Tokenizer**: Google မှ ဖန်တီးထားသော subword tokenizer တစ်ခုဖြစ်ပြီး input text ကို pre-tokenize လုပ်ရန် မလိုအပ်ပါ။
+*   **Unigram Segmentation Algorithm**: subword tokenization algorithm တစ်မျိုး။
+*   **Agnostic**: သီးခြားအချက်အလက်တစ်ခုကို ဂရုမစိုက်ခြင်း သို့မဟုတ် မှီခိုခြင်းမရှိခြင်း။
+*   **Accents**: ဘာသာစကားများတွင် စကားလုံးများအပေါ်တွင် အသုံးပြုသော အသံထွက်ပြောင်းလဲမှုများ။
+*   **Punctuation**: စာသားများတွင် အသုံးပြုသော သတ်ပုံအမှတ်အသားများ (ဥပမာ- comma, period, question mark)။
+*   **Whitespace Characters**: နေရာလွတ် (space, tab, newline)။
+*   **Maximum Context Size**: Model တစ်ခုက တစ်ပြိုင်နက်တည်း လုပ်ဆောင်နိုင်သော အများဆုံး tokens အရေအတွက်။
+*   **Truncation**: input sequence ၏ အရှည်ကို model ၏ maximum context size သို့ လျှော့ချခြင်း။
+*   **`text_target` Argument**: tokenizer တွင် label text များကို input text နှင့် ပြိုင်တူ tokenize လုပ်ရန် အသုံးပြုသော argument။
+*   **`max_input_length`**: Input sequence အတွက် သတ်မှတ်ထားသော အများဆုံး tokens အရေအတွက်။
+*   **`max_target_length`**: Target (label) sequence အတွက် သတ်မှတ်ထားသော အများဆုံး tokens အရေအတွက်။
+*   **`preprocess_function()`**: data ကို preprocessing လုပ်ရန်အတွက် သတ်မှတ်ထားသော function။
+*   **`Dataset.map()` Function**: 🤗 Datasets library မှာ ပါဝင်တဲ့ method တစ်ခုဖြစ်ပြီး dataset ရဲ့ element တစ်ခုစီ ဒါမှမဟုတ် batch တစ်ခုစီပေါ်မှာ function တစ်ခုကို အသုံးပြုနိုင်စေသည်။
+*   **`batched=True`**: `map()` method မှာ အသုံးပြုသော argument တစ်ခုဖြစ်ပြီး function ကို dataset ရဲ့ element အများအပြားပေါ်မှာ တစ်ပြိုင်နက်တည်း အသုံးပြုစေသည်။
+*   **Multithreading Capabilities**: Program တစ်ခု၏ threads များစွာကို တစ်ပြိုင်နက်တည်း လုပ်ဆောင်နိုင်စွမ်း။
+*   **ROUGE Score (Recall-Oriented Understudy for Gisting Evaluation)**: generated summary တစ်ခုကို reference summaries များနှင့် နှိုင်းယှဉ်ခြင်းဖြင့် text summarization model များ၏ စွမ်းဆောင်ရည်ကို တိုင်းတာသော metric။
+*   **Text Generation Tasks**: AI model များမှ စာသားအသစ်များ ထုတ်လုပ်ခြင်းနှင့် သက်ဆိုင်သော လုပ်ငန်းများ။
+*   **Exact Match**: စာသားနှစ်ခု သို့မဟုတ် စကားလုံးနှစ်ခု တိတိကျကျ တူညီခြင်း။
+*   **Precision**: generated summary ထဲက ဘယ်လောက်အတိုင်းအတာအထိ relevant ဖြစ်လဲဆိုတာကို တိုင်းတာသော metric။
+*   **Recall**: reference summary ရဲ့ ဘယ်လောက်အတိုင်းအတာအထိ generated summary က ဖမ်းယူနိုင်လဲဆိုတာကို တိုင်းတာသော metric။
+*   **F1-score**: Precision နှင့် Recall တို့၏ harmonic mean ကို တွက်ချက်သော metric။
+*   **`rouge_score` Package**: ROUGE score ကို တွက်ချက်ရန်အတွက် Python package။
+*   **`evaluate` Library**: Hugging Face မှ metrics များကို load လုပ်ရန်နှင့် တွက်ချက်ရန်အတွက် library။
+*   **`evaluate.load("rouge")`**: ROUGE metric ကို load လုပ်ရန် command။
+*   **`rouge_score.compute()` Function**: ROUGE scores များကို တွက်ချက်ရန် function။
+*   **Confidence Intervals**: parameter တစ်ခု၏ ဖြစ်နိုင်ခြေတန်ဖိုးများ ပါဝင်နိုင်သော အတိုင်းအတာတစ်ခု။
+*   **`low`, `mid`, `high` Attributes**: Confidence interval ၏ အနိမ့်ဆုံး၊ အလယ်အလတ်၊ အမြင့်ဆုံး တန်ဖိုးများ။
+*   **Text Granularity**: စာသားကို ခွဲခြမ်းစိတ်ဖြာသည့် အဆင့် (ဥပမာ- စကားလုံးများ၊ bigrams, sentences)။
+*   **Unigrams**: စာသားတစ်ခုမှ တစ်လုံးချင်းစီသော စကားလုံးများ။
+*   **Bigrams**: စာသားတစ်ခုမှ စကားလုံးအတွဲများ။
+*   **`rougeL`**: Longest Common Subsequence (LCS) ကို အခြေခံ၍ တွက်ချက်သော ROUGE score။ sentence တစ်ခုစီ၏ average LCS ကို တိုင်းတာသည်။
+*   **`rougeLsum`**: `rougeL` နှင့် ဆင်တူသော်လည်း summary တစ်ခုလုံး၏ LCS ကို တိုင်းတာသည်။
+*   **Longest Common Substrings**: စာသားနှစ်ခုကြားရှိ အရှည်ဆုံး တူညီသော စာသားအပိုင်းအစ။
+*   **Baseline**: Model ၏ စွမ်းဆောင်ရည်ကို နှိုင်းယှဉ်ရန်အတွက် အသုံးပြုသော ရိုးရှင်းသော သို့မဟုတ် အခြေခံ model။
+*   **Lead-3 Baseline**: Text summarization တွင် article တစ်ခု၏ ပထမဆုံး sentences သုံးခုကို summary အဖြစ် ယူသော baseline။
+*   **`nltk` Library (Natural Language Toolkit)**: Python အတွက် NLP လုပ်ငန်းများအတွက် ကိရိယာများနှင့် library များ စုစည်းမှု။
+*   **`punkt` (NLTK Tokenizer Model)**: `nltk` library အတွင်းရှိ sentence tokenizer အတွက် training data။
+*   **`sent_tokenize()` Function**: `nltk` မှ စာသားတစ်ခုကို sentences များအဖြစ် ပိုင်းခြားပေးသော function။
+*   **`three_sentence_summary()` Function**: စာသားတစ်ခုမှ ပထမဆုံး sentences သုံးခုကို ထုတ်ယူရန် သတ်မှတ်ထားသော function။
+*   **`evaluate_baseline()` Function**: baseline model ၏ စွမ်းဆောင်ရည်ကို ROUGE metric ဖြင့် အကဲဖြတ်ရန် function။
+*   **`pandas`**: Python programming language အတွက် data analysis နှင့် manipulation အတွက် အသုံးပြုသော open-source library။
+*   **`round()` Function**: နံပါတ်တစ်ခုကို သတ်မှတ်ထားသော ဒသမနေရာအထိ ချုံ့ရန် Python function။
+*   **Skewed**: data ၏ ဖြန့်ဝေမှု (distribution) သည် တစ်ဖက်သို့ စောင်းနေခြင်း။
+*   **`AutoModelForSeq2SeqLM`**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး sequence-to-sequence language modeling (ဥပမာ- summarization, translation) အတွက် model တစ်ခုကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **Sequence-to-sequence Task**: input sequence တစ်ခုမှ output sequence တစ်ခုကို ထုတ်လုပ်သော task အမျိုးအစား။
+*   **`TFAutoModelForSeq2SeqLM`**: TensorFlow framework အတွက် `AutoModelForSeq2SeqLM` နှင့် တူညီသော လုပ်ဆောင်ချက်များရှိသည်။
+*   **Downstream Task**: Pretrained model တစ်ခုကို fine-tune လုပ်ရန် အသုံးပြုသော သီးခြားလုပ်ငန်း။
+*   **Randomly Initialized Network**: အစပိုင်းတွင် weights များကို ကျပန်းတန်ဖိုးများဖြင့် သတ်မှတ်ထားသော neural network။
+*   **`notebook_login()` Function**: Jupyter/Colab Notebooks များတွင် Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော function။
+*   **Credentials**: အသုံးပြုသူအမည်နှင့် စကားဝှက်ကဲ့သို့ အကောင့်ဝင်ရန်အတွက် အချက်အလက်များ။
+*   **`huggingface-cli login`**: Hugging Face CLI (Command Line Interface) မှ Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော command။
+*   **`Seq2SeqTrainingArguments`**: 🤗 Transformers library မှ sequence-to-sequence models များကို train လုပ်ရန်အတွက် training arguments များကို သတ်မှတ်ပေးသော class။
+*   **`Seq2SeqTrainer`**: 🤗 Transformers library မှ sequence-to-sequence models များကို လေ့ကျင့်ရန်အတွက် မြင့်မားသောအဆင့် (high-level) API။
+*   **Hyperparameters**: Model ကို မလေ့ကျင့်မီ သတ်မှတ်ရသော parameters များ (ဥပမာ- learning rate, batch size)။
+*   **`output_dir`**: Training outputs များကို သိမ်းဆည်းမည့် directory။
+*   **`evaluation_strategy="epoch"`**: Training လုပ်နေစဉ် evaluation ကို epoch တိုင်းတွင် ပြုလုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`learning_rate`**: Training လုပ်ငန်းစဉ်အတွင်း model ၏ weights များကို မည်မျှပြောင်းလဲရမည်ကို ထိန်းချုပ်သော parameter။
+*   **`per_device_train_batch_size`**: device တစ်ခုစီ (ဥပမာ- GPU) ပေါ်တွင် training အတွက် batch size။
+*   **`per_device_eval_batch_size`**: device တစ်ခုစီ (ဥပမာ- GPU) ပေါ်တွင် evaluation အတွက် batch size။
+*   **`weight_decay`**: Overfitting ကို လျှော့ချရန်အတွက် optimizer တွင် အသုံးပြုသော regularization နည်းလမ်း။
+*   **`save_total_limit`**: training လုပ်နေစဉ် သိမ်းဆည်းထားမည့် checkpoints အရေအတွက်ကို ကန့်သတ်ခြင်း။
+*   **`num_train_epochs`**: Model ကို training dataset တစ်ခုလုံးဖြင့် လေ့ကျင့်သည့် အကြိမ်အရေအတွက်။
+*   **`predict_with_generate=True`**: `Seq2SeqTrainer` ကို evaluation လုပ်နေစဉ် `model.generate()` method ကို အသုံးပြု၍ summaries များ ထုတ်လုပ်ရန် ညွှန်ကြားခြင်း။
+*   **`logging_steps`**: training loss ကို မည်မျှ steps ကြာတိုင်း log လုပ်မည်ကို သတ်မှတ်ခြင်း။
+*   **`push_to_hub=True`**: training ပြီးနောက် model ကို Hugging Face Hub သို့ push လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`hub_model_id` Argument**: Hugging Face Hub သို့ push လုပ်မည့် repository ၏ ID ကို သတ်မှတ်ရန် argument။
+*   **Organization**: Hugging Face Hub တွင် models များနှင့် datasets များကို စုစည်းပြီး မျှဝေရန် အသုံးပြုသော အဖွဲ့အစည်းအကောင့်။
+*   **`compute_metrics()` Function**: model ၏ predictions များနှင့် ground truth labels များကို အသုံးပြု၍ evaluation metrics များကို တွက်ချက်ရန် function။
+*   **`eval_pred`**: `compute_metrics` function သို့ ပေးပို့သော predictions နှင့် labels အတွဲ။
+*   **`predictions`**: Model မှ ထုတ်လုပ်သော ခန့်မှန်းချက်များ (tokens ID များ)။
+*   **`labels`**: Ground truth labels (tokens ID များ)။
+*   **`tokenizer.batch_decode()`**: batch တစ်ခုအတွင်းရှိ tokens ID များကို text အဖြစ် decode လုပ်သော tokenizer method။
+*   **`skip_special_tokens=True`**: decoding လုပ်နေစဉ် special tokens များကို ကျော်သွားရန် သတ်မှတ်ခြင်း။
+*   **`np.where(labels != -100, labels, tokenizer.pad_token_id)`**: NumPy function တစ်ခုဖြစ်ပြီး labels array ထဲက `-100` တွေကို `tokenizer.pad_token_id` နဲ့ အစားထိုးသည်။
+*   **`use_stemmer=True`**: ROUGE score တွက်ချက်ရာတွင် stemming ကို အသုံးပြုရန် သတ်မှတ်ခြင်း။
+*   **Median Scores**: scores များ၏ အလယ်တန်ဖိုး။
+*   **Data Collator**: batch တစ်ခုအတွင်း samples များကို စုစည်းပေးသော function။
+*   **Encoder-decoder Transformer Model**: Transformer architecture တစ်မျိုးဖြစ်ပြီး input sequence ကို encode လုပ်ရန် encoder နှင့် output sequence ကို decode လုပ်ရန် decoder နှစ်ခုပါဝင်သည်။
+*   **Ground Truth Labels**: မှန်ကန်သော သို့မဟုတ် အမှန်တကယ် labels များ။
+*   **Masked Self-attention**: Transformer တွင် self-attention mechanism ကို အသုံးပြုပြီး အချို့သော input tokens များကို ဖုံးကွယ်ထားခြင်း။
+*   **`DataCollatorForSeq2Seq`**: Hugging Face Transformers library မှ sequence-to-sequence models များအတွက် dynamic padding ကို လုပ်ဆောင်ပေးသော data collator။
+*   **Dynamically Pad**: batch တစ်ခုအတွင်းရှိ samples များကို အဲဒီ batch ထဲက အရှည်ဆုံး sample ရဲ့ အရှည်အထိသာ padding လုပ်ခြင်း။
+*   **`tokenized_datasets.remove_columns()`**: dataset မှ column များကို ဖယ်ရှားရန် method။
+*   **`column_names`**: dataset ၏ column အမည်များစာရင်း။
+*   **`dict`**: Python ၏ dictionary data structure။
+*   **`input_ids`**: Tokenizer မှ ထုတ်ပေးသော tokens တစ်ခုစီ၏ ထူးခြားသော ဂဏန်းဆိုင်ရာ ID များ။
+*   **`attention_mask`**: မော်ဒယ်ကို အာရုံစိုက်သင့်သည့် tokens များနှင့် လျစ်လျူရှုသင့်သည့် (padding) tokens များကို ခွဲခြားပေးသည့် binary mask။
+*   **`[PAD]` Token**: Padding အတွက် အသုံးပြုသော special token။
+*   **`pad_token_id`**: Padding token ၏ ID။
+*   **`decoder_input_ids`**: Decoder သို့ input အဖြစ် ပေးပို့သော ID များ။ labels များကို ညာဘက်သို့ ရွှေ့ထားသော ပုံစံဖြစ်သည်။
+*   **`Seq2SeqTrainer`**: Hugging Face Transformers library မှ sequence-to-sequence models များကို လေ့ကျင့်ရန်အတွက် မြင့်မားသောအဆင့် (high-level) API။
+*   **`trainer.train()`**: training လုပ်ငန်းစဉ်ကို စတင်ရန် method။
+*   **`trainer.evaluate()`**: model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် method။
+*   **`eval_loss`**: Evaluation dataset ပေါ်ရှိ loss တန်ဖိုး။
+*   **`eval_rouge1`, `eval_rouge2`, `eval_rougeL`, `eval_rougeLsum`**: Evaluation dataset ပေါ်ရှိ ROUGE scores များ။
+*   **`eval_gen_len`**: Generated summaries များ၏ ပျမ်းမျှအရှည်။
+*   **`eval_runtime`**: Evaluation လုပ်ဆောင်ရန် ကြာမြင့်သော အချိန်။
+*   **`eval_samples_per_second`**: တစ်စက္ကန့်လျှင် လုပ်ဆောင်သော samples အရေအတွက်။
+*   **`eval_steps_per_second`**: တစ်စက္ကန့်လျှင် လုပ်ဆောင်သော training steps အရေအတွက်။
+*   **Lead-3 Baseline**: Text summarization တွင် article တစ်ခု၏ ပထမဆုံး sentences သုံးခုကို summary အဖြစ် ယူသော baseline။
+*   **`trainer.push_to_hub()`**: model weights များနှင့် configuration files များကို Hugging Face Hub သို့ push လုပ်ရန် method။
+*   **`commit_message`**: Git commit အတွက် မက်ဆေ့ခ်ျ။
+*   **`tags`**: Hub ပေါ်ရှိ model ကို categorize လုပ်ရန် အသုံးပြုသော tags များ။
+*   **Text Generation Pipeline**: စာသားအသစ်များ ထုတ်လုပ်ရန်အတွက် ဒီဇိုင်းထုတ်ထားသော pipeline။
+*   **Git Commit Hash**: Git repository တွင် commit တစ်ခုစီကို ကိုယ်စားပြုသော ထူးခြားသည့် ID။
+*   **Model Repository**: Git version control system ကို အသုံးပြု၍ model file များ၊ tokenizer file များ၊ model card (README.md) နှင့် အခြားဆက်စပ်ဖိုင်များကို သိမ်းဆည်းထားသော နေရာ။
+*   **Low-level Features**: library ၏ အသေးစိတ်လုပ်ဆောင်မှုများကို တိုက်ရိုက်ထိန်းချုပ်နိုင်သော functions သို့မဟုတ် methods များ။
+*   **🤗 Accelerate**: Hugging Face က ထုတ်လုပ်ထားတဲ့ library တစ်ခုဖြစ်ပြီး PyTorch code တွေကို မတူညီတဲ့ training environment (ဥပမာ - GPU အများအပြား၊ distributed training) တွေမှာ အလွယ်တကူ run နိုင်အောင် ကူညီပေးပါတယ်။
+*   **`tf.data.Dataset`**: TensorFlow framework တွင် data pipeline များကို ဖန်တီးရန် အသုံးပြုသော dataset object။
+*   **`model.prepare_tf_dataset()`**: Hugging Face `Dataset` object ကို TensorFlow `tf.data.Dataset` သို့ ပြောင်းလဲရန် method။
+*   **`collate_fn`**: `tf.data.Dataset` တွင် batch တစ်ခုအတွင်း samples များကို စုစည်းရန် အသုံးပြုသော function (Data Collator)။
+*   **`shuffle=True`**: dataset ကို shuffle လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`batch_size`**: training လုပ်ငန်းစဉ်တစ်ခုစီတွင် model သို့ ပေးပို့သော input samples အရေအတွက်။
+*   **`optimizer`**: Model ၏ parameters များကို update လုပ်ရန် အသုံးပြုသော algorithm။
+*   **`schedule`**: Learning rate schedule။
+*   **`create_optimizer()`**: Hugging Face Transformers library မှ optimizer နှင့် learning rate schedule ကို ဖန်တီးရန် function။
+*   **`tensorflow as tf`**: TensorFlow library ကို `tf` အဖြစ် import လုပ်ခြင်း။
+*   **`init_lr`**: ကနဦး learning rate။
+*   **`num_warmup_steps`**: Training အစပိုင်းတွင် learning rate ကို တဖြည်းဖြည်း တိုးမြှင့်မည့် steps အရေအတွက်။
+*   **`num_train_steps`**: စုစုပေါင်း training steps အရေအတွက်။
+*   **`weight_decay_rate`**: `weight_decay` အတွက် rate။
+*   **`model.compile()`**: Keras model ကို training အတွက် ပြင်ဆင်ရန် method။
+*   **`tf.keras.mixed_precision.set_global_policy("mixed_float16")`**: TensorFlow တွင် mixed-precision training ကို ဖွင့်ရန် သတ်မှတ်ခြင်း။
+*   **Mixed-precision Float16**: training လုပ်နေစဉ် floating-point numbers များကို 16-bit format ဖြင့် အသုံးပြုခြင်း။ ၎င်းသည် memory အသုံးပြုမှုကို လျှော့ချပြီး training ကို အရှိန်မြှင့်သည်။
+*   **`model.fit()`**: Keras model ကို training လုပ်ရန် method။
+*   **`validation_data`**: Training လုပ်နေစဉ် evaluation အတွက် အသုံးပြုမည့် dataset။
+*   **`callbacks`**: Training လုပ်နေစဉ် သတ်မှတ်ထားသော အချိန်များတွင် လုပ်ဆောင်မည့် functions များ (ဥပမာ- `PushToHubCallback`)။
+*   **`epochs`**: Model ကို training dataset တစ်ခုလုံးဖြင့် လေ့ကျင့်သည့် အကြိမ်အရေအတွက်။
+*   **`PushToHubCallback`**: Hugging Face Transformers Keras callback တစ်ခုဖြစ်ပြီး training လုပ်နေစဉ် model ကို Hub သို့ push လုပ်ရန်။
+*   **`tqdm`**: Python library တစ်ခုဖြစ်ပြီး loops တွေအတွက် progress bar တွေကို ပြသပေးသည်။
+*   **XLA (Accelerated Linear Algebra)**: TensorFlow ရဲ့ compiler တစ်ခုဖြစ်ပြီး deep learning models တွေကို performance မြှင့်တင်ပေးသည်။
+*   **Computation Graph**: TensorFlow model ၏ operations များနှင့် ၎င်းတို့ ချိတ်ဆက်ပုံကို ဖော်ပြသော graph။
+*   **`@tf.function(jit_compile=True)` Decorator**: Python function တစ်ခုကို TensorFlow Graph function အဖြစ် compile လုပ်ရန် သတ်မှတ်ခြင်း။ `jit_compile=True` က XLA compilation ကို ဖွင့်သည်။
+*   **`generate_with_xla()` Function**: XLA compilation ဖြင့် model ၏ `generate()` method ကို အသုံးပြုသော function။
+*   **`max_new_tokens`**: Generated output ၏ အများဆုံး tokens အရေအတွက်။
+*   **`tqdm`**: Python library တစ်ခုဖြစ်ပြီး loops တွေအတွက် progress bar တွေကို ပြသပေးသည်။
+*   **`all_preds`**: Generated predictions များကို သိမ်းဆည်းထားသော list။
+*   **`all_labels`**: Ground truth labels များကို သိမ်းဆည်းထားသော list။
+*   **`DataLoader` (PyTorch)**: Dataset ကနေ data တွေကို batch အလိုက် load လုပ်ပေးတဲ့ PyTorch utility class။
+*   **`tokenized_datasets.set_format("torch")`**: dataset ၏ output format ကို PyTorch tensors အဖြစ် သတ်မှတ်ခြင်း။
+*   **`torch.utils.data.DataLoader`**: PyTorch ၏ `DataLoader` class။
+*   **`AdamW`**: PyTorch မှာ အသုံးပြုတဲ့ AdamW optimizer။ Model ၏ parameters များကို training လုပ်ရာမှာ အသုံးပြုသည်။
+*   **`model.parameters()`**: model ၏ လေ့ကျင့်နိုင်သော parameters (weights နှင့် biases) များကို ပြန်ပေးသော method။
+*   **`lr`**: Learning rate။
+*   **`Accelerator`**: 🤗 Accelerate library ၏ class တစ်ခုဖြစ်ပြီး distributed training setting တွင် model, optimizer, dataloaders များကို ပြင်ဆင်ရန်။
+*   **`accelerator.prepare()`**: model, optimizer, dataloaders များကို distributed training အတွက် ပြင်ဆင်ရန် Accelerate method။
+*   **TPU (Tensor Processing Unit)**: Google မှ AI/ML workloads များအတွက် အထူးဒီဇိုင်းထုတ်ထားသော processor တစ်မျိုး။
+*   **Learning Rate Schedule**: Training လုပ်နေစဉ် learning rate ကို မည်သို့ပြောင်းလဲမည်ကို သတ်မှတ်သော strategy။
+*   **`get_scheduler()`**: Hugging Face Transformers library မှ learning rate scheduler ကို ဖန်တီးရန် function။
+*   **`num_update_steps_per_epoch`**: epoch တစ်ခုစီတွင် update လုပ်သော steps အရေအတွက်။
+*   **`num_training_steps`**: စုစုပေါင်း training steps အရေအတွက်။
+*   **`postprocess_text()` Function**: generated summaries များကို evaluation အတွက် ပြင်ဆင်ရန် function။
+*   **`nltk.sent_tokenize()`**: `nltk` မှ စာသားတစ်ခုကို sentences များအဖြစ် ပိုင်းခြားပေးသော function။
+*   **🤗 Hub Library**: Hugging Face Hub နှင့် အပြန်အလှန်ဆက်သွယ်ရန် Python library။
+*   **`get_full_repo_name()` Function**: Hugging Face Hub တွင် repository ID ကို user profile နှင့် ပေါင်းစပ်ပြီး repository ၏ အမည်အပြည့်အစုံကို ရယူရန် function။
+*   **`repo_name`**: Repository ၏ အမည်အပြည့်အစုံ။
+*   **`Repository` Class**: `huggingface_hub` library မှ Git repository များကို ကိုင်တွယ်ရန်အတွက် class။
+*   **`output_dir`**: Training outputs များကို သိမ်းဆည်းမည့် directory။
+*   **`clone_from`**: remote repository မှ local repository သို့ clone လုပ်ရန် URL။
+*   **`repo.push_to_hub()` Method**: `Repository` object မှ changes များကို Hub သို့ push လုပ်ရန် method။
+*   **`blocking=False`**: `push_to_hub()` method တွင် asynchronous (တစ်ပြိုင်နက်တည်းမဟုတ်ဘဲ) push ကို ခွင့်ပြုရန် argument။
+*   **Asynchronously**: လုပ်ငန်းစဉ်တစ်ခု ပြီးဆုံးရန် မစောင့်ဘဲ နောက်ထပ်လုပ်ငန်းစဉ်များကို ဆက်လက်လုပ်ဆောင်ခြင်း။
+*   **`progress_bar`**: `tqdm` library မှ progress bar object။
+*   **`model.train()`**: PyTorch model ကို training mode သို့ ပြောင်းလဲခြင်း။
+*   **`model.eval()`**: PyTorch model ကို evaluation mode သို့ ပြောင်းလဲခြင်း။
+*   **`outputs = model(**batch)`**: model ကို input batch ဖြင့် run ပြီး outputs များကို ရယူခြင်း။
+*   **`loss = outputs.loss`**: model output မှ loss value ကို ရယူခြင်း။
+*   **`accelerator.backward(loss)`**: Accelerate ဖြင့် loss ကို backpropagate လုပ်ခြင်း။
+*   **`optimizer.step()`**: optimizer မှ model parameters များကို update လုပ်ခြင်း။
+*   **`lr_scheduler.step()`**: learning rate scheduler မှ learning rate ကို update လုပ်ခြင်း။
+*   **`optimizer.zero_grad()`**: optimizer ၏ gradients များကို သုညသို့ ပြန်သတ်မှတ်ခြင်း။
+*   **`progress_bar.update(1)`**: progress bar ကို တစ်ဆင့် တိုးမြှင့်ခြင်း။
+*   **`torch.no_grad()`**: PyTorch တွင် gradient calculation ကို ပိတ်ခြင်း (evaluation အတွက်)။
+*   **`accelerator.unwrap_model(model)`**: Accelerate ဖြင့် wrap လုပ်ထားသော model မှ underlying model ကို ရယူခြင်း။
+*   **`model.generate()`**: model မှ output sequence ကို ထုတ်လုပ်ရန် method။
+*   **`accelerator.pad_across_processes()`**: Distributed training တွင် processes များအလိုက် tensors များကို padding လုပ်ရန် Accelerate method။
+*   **`dim`**: padding လုပ်မည့် dimension။
+*   **`pad_index`**: padding အတွက် အသုံးပြုမည့် ID။
+*   **`accelerator.gather()`**: Distributed training တွင် processes များအလိုက် tensors များကို စုစည်းရန် Accelerate method။
+*   **`cpu().numpy()`**: PyTorch tensor ကို CPU သို့ ရွှေ့ပြီး NumPy array အဖြစ် ပြောင်းလဲခြင်း။
+*   **`isinstance(generated_tokens, tuple)`**: `generated_tokens` သည် tuple အမျိုးအစားဖြစ်ခြင်းရှိမရှိ စစ်ဆေးခြင်း။
+*   **`rouge_score.add_batch()`**: batch တစ်ခုအတွက် predictions နှင့် references များကို ROUGE metric သို့ ထည့်သွင်းခြင်း။
+*   **`rouge_score.compute()`**: စုစည်းထားသော predictions နှင့် references များအတွက် ROUGE scores များကို တွက်ချက်ခြင်း။
+*   **`accelerator.wait_for_everyone()`**: Distributed training တွင် processes အားလုံး ပြီးဆုံးရန် စောင့်ဆိုင်းခြင်း။
+*   **`unwrapped_model.save_pretrained()`**: pretrained model ၏ weights များကို သိမ်းဆည်းရန် method။
+*   **`save_function=accelerator.save`**: Accelerate ဖြင့် save လုပ်ရန် function ကို သတ်မှတ်ခြင်း။
+*   **`accelerator.is_main_process`**: လက်ရှိ process သည် main process ဖြစ်ခြင်းရှိမရှိ စစ်ဆေးခြင်း။
+*   **`tokenizer.save_pretrained(output_dir)`**: tokenizer ၏ files များကို သိမ်းဆည်းရန် method။
+*   **Inference Widget**: Hugging Face Hub ပေါ်တွင် model ကို web interface မှတစ်ဆင့် စမ်းသပ်နိုင်သော ကိရိယာ။
+*   **`pipeline()` Object**: Hugging Face Transformers library မှ model ကို အသုံးပြုရလွယ်ကူစေသော object။
+*   **`hub_model_id`**: Hugging Face Hub ပေါ်ရှိ model ၏ ID။
+*   **`summarizer`**: summarization pipeline object။
+*   **`summary_text`**: pipeline မှ ထုတ်ပေးသော summary text။
+*   **`print_summary()` Function**: review, title, နှင့် generated summary များကို print လုပ်ရန် function။
+*   **Abstractive Summarization**: input text မှ စကားလုံးများကို တိုက်ရိုက်ကူးယူခြင်းမဟုတ်ဘဲ၊ model က ကိုယ်ပိုင်စကားလုံးများဖြင့် အဓိပ္ပာယ်ကို နားလည်ပြီး အနှစ်ချုပ်ကို ထုတ်လုပ်ခြင်း။
+*   **Extractive Summarization**: input text မှ မူရင်းစာကြောင်းများ သို့မဟုတ် စကားလုံးများကို ရွေးထုတ်ပြီး အနှစ်ချုပ်ကို ဖန်တီးခြင်း။
+*   **Bilingual**: ဘာသာစကားနှစ်မျိုး။

--- a/chapters/my/chapter7/6.mdx
+++ b/chapters/my/chapter7/6.mdx
@@ -1,0 +1,1125 @@
+<FrameworkSwitchCourse {fw} />
+
+# Causal Language Model တစ်ခုကို အစကနေ လေ့ကျင့်ခြင်း[[training-a-causal-language-model-from-scratch]]
+
+{#if fw === 'pt'}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section6_pt.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section6_pt.ipynb"},
+]} />
+
+{:else}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section6_tf.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section6_tf.ipynb"},
+]} />
+
+{/if}
+
+အခုအထိတော့ ကျွန်တော်တို့ဟာ pretrained models တွေကို အများအားဖြင့် အသုံးပြုခဲ့ကြပြီး pretraining ကနေရရှိတဲ့ weights တွေကို ပြန်လည်အသုံးပြုခြင်းဖြင့် use cases အသစ်တွေအတွက် fine-tuning လုပ်ခဲ့ကြပါတယ်။ [Chapter 1](/course/chapter1) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့အတိုင်း၊ ဒါကို _transfer learning_ လို့ အများအားဖြင့် ရည်ညွှန်းကြပြီး၊ labeled data ရှားပါးတဲ့ လက်တွေ့ကမ္ဘာသုံး use cases အများစုမှာ Transformer models တွေကို အသုံးချဖို့အတွက် အလွန်အောင်မြင်တဲ့ နည်းဗျူဟာတစ်ခု ဖြစ်ပါတယ်။ ဒီအခန်းမှာ၊ ကျွန်တော်တို့ မတူညီတဲ့ နည်းလမ်းတစ်ခုကို အသုံးပြုပြီး model အသစ်တစ်ခုကို အစကနေ train လုပ်ပါမယ်။ ဒါက သင့်မှာ data အများကြီးရှိပြီး လက်ရှိ models တွေအတွက် အသုံးပြုခဲ့တဲ့ pretraining data တွေနဲ့ အလွန်ကွာခြားတယ်ဆိုရင် ကောင်းမွန်တဲ့ နည်းလမ်းတစ်ခုပါပဲ။ သို့သော်လည်း၊ လက်ရှိ model တစ်ခုကို fine-tune လုပ်တာထက် language model တစ်ခုကို pretrain လုပ်ဖို့အတွက် compute resources တွေ သိသိသာသာ ပိုလိုအပ်ပါတယ်။ model အသစ်တစ်ခုကို train လုပ်တာ အဓိပ္ပာယ်ရှိနိုင်တဲ့ ဥပမာတွေကတော့ musical notes, DNA လို molecular sequences ဒါမှမဟုတ် programming languages တွေ ပါဝင်တဲ့ datasets တွေ ဖြစ်ပါတယ်။ နောက်ဆုံးပြောခဲ့တဲ့အရာတွေက TabNine နဲ့ OpenAI ရဲ့ Codex model က ပံ့ပိုးပေးထားတဲ့ GitHub ရဲ့ Copilot လို tools တွေကြောင့် မကြာသေးခင်က အရှိန်အဟုန် ရရှိလာခဲ့ပါတယ်။ ဒါတွေက code ရဲ့ ရှည်လျားတဲ့ sequences တွေကို generate လုပ်နိုင်ပါတယ်။ text generation ရဲ့ ဒီ task ကို auto-regressive သို့မဟုတ် GPT-2 လို causal language models တွေနဲ့ အကောင်းဆုံး ကိုင်တွယ်ဖြေရှင်းနိုင်ပါတယ်။
+
+ဒီအပိုင်းမှာ ကျွန်တော်တို့ code generation model ရဲ့ scaled-down version တစ်ခုကို တည်ဆောက်ပါမယ်၊ Python code ရဲ့ subset တစ်ခုကို အသုံးပြုပြီး full functions ဒါမှမဟုတ် classes တွေအစား one-line completions တွေအပေါ် အာရုံစိုက်ပါမယ်။ Python မှာ data နဲ့ အလုပ်လုပ်တဲ့အခါ သင်ဟာ `matplotlib`, `seaborn`, `pandas`, နဲ့ `scikit-learn` libraries တွေ ပါဝင်တဲ့ Python data science stack နဲ့ မကြာခဏ ထိတွေ့နေရပါလိမ့်မယ်။ အဲဒီ frameworks တွေကို အသုံးပြုတဲ့အခါ သီးခြား commands တွေကို ရှာဖွေဖို့ လိုအပ်တာက ပုံမှန်ပါပဲ၊ ဒါကြောင့် ကျွန်တော်တို့အတွက် ဒီ calls တွေကို ဖြည့်စွက်ပေးနိုင်တဲ့ model တစ်ခုကို အသုံးပြုနိုင်ရင် ကောင်းပါလိမ့်မယ်။
+
+<Youtube id="Vpjb1lu0MDk"/>
+
+[Chapter 6](/course/chapter6) မှာ Python source code ကို process လုပ်ဖို့အတွက် ထိရောက်တဲ့ tokenizer တစ်ခုကို ကျွန်တော်တို့ ဖန်တီးခဲ့ပါတယ်၊ ဒါပေမယ့် ကျွန်တော်တို့ လိုအပ်နေသေးတာက model တစ်ခုကို pretrain လုပ်ဖို့အတွက် large-scale dataset တစ်ခုပါပဲ။ ဒီနေရာမှာ၊ ကျွန်တော်တို့ရဲ့ tokenizer ကို GitHub repositories ကနေ ရရှိတဲ့ Python code corpus တစ်ခုပေါ်မှာ အသုံးချပါမယ်။ ပြီးရင် model ကို train လုပ်ဖို့အတွက် `Trainer` API နဲ့ 🤗 Accelerate ကို အသုံးပြုပါမယ်။ စလိုက်ရအောင်!
+
+<iframe src="https://course-demos-codeparrot-ds.hf.space" frameBorder="0" height="300" title="Gradio app" class="block dark:hidden container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
+
+ဒါက ဒီအပိုင်းမှာ ပြသထားတဲ့ code ကို အသုံးပြုပြီး Hub ကို train လုပ်ပြီး upload လုပ်ထားတဲ့ model ကို လက်တွေ့ပြသနေတာ ဖြစ်ပါတယ်။ သင် [ဒီနေရာမှာ](https://huggingface.co/huggingface-course/codeparrot-ds?text=plt.imshow%28) ရှာတွေ့နိုင်ပါတယ်။ text generation မှာ randomization အချို့ဖြစ်ပေါ်နေတာကြောင့်၊ သင်အနည်းငယ်ကွဲပြားတဲ့ ရလဒ်ကို ရရှိနိုင်မယ်ဆိုတာ မှတ်သားပါ။
+
+## Data များကို စုဆောင်းခြင်း[[gathering-the-data]]
+
+Python code ကို GitHub လို code repositories တွေကနေ အလွယ်တကူ ရရှိနိုင်ပြီး၊ Python repository တိုင်းကို scraping လုပ်ခြင်းဖြင့် dataset တစ်ခု ဖန်တီးဖို့ ကျွန်တော်တို့ အသုံးပြုနိုင်ပါတယ်။ ဒါက [Transformers textbook](https://learning.oreilly.com/library/view/natural-language-processing/9781098136789/) မှာ large GPT-2 model တစ်ခုကို pretrain လုပ်ဖို့ အသုံးပြုခဲ့တဲ့ နည်းလမ်းပါပဲ။ `codeparrot` လို့ခေါ်တဲ့ Python files သန်း ၂၀ ခန့်ပါဝင်တဲ့ 180 GB ခန့်ရှိတဲ့ GitHub dump ကို အသုံးပြုပြီး၊ စာရေးဆရာတွေက dataset တစ်ခုကို တည်ဆောက်ခဲ့ပြီး အဲဒါကို [Hugging Face Hub](https://huggingface.co/datasets/transformersbook/codeparrot) မှာ မျှဝေခဲ့ပါတယ်။
+
+သို့သော်လည်း၊ full corpus ပေါ်မှာ training လုပ်တာက အချိန်နဲ့ compute-consuming ဖြစ်ပြီး၊ ကျွန်တော်တို့က Python data science stack နဲ့ ပတ်သက်တဲ့ dataset ရဲ့ subset ကိုပဲ လိုအပ်ပါတယ်။ ဒါကြောင့်၊ `codeparrot` dataset ကို ဒီ stack ထဲက libraries တွေ ပါဝင်တဲ့ files အားလုံးအတွက် filtering လုပ်ခြင်းဖြင့် စတင်ပါမယ်။ dataset ရဲ့ အရွယ်အစားကြောင့်၊ ကျွန်တော်တို့ ဒါကို download လုပ်တာကို ရှောင်ရှားချင်ပါတယ်၊ အစား streaming feature ကို အသုံးပြုပြီး on the fly မှာ filter လုပ်ပါမယ်။ အစောပိုင်းမှာ ကျွန်တော်တို့ ပြောခဲ့တဲ့ libraries တွေကို အသုံးပြုပြီး code samples တွေကို filter လုပ်ရာမှာ အကူအညီဖြစ်စေဖို့၊ အောက်ပါ function ကို အသုံးပြုပါမယ်။
+
+```py
+def any_keyword_in_string(string, keywords):
+    for keyword in keywords:
+        if keyword in string:
+            return True
+    return False
+```
+
+ဥပမာနှစ်ခုနဲ့ စမ်းသပ်ကြည့်ရအောင်။
+
+```py
+filters = ["pandas", "sklearn", "matplotlib", "seaborn"]
+example_1 = "import numpy as np"
+example_2 = "import pandas as pd"
+
+print(
+    any_keyword_in_string(example_1, filters), any_keyword_in_string(example_2, filters)
+)
+```
+
+```python out
+False True
+```
+
+ဒါကို အသုံးပြုပြီး dataset ကို stream လုပ်ပြီး ကျွန်တော်တို့ လိုချင်တဲ့ elements တွေကို filter လုပ်မယ့် function တစ်ခု ဖန်တီးနိုင်ပါတယ်။
+
+```py
+from collections import defaultdict
+from tqdm import tqdm
+from datasets import Dataset
+
+
+def filter_streaming_dataset(dataset, filters):
+    filtered_dict = defaultdict(list)
+    total = 0
+    for sample in tqdm(iter(dataset)):
+        total += 1
+        if any_keyword_in_string(sample["content"], filters):
+            for k, v in sample.items():
+                filtered_dict[k].append(v)
+    print(f"{len(filtered_dict['content'])/total:.2%} of data after filtering.")
+    return Dataset.from_dict(filtered_dict)
+```
+
+ပြီးရင် ဒီ function ကို streaming dataset ကို ရိုးရှင်းစွာ အသုံးချနိုင်ပါတယ်။
+
+```py
+# This cell will take a very long time to execute, so you should skip it and go to
+# the next one!
+from datasets import load_dataset
+
+split = "train"  # "valid"
+filters = ["pandas", "sklearn", "matplotlib", "seaborn"]
+
+data = load_dataset(f"transformersbook/codeparrot-{split}", split=split, streaming=True)
+filtered_data = filter_streaming_dataset(data, filters)
+```
+
+```python out
+3.26% of data after filtering.
+```
+
+ဒါက ကျွန်တော်တို့ကို မူရင်း dataset ရဲ့ ၃% ခန့် ကျန်ရှိစေပါတယ်၊ ဒါကလည်း အတော်လေး ကြီးမားနေဆဲပါပဲ — ရရှိလာတဲ့ dataset က 6 GB ရှိပြီး Python scripts ၆၀၀,၀၀၀ ပါဝင်ပါတယ်။
+
+full dataset ကို filtering လုပ်တာက သင့် machine နဲ့ bandwidth ပေါ်မူတည်ပြီး ၂-၃ နာရီ ကြာနိုင်ပါတယ်။ ဒီလို အချိန်ကုန်တဲ့ လုပ်ငန်းစဉ်ကို သင်ကိုယ်တိုင် မလုပ်ချင်ဘူးဆိုရင်၊ ကျွန်တော်တို့က Hub ပေါ်မှာ filtered dataset ကို download လုပ်ဖို့ ပံ့ပိုးပေးထားပါတယ်။
+
+```py
+from datasets import load_dataset, DatasetDict
+
+ds_train = load_dataset("huggingface-course/codeparrot-ds-train", split="train")
+ds_valid = load_dataset("huggingface-course/codeparrot-ds-valid", split="validation")
+
+raw_datasets = DatasetDict(
+    {
+        "train": ds_train,  # .shuffle().select(range(50000)),
+        "valid": ds_valid,  # .shuffle().select(range(500))
+    }
+)
+
+raw_datasets
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['repo_name', 'path', 'copies', 'size', 'content', 'license'],
+        num_rows: 606720
+    })
+    valid: Dataset({
+        features: ['repo_name', 'path', 'copies', 'size', 'content', 'license'],
+        num_rows: 3322
+    })
+})
+```
+
+> [!TIP]
+> Pretraining the language model will take a while. We suggest that you first run the training loop on a sample of the data by uncommenting the two partial lines above, and make sure that the training successfully completes and the models are stored. Nothing is more frustrating than a training run failing at the last step because you forgot to create a folder or because there's a typo at the end of the training loop!
+
+dataset ကနေ ဥပမာတစ်ခုကို ကြည့်ရအောင်။ field တစ်ခုစီရဲ့ ပထမဆုံး characters ၂၀၀ ကိုပဲ ပြသပါမယ်။
+
+```py
+for key in raw_datasets["train"][0]:
+    print(f"{key.upper()}: {raw_datasets['train'][0][key][:200]}")
+```
+
+```python out
+'REPO_NAME: kmike/scikit-learn'
+'PATH: sklearn/utils/__init__.py'
+'COPIES: 3'
+'SIZE: 10094'
+'''CONTENT: """
+The :mod:`sklearn.utils` module includes various utilites.
+"""
+
+from collections import Sequence
+
+import numpy as np
+from scipy.sparse import issparse
+import warnings
+
+from .murmurhash import murm
+LICENSE: bsd-3-clause'''
+```
+
+`content` field က ကျွန်တော်တို့ model train လုပ်ချင်တဲ့ code ကို ပါဝင်နေတာ တွေ့ရပါတယ်။ အခု dataset ရှိပြီဆိုတော့၊ pretraining အတွက် သင့်လျော်တဲ့ format ဖြစ်အောင် texts တွေကို ပြင်ဆင်ဖို့ လိုပါတယ်။
+
+## Dataset ကို ပြင်ဆင်ခြင်း[[preparing-the-dataset]]
+
+<Youtube id="ma1TrR7gE7I"/>
+
+ပထမအဆင့်က data ကို tokenize လုပ်မှာ ဖြစ်ပါတယ်၊ ဒါမှ training အတွက် အသုံးပြုနိုင်မှာပါ။ ကျွန်တော်တို့ရဲ့ ပန်းတိုင်က အဓိကအားဖြင့် တိုတောင်းတဲ့ function calls တွေကို autocomplete လုပ်တာဖြစ်တာကြောင့်၊ context size ကို အတော်လေး သေးငယ်အောင် ထားနိုင်ပါတယ်။ ဒါက model ကို အများကြီး ပိုမြန်မြန် train လုပ်နိုင်ပြီး memory အများကြီး သုံးစွဲမှု နည်းပါးစေတဲ့ အကျိုးကျေးဇူး ရှိပါတယ်။ သင့် application အတွက် context ပိုလိုအပ်တယ်ဆိုရင် (ဥပမာ - function definition ပါတဲ့ file တစ်ခုပေါ်မှာ အခြေခံပြီး unit tests တွေ ရေးစေချင်တယ်ဆိုရင်) အဲဒီနံပါတ်ကို သေချာတိုးမြှင့်ပါ၊ ဒါပေမယ့် ဒါက ပိုကြီးမားတဲ့ GPU memory footprint နဲ့ ပါလာနိုင်တယ်ဆိုတာကိုလည်း သတိရပါ။ အခုအတွက်တော့ context size ကို 128 tokens မှာ သတ်မှတ်ထားပါမယ်၊ GPT-2 ဒါမှမဟုတ် GPT-3 မှာ အသုံးပြုတဲ့ 1,024 ဒါမှမဟုတ် 2,048 နဲ့ မတူပါဘူး။
+
+documents အများစုမှာ 128 tokens ထက် အများကြီး ပိုများတဲ့ tokens တွေ ပါဝင်တာကြောင့်၊ inputs တွေကို maximum length အထိ ရိုးရှင်းစွာ truncate လုပ်တာက ကျွန်တော်တို့ dataset ရဲ့ အစိတ်အပိုင်းကြီးတစ်ခုကို ဖယ်ရှားပစ်ပါလိမ့်မယ်။ အစား၊ ကျွန်တော်တို့ `return_overflowing_tokens` option ကို အသုံးပြုပြီး input တစ်ခုလုံးကို tokenize လုပ်ပြီး chunks များစွာအဖြစ် ပိုင်းခြားပါမယ်၊ [Chapter 6](/course/chapter6/4) မှာ လုပ်ခဲ့တဲ့အတိုင်းပါပဲ။ `return_length` option ကိုလည်း အသုံးပြုပြီး ဖန်တီးထားတဲ့ chunk တစ်ခုစီရဲ့ length ကို အလိုအလျောက် ပြန်ပေးပါမယ်။ အများအားဖြင့် နောက်ဆုံး chunk က context size ထက် ပိုသေးငယ်နေမှာဖြစ်ပြီး၊ padding ပြဿနာတွေကို ရှောင်ရှားဖို့အတွက် ဒီအပိုင်းတွေကို ဖယ်ရှားပါမယ်၊ ကျွန်တော်တို့မှာ data အလုံအလောက်ရှိနေတာကြောင့် ဒါတွေ တကယ်မလိုအပ်ပါဘူး။
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/chunking_texts.svg" alt="Chunking a large texts in several pieces."/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/chunking_texts-dark.svg" alt="Chunking a large texts in several pieces."/>
+</div>
+
+ဒါက ဘယ်လိုအလုပ်လုပ်လဲဆိုတာကို ပထမဆုံးဥပမာနှစ်ခုကို ကြည့်ပြီး အတိအကျ ကြည့်ရအောင်။
+
+```py
+from transformers import AutoTokenizer
+
+context_length = 128
+tokenizer = AutoTokenizer.from_pretrained("huggingface-course/code-search-net-tokenizer")
+
+outputs = tokenizer(
+    raw_datasets["train"][:2]["content"],
+    truncation=True,
+    max_length=context_length,
+    return_overflowing_tokens=True,
+    return_length=True,
+)
+
+print(f"Input IDs length: {len(outputs['input_ids'])}")
+print(f"Input chunk lengths: {(outputs['length'])}")
+print(f"Chunk mapping: {outputs['overflow_to_sample_mapping']}")
+```
+
+```python out
+Input IDs length: 34
+Input chunk lengths: [128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 117, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 128, 41]
+Chunk mapping: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+```
+
+အဲဒီဥပမာနှစ်ခုကနေ segments ၃၄ ခု ရရှိတာကို တွေ့ရပါတယ်။ chunk lengths တွေကို ကြည့်ရင်၊ documents နှစ်ခုလုံးရဲ့ အဆုံးက chunks တွေမှာ 128 tokens ထက် နည်းပါးတာကို တွေ့ရပါတယ် (အသီးသီး 117 နဲ့ 41)။ ဒါတွေက ကျွန်တော်တို့မှာရှိတဲ့ စုစုပေါင်း chunks တွေရဲ့ အစိတ်အပိုင်းအနည်းငယ်မျှသာ ဖြစ်တာကြောင့်၊ ဒါတွေကို လုံခြုံစွာ ဖယ်ရှားနိုင်ပါတယ်။ `overflow_to_sample_mapping` field နဲ့၊ ဘယ် chunks တွေက ဘယ် input samples တွေနဲ့ သက်ဆိုင်တယ်ဆိုတာကိုလည်း ပြန်လည်တည်ဆောက်နိုင်ပါတယ်။
+
+ဒီ operation နဲ့ ကျွန်တော်တို့ 🤗 Datasets မှာရှိတဲ့ `Dataset.map()` function ရဲ့ အသုံးဝင်တဲ့ feature တစ်ခုကို အသုံးပြုနေပါတယ်။ ဒါက one-to-one maps တွေ မလိုအပ်ပါဘူး၊ [section 3](/course/chapter7/3) မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့အတိုင်း၊ input batch ထက် elements ပိုများတာ ဒါမှမဟုတ် နည်းပါးတာနဲ့ batches တွေကို ဖန်တီးနိုင်ပါတယ်။ ဒါက data augmentation ဒါမှမဟုတ် data filtering လို operations တွေ လုပ်တဲ့အခါ elements အရေအတွက်ကို ပြောင်းလဲတဲ့အခါ အသုံးဝင်ပါတယ်။ ကျွန်တော်တို့ရဲ့ ကိစ္စမှာ၊ element တစ်ခုစီကို သတ်မှတ်ထားတဲ့ context size ရှိတဲ့ chunks တွေအဖြစ် tokenize လုပ်တဲ့အခါ၊ document တစ်ခုစီကနေ samples များစွာကို ဖန်တီးပါတယ်။ ကျွန်တော်တို့က လက်ရှိ columns တွေကို ဖျက်ပစ်ဖို့ပဲ လိုအပ်ပါတယ်၊ ဘာလို့လဲဆိုတော့ ၎င်းတို့မှာ conflicting size ရှိနေလို့ပါ။ အကယ်၍ ဒါတွေကို ဆက်ထားချင်တယ်ဆိုရင်၊ ၎င်းတို့ကို သင့်လျော်စွာ ထပ်ခါတလဲလဲ လုပ်ပြီး `Dataset.map()` call ထဲကနေ ပြန်ပေးနိုင်ပါတယ်။
+
+```py
+def tokenize(element):
+    outputs = tokenizer(
+        element["content"],
+        truncation=True,
+        max_length=context_length,
+        return_overflowing_tokens=True,
+        return_length=True,
+    )
+    input_batch = []
+    for length, input_ids in zip(outputs["length"], outputs["input_ids"]):
+        if length == context_length:
+            input_batch.append(input_ids)
+    return {"input_ids": input_batch}
+
+
+tokenized_datasets = raw_datasets.map(
+    tokenize, batched=True, remove_columns=raw_datasets["train"].column_names
+)
+tokenized_datasets
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['input_ids'],
+        num_rows: 16702061
+    })
+    valid: Dataset({
+        features: ['input_ids'],
+        num_rows: 93164
+    })
+})
+```
+
+ကျွန်တော်တို့မှာ အခု 128 tokens စီပါဝင်တဲ့ examples 16.7 သန်း ရှိနေပြီး၊ ဒါက စုစုပေါင်း 2.1 ဘီလီယံ tokens ခန့်နဲ့ ကိုက်ညီပါတယ်။ ဥပမာအနေနဲ့၊ OpenAI ရဲ့ GPT-3 နဲ့ Codex models တွေကို ဘီလီယံ ၃၀၀ နဲ့ ဘီလီယံ ၁၀၀ tokens အသီးသီးပေါ်မှာ train လုပ်ထားပါတယ်၊ Codex models တွေကို GPT-3 checkpoints တွေကနေ initialize လုပ်ထားတာပါ။ ဒီအပိုင်းမှာ ကျွန်တော်တို့ရဲ့ ပန်းတိုင်က ရှည်လျားပြီး သဟဇာတဖြစ်တဲ့ texts တွေကို generate လုပ်နိုင်တဲ့ ဒီ models တွေနဲ့ ယှဉ်ပြိုင်ဖို့ မဟုတ်ပါဘူး၊ ဒါပေမယ့် data scientists တွေအတွက် မြန်ဆန်တဲ့ autocomplete function ကို ပံ့ပိုးပေးမယ့် scaled-down version တစ်ခုကို ဖန်တီးဖို့ပါပဲ။
+
+အခု dataset အဆင်သင့်ဖြစ်ပြီဆိုတော့၊ model ကို တည်ဆောက်ကြရအောင်!
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** context size ထက် သေးငယ်တဲ့ chunks တွေအားလုံးကို ဖယ်ရှားပစ်တာက ဒီနေရာမှာ သိပ်ပြဿနာမရှိခဲ့ပါဘူး၊ ဘာလို့လဲဆိုတော့ ကျွန်တော်တို့က small context windows တွေကို အသုံးပြုနေလို့ပါ။ သင် context size ကို တိုးမြှင့်တာနဲ့အမျှ (သို့မဟုတ် တိုတောင်းတဲ့ documents corpus တစ်ခုရှိတယ်ဆိုရင်) ဖယ်ရှားပစ်တဲ့ chunks တွေရဲ့ အချိုးအစားလည်း တိုးလာပါလိမ့်မယ်။ data ကို ပြင်ဆင်ဖို့ ပိုထိရောက်တဲ့ နည်းလမ်းက batch တစ်ခုထဲက tokenized samples အားလုံးကို `eos_token_id` token တစ်ခုနဲ့ ကြားထဲမှာ ပေါင်းစပ်ပြီး၊ ပြီးရင် concatenated sequences တွေပေါ်မှာ chunking ကို လုပ်ဆောင်တာပါပဲ။ လေ့ကျင့်ခန်းအနေနဲ့၊ အဲဒီနည်းလမ်းကို အသုံးပြုဖို့ `tokenize()` function ကို ပြင်ဆင်ပါ။ `truncation=False` ကို သတ်မှတ်ပြီး tokenizer ကနေ အခြား arguments တွေကို ဖယ်ရှားပြီး token IDs ရဲ့ full sequence ကို ရယူချင်တယ်ဆိုတာ သတိပြုပါ။
+
+## Model အသစ်တစ်ခုကို စတင်ခြင်း[[initializing-a-new-model]]
+
+ကျွန်တော်တို့ရဲ့ ပထမအဆင့်က GPT-2 model တစ်ခုကို လုံးဝအသစ်ကနေ initialize လုပ်ဖို့ပါပဲ။ ကျွန်တော်တို့ရဲ့ model အတွက် small GPT-2 model အတွက် configuration တူတူကို အသုံးပြုပါမယ်၊ ဒါကြောင့် pretrained configuration ကို load လုပ်ပြီး tokenizer size က model vocabulary size နဲ့ ကိုက်ညီကြောင်း သေချာစေကာ `bos` နဲ့ `eos` (beginning and end of sequence) token IDs တွေကို ထည့်ပေးပါမယ်-
+
+{#if fw === 'pt'}
+
+```py
+from transformers import AutoTokenizer, GPT2LMHeadModel, AutoConfig
+
+config = AutoConfig.from_pretrained(
+    "gpt2",
+    vocab_size=len(tokenizer),
+    n_ctx=context_length,
+    bos_token_id=tokenizer.bos_token_id,
+    eos_token_id=tokenizer.eos_token_id,
+)
+```
+
+အဲဒီ configuration နဲ့ model အသစ်တစ်ခုကို load လုပ်နိုင်ပါတယ်။ ဒါဟာ ကျွန်တော်တို့ `from_pretrained()` function ကို မသုံးဘဲ model ကို ကိုယ်တိုင် initialize လုပ်တာ ပထမဆုံးအကြိမ် ဖြစ်တယ်ဆိုတာ မှတ်သားပါ။
+
+```py
+model = GPT2LMHeadModel(config)
+model_size = sum(t.numel() for t in model.parameters())
+print(f"GPT-2 size: {model_size/1000**2:.1f}M parameters")
+```
+
+```python out
+GPT-2 size: 124.2M parameters
+```
+
+{:else}
+
+```py
+from transformers import AutoTokenizer, TFGPT2LMHeadModel, AutoConfig
+
+config = AutoConfig.from_pretrained(
+    "gpt2",
+    vocab_size=len(tokenizer),
+    n_ctx=context_length,
+    bos_token_id=tokenizer.bos_token_id,
+    eos_token_id=tokenizer.eos_token_id,
+)
+```
+
+အဲဒီ configuration နဲ့ model အသစ်တစ်ခုကို load လုပ်နိုင်ပါတယ်။ ဒါဟာ ကျွန်တော်တို့ `from_pretrained()` function ကို မသုံးဘဲ model ကို ကိုယ်တိုင် initialize လုပ်တာ ပထမဆုံးအကြိမ် ဖြစ်တယ်ဆိုတာ မှတ်သားပါ။
+
+```py
+model = TFGPT2LMHeadModel(config)
+model(model.dummy_inputs)  # Builds the model
+model.summary()
+```
+
+```python out
+_________________________________________________________________
+Layer (type)                 Output Shape              Param #   
+=================================================================
+transformer (TFGPT2MainLayer multiple                  124242432 
+=================================================================
+Total params: 124,242,432
+Trainable params: 124,242,432
+Non-trainable params: 0
+_________________________________________________________________
+```
+
+{/if}
+
+ကျွန်တော်တို့ရဲ့ model မှာ parameters 124M ရှိပြီး ဒါတွေကို tune လုပ်ရပါမယ်။ training မစတင်ခင်၊ batches တွေကို ဖန်တီးပေးမယ့် data collator တစ်ခုကို တည်ဆောက်ဖို့ လိုပါတယ်။ `DataCollatorForLanguageModeling` collator ကို အသုံးပြုနိုင်ပါတယ်၊ ဒါက language modeling အတွက် အထူးဒီဇိုင်းထုတ်ထားတာပါ (နာမည်က သိမ်မွေ့စွာ အကြံပြုထားတဲ့အတိုင်း)။ batches တွေကို stacking နဲ့ padding လုပ်ခြင်းအပြင်၊ ဒါက language model labels တွေ ဖန်တီးတာကိုပါ ဂရုစိုက်ပေးပါတယ် — causal language modeling မှာ inputs တွေက labels တွေအဖြစ်လည်း လုပ်ဆောင်ပါတယ် (element တစ်ခုနဲ့ ရွှေ့ထားရုံပါပဲ)၊ ပြီးတော့ ဒီ data collator က training လုပ်နေစဉ် on the fly မှာ ဒါတွေကို ဖန်တီးပေးတာကြောင့် `input_ids` တွေကို ထပ်ပွားဖို့ မလိုအပ်ပါဘူး။
+
+`DataCollatorForLanguageModeling` က masked language modeling (MLM) နဲ့ causal language modeling (CLM) နှစ်ခုလုံးကို ထောက်ပံ့ပေးတယ်ဆိုတာ မှတ်သားပါ။ default အားဖြင့် ဒါက MLM အတွက် data ကို ပြင်ဆင်ပေးပါတယ်၊ ဒါပေမယ့် `mlm=False` argument ကို သတ်မှတ်ခြင်းဖြင့် CLM ကို ပြောင်းနိုင်ပါတယ်။
+
+{#if fw === 'pt'}
+
+```py
+from transformers import DataCollatorForLanguageModeling
+
+tokenizer.pad_token = tokenizer.eos_token
+data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False)
+```
+
+{:else}
+
+```py
+from transformers import DataCollatorForLanguageModeling
+
+tokenizer.pad_token = tokenizer.eos_token
+data_collator = DataCollatorForLanguageModeling(tokenizer, mlm=False, return_tensors="tf")
+```
+
+{/if}
+
+ဥပမာတစ်ခု ကြည့်ရအောင်...
+
+```py
+out = data_collator([tokenized_datasets["train"][i] for i in range(5)])
+for key in out:
+    print(f"{key} shape: {out[key].shape}")
+```
+
+{#if fw === 'pt'}
+
+```python out
+input_ids shape: torch.Size([5, 128])
+attention_mask shape: torch.Size([5, 128])
+labels shape: torch.Size([5, 128])
+```
+
+{:else}
+
+```python out
+input_ids shape: (5, 128)
+attention_mask shape: (5, 128)
+labels shape: (5, 128)
+```
+
+{/if}
+
+examples တွေကို stacking လုပ်ထားပြီး tensors အားလုံးမှာ shape တူတူရှိတာကို တွေ့ရပါတယ်။
+
+{#if fw === 'tf'}
+
+အခု ကျွန်တော်တို့ ဖန်တီးခဲ့တဲ့ data collator နဲ့ datasets တွေကို TensorFlow datasets တွေအဖြစ် ပြောင်းလဲဖို့ `prepare_tf_dataset()` method ကို အသုံးပြုနိုင်ပါပြီ။
+
+```python
+tf_train_dataset = model.prepare_tf_dataset(
+    tokenized_datasets["train"],
+    collate_fn=data_collator,
+    shuffle=True,
+    batch_size=32,
+)
+tf_eval_dataset = model.prepare_tf_dataset(
+    tokenized_datasets["valid"],
+    collate_fn=data_collator,
+    shuffle=False,
+    batch_size=32,
+)
+```
+
+{/if}
+
+> [!WARNING]
+> ⚠️ inputs တွေနဲ့ labels တွေကို ချိန်ညှိဖို့ ရွှေ့ပြောင်းတာက model ထဲမှာ ဖြစ်ပေါ်ပါတယ်၊ ဒါကြောင့် data collator က inputs တွေကို labels တွေဖန်တီးဖို့ ကူးယူရုံပါပဲ။
+
+အခု ကျွန်တော်တို့ model ကို train လုပ်ဖို့ အရာအားလုံး အဆင်သင့်ဖြစ်ပါပြီ — ဒီလောက်အလုပ်အများကြီး မဟုတ်ပါလား! training မစတင်ခင် Hugging Face ကို login ဝင်သင့်ပါတယ်။ သင် notebook မှာ အလုပ်လုပ်နေတယ်ဆိုရင်၊ အောက်ပါ utility function နဲ့ လုပ်နိုင်ပါတယ်။
+
+```python
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+ဒါက သင် Hugging Face login credentials တွေ ထည့်သွင်းနိုင်မယ့် widget တစ်ခုကို ပြသပေးပါလိမ့်မယ်။
+
+သင် notebook မှာ အလုပ်မလုပ်ဘူးဆိုရင်၊ သင့် terminal မှာ အောက်ပါစာကြောင်းကို ရိုက်ထည့်လိုက်ပါ။
+
+```bash
+huggingface-cli login
+```
+
+{#if fw === 'pt'}
+
+ကျန်ရှိတာက training arguments တွေကို configure လုပ်ပြီး `Trainer` ကို စတင်ဖို့ပါပဲ။ warmup နဲ့ 256 (`per_device_train_batch_size` * `gradient_accumulation_steps`) ရဲ့ effective batch size နဲ့ cosine learning rate schedule ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။ gradient accumulation က single batch တစ်ခု memory ထဲ မဆံ့တဲ့အခါ အသုံးပြုပြီး၊ forward/backward passes များစွာကနေ gradient ကို တဖြည်းဖြည်း တည်ဆောက်ပါတယ်။ 🤗 Accelerate နဲ့ training loop ကို ဖန်တီးတဲ့အခါ ဒါကို လက်တွေ့ မြင်တွေ့ရပါလိမ့်မယ်။
+
+```py
+from transformers import Trainer, TrainingArguments
+
+args = TrainingArguments(
+    output_dir="codeparrot-ds",
+    per_device_train_batch_size=32,
+    per_device_eval_batch_size=32,
+    evaluation_strategy="steps",
+    eval_steps=5_000,
+    logging_steps=5_000,
+    gradient_accumulation_steps=8,
+    num_train_epochs=1,
+    weight_decay=0.1,
+    warmup_steps=1_000,
+    lr_scheduler_type="cosine",
+    learning_rate=5e-4,
+    save_steps=5_000,
+    fp16=True,
+    push_to_hub=True,
+)
+
+trainer = Trainer(
+    model=model,
+    tokenizer=tokenizer,
+    args=args,
+    data_collator=data_collator,
+    train_dataset=tokenized_datasets["train"],
+    eval_dataset=tokenized_datasets["valid"],
+)
+```
+
+အခု ကျွန်တော်တို့ `Trainer` ကို စတင်ပြီး training ပြီးဆုံးဖို့ စောင့်ဆိုင်းနိုင်ပါပြီ။ ဒါကို training set အပြည့်အစုံ ဒါမှမဟုတ် subset တစ်ခုပေါ်မှာ run ခြင်းပေါ်မူတည်ပြီး ၂၀ နာရီ ဒါမှမဟုတ် ၂ နာရီ အသီးသီး ကြာမြင့်ပါလိမ့်မယ်၊ ဒါကြောင့် ကော်ဖီအချို့နဲ့ ဖတ်ဖို့ ကောင်းမွန်တဲ့ စာအုပ်တစ်အုပ် ယူထားပါ။
+
+```py
+trainer.train()
+```
+
+training ပြီးဆုံးသွားပြီးနောက်၊ model နဲ့ tokenizer ကို Hub သို့ push လုပ်နိုင်ပါတယ်။
+
+```py
+trainer.push_to_hub()
+```
+
+{:else}
+
+ကျန်ရှိတာက training hyperparameters တွေကို configure လုပ်ပြီး `compile()` နဲ့ `fit()` ကို ခေါ်ဖို့ပါပဲ။ training ရဲ့ stability ကို တိုးတက်စေဖို့အတွက် warmup အချို့နဲ့ learning rate schedule ကို အသုံးပြုပါမယ်။
+
+```py
+from transformers import create_optimizer
+import tensorflow as tf
+
+num_train_steps = len(tf_train_dataset)
+optimizer, schedule = create_optimizer(
+    init_lr=5e-5,
+    num_warmup_steps=1_000,
+    num_train_steps=num_train_steps,
+    weight_decay_rate=0.01,
+)
+model.compile(optimizer=optimizer)
+
+# Train in mixed-precision float16
+tf.keras.mixed_precision.set_global_policy("mixed_float16")
+```
+
+အခု ကျွန်တော်တို့ `model.fit()` ကို ခေါ်ပြီး training ပြီးဆုံးဖို့ စောင့်ဆိုင်းနိုင်ပါပြီ။ ဒါကို training set အပြည့်အစုံ ဒါမှမဟုတ် subset တစ်ခုပေါ်မှာ run ခြင်းပေါ်မူတည်ပြီး ၂၀ နာရီ ဒါမှမဟုတ် ၂ နာရီ အသီးသီး ကြာမြင့်ပါလိမ့်မယ်၊ ဒါကြောင့် ကော်ဖီအချို့နဲ့ ဖတ်ဖို့ ကောင်းမွန်တဲ့ စာအုပ်တစ်အုပ် ယူထားပါ။ training ပြီးဆုံးသွားပြီးနောက် model နဲ့ tokenizer ကို Hub သို့ push လုပ်နိုင်ပါတယ်။
+
+```py
+from transformers.keras_callbacks import PushToHubCallback
+
+callback = PushToHubCallback(output_dir="codeparrot-ds", tokenizer=tokenizer)
+
+model.fit(tf_train_dataset, validation_data=tf_eval_dataset, callbacks=[callback])
+```
+
+{/if}
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** GPT-2 ကို raw texts ကနေ train လုပ်ဖို့ `TrainingArguments` အပြင် code လိုင်း ၃၀ ခန့်ပဲ ကျွန်တော်တို့ အသုံးပြုခဲ့ရပါတယ်။ သင့်ကိုယ်ပိုင် dataset နဲ့ စမ်းသပ်ကြည့်ပြီး ကောင်းမွန်တဲ့ ရလဒ်တွေ ရမရ ကြည့်ပါ။
+
+> [!TIP]
+> {#if fw === 'pt'}
+>
+> 💡 သင့်မှာ multiple GPUs ပါတဲ့ machine တစ်ခုရှိရင်၊ အဲဒီမှာ code ကို run ကြည့်ပါ။ `Trainer` က multiple machines တွေကို အလိုအလျောက် စီမံခန့်ခွဲပေးပြီး၊ ဒါက training ကို အလွန်အမင်း မြန်ဆန်စေနိုင်ပါတယ်။
+>
+> {:else}
+>
+> 💡 သင့်မှာ multiple GPUs ပါတဲ့ machine တစ်ခုရှိရင်၊ training ကို သိသိသာသာ အရှိန်မြှင့်ဖို့ `MirroredStrategy` context ကို အသုံးပြုကြည့်နိုင်ပါတယ်။ သင်ဟာ `tf.distribute.MirroredStrategy` object တစ်ခုကို ဖန်တီးဖို့ လိုအပ်ပါလိမ့်မယ်၊ ပြီးတော့ `to_tf_dataset()` ဒါမှမဟုတ် `prepare_tf_dataset()` methods တွေအပြင် model creation နဲ့ `fit()` ကို ခေါ်တာတွေ အားလုံးက ၎င်းရဲ့ `scope()` context ထဲမှာ run နေကြောင်း သေချာပါစေ။ ဒီအကြောင်းကို [ဒီနေရာမှာ](https://www.tensorflow.org/guide/distributed_training#use_tfdistributestrategy_with_keras_modelfit) မှတ်တမ်းကို ကြည့်နိုင်ပါတယ်။
+>
+> {/if}
+
+## Pipeline ဖြင့် Code Generation[[code-generation-with-a-pipeline]]
+
+အခုကတော့ အမှန်တရားရဲ့အချိန်ပါပဲ။ train လုပ်ထားတဲ့ model က ဘယ်လောက်ကောင်းကောင်း အလုပ်လုပ်လဲ ကြည့်ရအောင်။ loss က တသမတ်တည်း ကျဆင်းသွားတာကို logs တွေမှာ ကျွန်တော်တို့ မြင်နိုင်ပါတယ်၊ ဒါပေမယ့် model ကို စမ်းသပ်ဖို့ prompts အချို့မှာ ဘယ်လောက်ကောင်းကောင်း အလုပ်လုပ်လဲ ကြည့်ရအောင်။ ဒါကိုလုပ်ဖို့ model ကို text generation `pipeline` တစ်ခုထဲမှာ ထည့်သွင်းပါမယ်၊ ပြီးတော့ မြန်ဆန်တဲ့ generation တွေအတွက် GPU တစ်ခုရှိရင် GPU ပေါ်မှာ ထားပါမယ်။
+
+{#if fw === 'pt'}
+
+```py
+import torch
+from transformers import pipeline
+
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+pipe = pipeline(
+    "text-generation", model="huggingface-course/codeparrot-ds", device=device
+)
+```
+
+{:else}
+
+```py
+from transformers import pipeline
+
+course_model = TFGPT2LMHeadModel.from_pretrained("huggingface-course/codeparrot-ds")
+course_tokenizer = AutoTokenizer.from_pretrained("huggingface-course/codeparrot-ds")
+pipe = pipeline(
+    "text-generation", model=course_model, tokenizer=course_tokenizer, device=0
+)
+```
+
+{/if}
+
+scatter plot တစ်ခု ဖန်တီးတဲ့ ရိုးရှင်းတဲ့ task နဲ့ စတင်ကြရအောင်။
+
+```py
+txt = """\
+# create some data
+x = np.random.randn(100)
+y = np.random.randn(100)
+
+# create scatter plot with x, y
+"""
+print(pipe(txt, num_return_sequences=1)[0]["generated_text"])
+```
+
+```python out
+# create some data
+x = np.random.randn(100)
+y = np.random.randn(100)
+
+# create scatter plot with x, y
+plt.scatter(x, y)
+
+# create scatter
+```
+
+ရလဒ်က မှန်ကန်ပုံရပါတယ်။ `pandas` operation တစ်ခုအတွက်လည်း အလုပ်လုပ်သလား။ arrays နှစ်ခုကနေ `DataFrame` တစ်ခု ဖန်တီးနိုင်မလား ကြည့်ရအောင်။
+
+```py
+txt = """\
+# create some data
+x = np.random.randn(100)
+y = np.random.randn(100)
+
+# create dataframe from x and y
+"""
+print(pipe(txt, num_return_sequences=1)[0]["generated_text"])
+```
+
+```python out
+# create some data
+x = np.random.randn(100)
+y = np.random.randn(100)
+
+# create dataframe from x and y
+df = pd.DataFrame({'x': x, 'y': y})
+df.insert(0,'x', x)
+for
+```
+
+ကောင်းပါပြီ၊ ဒါက မှန်ကန်တဲ့ အဖြေပါ — ဒါပေမယ့် နောက်မှ column `x` ကို ထပ်ထည့်ပြန်ပါတယ်။ generate လုပ်တဲ့ tokens အရေအတွက် ကန့်သတ်ထားတာကြောင့်၊ အောက်ပါ `for` loop က ဖြတ်တောက်ခံထားရပါတယ်။ နည်းနည်းပိုရှုပ်ထွေးတဲ့အရာတစ်ခု လုပ်နိုင်မလား၊ `groupby` operation ကို အသုံးပြုရာမှာ model က ကျွန်တော်တို့ကို ကူညီနိုင်မလား ကြည့်ရအောင်။
+
+```py
+txt = """\
+# dataframe with profession, income and name
+df = pd.DataFrame({'profession': x, 'income':y, 'name': z})
+
+# calculate the mean income per profession
+"""
+print(pipe(txt, num_return_sequences=1)[0]["generated_text"])
+```
+
+```python out
+# dataframe with profession, income and name
+df = pd.DataFrame({'profession': x, 'income':y, 'name': z})
+
+# calculate the mean income per profession
+profession = df.groupby(['profession']).mean()
+
+# compute the
+```
+
+မဆိုးပါဘူး၊ ဒါက မှန်ကန်တဲ့နည်းလမ်းပါပဲ။ နောက်ဆုံးအနေနဲ့ `scikit-learn` အတွက်လည်း အသုံးပြုနိုင်မလား၊ Random Forest model တစ်ခုကို တည်ဆောက်နိုင်မလား ကြည့်ရအောင်-
+
+```py
+txt = """
+# import random forest regressor from scikit-learn
+from sklearn.ensemble import RandomForestRegressor
+
+# fit random forest model with 300 estimators on X, y:
+"""
+print(pipe(txt, num_return_sequences=1)[0]["generated_text"])
+```
+
+```python out
+# import random forest regressor from scikit-learn
+from sklearn.ensemble import RandomForestRegressor
+
+# fit random forest model with 300 estimators on X, y:
+rf = RandomForestRegressor(n_estimators=300, random_state=random_state, max_depth=3)
+rf.fit(X, y)
+rf
+```
+
+{#if fw === 'tf'}
+
+ဒီဥပမာအချို့ကို ကြည့်ရတာ၊ model ဟာ Python data science stack ရဲ့ syntax အချို့ကို သင်ယူခဲ့ပုံရပါတယ်။ Oof course, လက်တွေ့ကမ္ဘာမှာ deploy မလုပ်ခင် model ကို ပိုမိုစေ့စပ်သေချာစွာ evaluation လုပ်ဖို့ လိုအပ်ပါလိမ့်မယ်၊ ဒါပေမယ့် ဒါကတော့ အထင်ကြီးစရာ prototype တစ်ခုပါပဲ။
+
+{:else}
+
+ဒီဥပမာအချို့ကို ကြည့်ရတာ၊ model ဟာ Python data science stack ရဲ့ syntax အချို့ကို သင်ယူခဲ့ပုံရပါတယ်။ (Oof course, လက်တွေ့ကမ္ဘာမှာ deploy မလုပ်ခင် model ကို ပိုမိုစေ့စပ်သေချာစွာ evaluation လုပ်ဖို့ လိုအပ်ပါလိမ့်မယ်)။ သို့သော်လည်း၊ ပေးထားတဲ့ use case တစ်ခုအတွက် လိုအပ်တဲ့ performance ကို ရရှိဖို့အတွက် model training ကို ပိုမို customize လုပ်ဖို့ လိုအပ်တာတွေလည်း ရှိပါတယ်။ ဥပမာ၊ batch size ကို dynamically update လုပ်ချင်ရင် ဒါမှမဟုတ် bad examples တွေကို on the fly မှာ ကျော်သွားမယ့် conditional training loop တစ်ခုရှိချင်ရင် ဘယ်လိုလုပ်မလဲ။ နည်းလမ်းတစ်ခုကတော့ `Trainer` ကို subclass လုပ်ပြီး လိုအပ်တဲ့ ပြောင်းလဲမှုတွေကို ထည့်သွင်းတာပါပဲ၊ ဒါပေမယ့် တခါတလေ training loop ကို အစကနေ ရေးတာက ပိုရိုးရှင်းပါတယ်။ အဲဒီနေရာမှာ 🤗 Accelerate က ဝင်လာတာပါ။
+
+{/if}
+
+{#if fw === 'pt'}
+
+## 🤗 Accelerate ဖြင့် Training[[training-with-accelerate]]
+
+`Trainer` နဲ့ model တစ်ခုကို ဘယ်လို train လုပ်ရမယ်ဆိုတာ ကျွန်တော်တို့ မြင်ခဲ့ရပြီးပါပြီ၊ ဒါက customization အချို့ကို ခွင့်ပြုနိုင်ပါတယ်။ သို့သော်လည်း၊ တခါတလေ ကျွန်တော်တို့ training loop အပေါ် အပြည့်အဝ ထိန်းချုပ်ချင်တာ ဒါမှမဟုတ် ထူးခြားဆန်းကြယ်တဲ့ ပြောင်းလဲမှုအချို့ လုပ်ချင်ပါတယ်။ ဒီလိုကိစ္စမှာ 🤗 Accelerate က အကောင်းဆုံးရွေးချယ်မှုဖြစ်ပြီး၊ ဒီအပိုင်းမှာ ကျွန်တော်တို့ရဲ့ model ကို train လုပ်ဖို့အတွက် အသုံးပြုဖို့ အဆင့်တွေကို ကျွန်တော်တို့ ဖော်ပြပေးပါမယ်။ ပိုစိတ်ဝင်စားဖို့ကောင်းအောင်၊ training loop ကို twist တစ်ခုလည်း ထည့်သွင်းပါမယ်။
+
+<Youtube id="Hm8_PgVTFuc"/>
+
+ကျွန်တော်တို့ဟာ data science libraries တွေအတွက် သဘာဝကျတဲ့ autocompletion ကို အဓိက စိတ်ဝင်စားတာကြောင့်၊ ဒီ libraries တွေကို ပိုအသုံးပြုတဲ့ training samples တွေကို ပိုအလေးထားဖို့ အဓိပ္ပာယ်ရှိပါတယ်။ `plt`, `pd`, `sk`, `fit`, နဲ့ `predict` လို keywords တွေကို အသုံးပြုခြင်းဖြင့် ဒီ examples တွေကို အလွယ်တကူ ဖော်ထုတ်နိုင်ပါတယ်။ ဒါတွေက `matplotlib.pyplot`, `pandas`, နဲ့ `sklearn` အတွက် အသုံးများဆုံး import names တွေအပြင် နောက်ဆုံးနှစ်ခုရဲ့ fit/predict pattern လည်း ဖြစ်ပါတယ်။ ဒါတွေကို token တစ်ခုစီအဖြစ် ကိုယ်စားပြုထားရင်၊ ၎င်းတို့ input sequence မှာ ပါဝင်ခြင်းရှိမရှိ အလွယ်တကူ စစ်ဆေးနိုင်ပါတယ်။ Tokens တွေမှာ whitespace prefix ရှိနိုင်တာကြောင့်၊ tokenizer vocabulary ထဲက အဲဒီ versions တွေကိုလည်း စစ်ဆေးပါမယ်။ ဒါက အလုပ်လုပ်မလုပ် စစ်ဆေးဖို့အတွက်၊ multiple tokens အဖြစ် ခွဲခြားသင့်တဲ့ test token တစ်ခု ထည့်ပါမယ်။
+
+```py
+keytoken_ids = []
+for keyword in [
+    "plt",
+    "pd",
+    "sk",
+    "fit",
+    "predict",
+    " plt",
+    " pd",
+    " sk",
+    " fit",
+    " predict",
+    "testtest",
+]:
+    ids = tokenizer([keyword]).input_ids[0]
+    if len(ids) == 1:
+        keytoken_ids.append(ids[0])
+    else:
+        print(f"Keyword has not single token: {keyword}")
+```
+
+```python out
+'Keyword has not single token: testtest'
+```
+
+ကောင်းပါပြီ၊ ဒါက ကောင်းကောင်းအလုပ်လုပ်ပုံရပါတယ်။ အခု input sequence၊ logits နဲ့ ကျွန်တော်တို့ ရွေးချယ်ခဲ့တဲ့ key tokens တွေကို inputs အဖြစ် ယူတဲ့ custom loss function တစ်ခု ရေးနိုင်ပါပြီ။ ပထမဆုံး logits နဲ့ inputs တွေကို ချိန်ညှိဖို့ လိုပါတယ်- input sequence ကို တစ်ခုညာဘက်သို့ ရွှေ့ထားတာက labels တွေ ဖြစ်လာပါတယ်၊ ဘာလို့လဲဆိုတော့ နောက်ဆုံး token က လက်ရှိ token အတွက် label ဖြစ်လို့ပါ။ model က ပထမဆုံး token အတွက် prediction မလုပ်တာကြောင့် input sequence ရဲ့ ဒုတိယ token ကနေ labels တွေကို စတင်ခြင်းဖြင့် ဒါကို ကျွန်တော်တို့ အောင်မြင်နိုင်ပါတယ်။ ပြီးရင် နောက်ဆုံး logit ကို ဖြတ်ပစ်ပါမယ်၊ ဘာလို့လဲဆိုတော့ full input sequence နောက်က လိုက်လာမယ့် token အတွက် label မရှိလို့ပါပဲ။ ဒါတွေနဲ့ sample တစ်ခုစီရဲ့ loss ကို တွက်ချက်နိုင်ပြီး sample တစ်ခုစီမှာရှိတဲ့ keywords တွေရဲ့ ဖြစ်ပေါ်မှုတွေကို ရေတွက်နိုင်ပါတယ်။ နောက်ဆုံးအနေနဲ့၊ ဖြစ်ပေါ်မှုတွေကို weights အဖြစ် အသုံးပြုပြီး samples အားလုံးရဲ့ weighted average ကို တွက်ချက်ပါတယ်။ keywords မရှိတဲ့ samples တွေအားလုံးကို ဖယ်ရှားပစ်ဖို့ မလိုတာကြောင့်၊ weights တွေမှာ ၁ ကို ပေါင်းထည့်ပါတယ်။
+
+```py
+from torch.nn import CrossEntropyLoss
+import torch
+
+
+def keytoken_weighted_loss(inputs, logits, keytoken_ids, alpha=1.0):
+    # Shift so that tokens < n predict n
+    shift_labels = inputs[..., 1:].contiguous()
+    shift_logits = logits[..., :-1, :].contiguous()
+    # Calculate per-token loss
+    loss_fct = CrossEntropyLoss(reduce=False)
+    loss = loss_fct(shift_logits.view(-1, shift_logits.size(-1)), shift_labels.view(-1))
+    # Resize and average loss per sample
+    loss_per_sample = loss.view(shift_logits.size(0), shift_logits.size(1)).mean(axis=1)
+    # Calculate and scale weighting
+    weights = torch.stack([(inputs == kt).float() for kt in keytoken_ids]).sum(
+        axis=[0, 2]
+    )
+    weights = alpha * (1.0 + weights)
+    # Calculate weighted average
+    weighted_loss = (loss_per_sample * weights).mean()
+    return weighted_loss
+```
+
+ဒီအံ့သြဖွယ်ကောင်းတဲ့ loss function အသစ်နဲ့ training မစတင်ခင်၊ အချို့အရာတွေကို ပြင်ဆင်ဖို့ လိုပါတယ်။
+
+- batches တွေမှာ data ကို load လုပ်ဖို့ dataloaders တွေ လိုအပ်ပါတယ်။
+- weight decay parameters တွေကို တည်ဆောက်ဖို့ လိုပါတယ်။
+- အခါအားလျော်စွာ evaluate လုပ်ချင်တာကြောင့် evaluation code ကို function တစ်ခုထဲမှာ ထည့်သွင်းတာက အဓိပ္ပာယ်ရှိပါတယ်။
+
+dataloaders တွေနဲ့ စတင်ကြရအောင်။ dataset ရဲ့ format ကို `"torch"` လို့ သတ်မှတ်ဖို့ပဲ လိုအပ်ပြီး၊ ပြီးရင် သင့်လျော်တဲ့ batch size နဲ့ PyTorch `DataLoader` ကို ပေးနိုင်ပါတယ်။
+
+```py
+from torch.utils.data.dataloader import DataLoader
+
+tokenized_datasets.set_format("torch")
+train_dataloader = DataLoader(tokenized_datasets["train"], batch_size=32, shuffle=True)
+eval_dataloader = DataLoader(tokenized_datasets["valid"], batch_size=32)
+```
+
+နောက်တစ်ခုက parameters တွေကို အုပ်စုဖွဲ့ပါမယ်၊ ဒါမှ optimizer က ဘယ် parameters တွေက ထပ်ဆောင်း weight decay ရမလဲဆိုတာ သိမှာပါ။ ပုံမှန်အားဖြင့်၊ bias နဲ့ LayerNorm weights terms အားလုံးက ဒါကနေ ကင်းလွတ်ပါတယ်၊ ဒါကို ဘယ်လိုလုပ်ရမလဲဆိုတာ ဒီမှာပါ။
+
+```py
+weight_decay = 0.1
+
+
+def get_grouped_params(model, no_decay=["bias", "LayerNorm.weight"]):
+    params_with_wd, params_without_wd = [], []
+    for n, p in model.named_parameters():
+        if any(nd in n for nd in no_decay):
+            params_without_wd.append(p)
+        else:
+            params_with_wd.append(p)
+    return [
+        {"params": params_with_wd, "weight_decay": weight_decay},
+        {"params": params_without_wd, "weight_decay": 0.0},
+    ]
+```
+
+training လုပ်နေစဉ် validation set ပေါ်မှာ model ကို ပုံမှန် evaluate လုပ်ချင်တာကြောင့်၊ အဲဒါအတွက်လည်း function တစ်ခု ရေးကြရအောင်။ ဒါက evaluation dataloader ကို ဖြတ်ပြီး processes အားလုံးက losses တွေကို စုဆောင်းရုံပါပဲ။
+
+```py
+def evaluate():
+    model.eval()
+    losses = []
+    for step, batch in enumerate(eval_dataloader):
+        with torch.no_grad():
+            outputs = model(batch["input_ids"], labels=batch["input_ids"])
+
+        losses.append(accelerator.gather(outputs.loss))
+    loss = torch.mean(torch.cat(losses))
+    try:
+        perplexity = torch.exp(loss)
+    except OverflowError:
+        perplexity = float("inf")
+    return loss.item(), perplexity.item()
+```
+
+`evaluate()` function နဲ့ loss နဲ့ [perplexity](/course/chapter7/3) ကို ပုံမှန်ကြားကာလတွေမှာ report လုပ်နိုင်ပါတယ်။ နောက်တစ်ခုက၊ model ကို အစကနေ train လုပ်တာ သေချာစေဖို့ model ကို ပြန်လည်သတ်မှတ်ပါမယ်။
+
+```py
+model = GPT2LMHeadModel(config)
+```
+
+ပြီးရင် ကျွန်တော်တို့ optimizer ကို သတ်မှတ်နိုင်ပါတယ်၊ weight decay အတွက် parameters တွေကို ခွဲဖို့ ယခင် function ကို အသုံးပြုပြီး-
+
+```py
+from torch.optim import AdamW
+
+optimizer = AdamW(get_grouped_params(model), lr=5e-4)
+```
+
+အခု model, optimizer နဲ့ dataloaders တွေကို ပြင်ဆင်ပြီး training စတင်နိုင်ပါပြီ။
+
+```py
+from accelerate import Accelerator
+
+accelerator = Accelerator(fp16=True)
+
+model, optimizer, train_dataloader, eval_dataloader = accelerator.prepare(
+    model, optimizer, train_dataloader, eval_dataloader
+)
+```
+
+> [!TIP]
+> 🚨 သင် TPU ပေါ်မှာ train လုပ်နေတယ်ဆိုရင်၊ အပေါ်က cell ကနေ စတင်တဲ့ code အားလုံးကို dedicated training function တစ်ခုထဲကို ရွှေ့ဖို့ လိုအပ်ပါလိမ့်မယ်။ အသေးစိတ်အချက်အလက်တွေအတွက် [Chapter 3](/course/chapter3) ကို ကြည့်ပါ။
+
+ကျွန်တော်တို့ `train_dataloader` ကို `accelerator.prepare()` သို့ ပေးပို့ပြီးတာနဲ့၊ ၎င်းရဲ့ length ကို အသုံးပြုပြီး training steps အရေအတွက်ကို တွက်ချက်နိုင်ပါပြီ။ အဲဒီ method က ၎င်းရဲ့ length ကို ပြောင်းလဲမှာ ဖြစ်တာကြောင့် dataloader ကို ပြင်ဆင်ပြီးနောက် ဒါကို အမြဲလုပ်ဆောင်သင့်တယ်ဆိုတာ မှတ်သားပါ။ learning rate ကနေ ၀ အထိ classic linear schedule ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။
+
+```py
+from transformers import get_scheduler
+
+num_train_epochs = 1
+num_update_steps_per_epoch = len(train_dataloader)
+num_training_steps = num_train_epochs * num_update_steps_per_epoch
+
+lr_scheduler = get_scheduler(
+    name="linear",
+    optimizer=optimizer,
+    num_warmup_steps=1_000,
+    num_training_steps=num_training_steps,
+)
+```
+
+နောက်ဆုံးအနေနဲ့၊ ကျွန်တော်တို့ model ကို Hub ကို push လုပ်ဖို့အတွက်၊ working folder တစ်ခုထဲမှာ `Repository` object တစ်ခု ဖန်တီးဖို့ လိုအပ်ပါလိမ့်မယ်။ ပထမဆုံး Hugging Face Hub ကို login ဝင်ပါ၊ အကယ်၍ သင် login ဝင်ထားခြင်းမရှိသေးရင်ပေါ့။ ကျွန်တော်တို့ရဲ့ model ကို ပေးချင်တဲ့ model ID ကနေ repository name ကို ကျွန်တော်တို့ ဆုံးဖြတ်ပါမယ် (သင် `repo_name` ကို သင့်ကိုယ်ပိုင် ရွေးချယ်မှုနဲ့ အစားထိုးနိုင်ပါတယ်၊ ဒါက သင့် username ကို ပါဝင်ဖို့ပဲ လိုအပ်ပြီး၊ ဒါက `get_full_repo_name()` function က လုပ်ဆောင်တာပါ)။
+
+```py
+from huggingface_hub import Repository, get_full_repo_name
+
+model_name = "codeparrot-ds-accelerate"
+repo_name = get_full_repo_name(model_name)
+repo_name
+```
+
+```python out
+'sgugger/codeparrot-ds-accelerate'
+```
+
+ပြီးရင် အဲဒီ repository ကို local folder တစ်ခုထဲမှာ clone လုပ်နိုင်ပါတယ်။ အကယ်၍ ဒါက ရှိပြီးသားဆိုရင်၊ ဒီ local folder က ကျွန်တော်တို့ အလုပ်လုပ်နေတဲ့ repository ရဲ့ ရှိပြီးသား clone တစ်ခု ဖြစ်သင့်ပါတယ်။
+
+```py
+output_dir = "codeparrot-ds-accelerate"
+repo = Repository(output_dir, clone_from=repo_name)
+```
+
+အခု ကျွန်တော်တို့ `repo.push_to_hub()` method ကို ခေါ်ခြင်းဖြင့် `output_dir` မှာ သိမ်းဆည်းထားတဲ့ ဘယ်အရာကိုမဆို upload လုပ်နိုင်ပါပြီ။ ဒါက epoch တစ်ခုစီရဲ့ အဆုံးမှာ intermediate models တွေကို upload လုပ်ဖို့ ကူညီပေးပါလိမ့်မယ်။
+
+training မလုပ်ခင်၊ evaluation function မှန်ကန်စွာ အလုပ်လုပ်မလုပ် စစ်ဆေးဖို့ quick test တစ်ခု run ကြရအောင်။
+
+```py
+evaluate()
+```
+
+```python out
+(10.934126853942871, 56057.14453125)
+```
+
+ဒါတွေက loss နဲ့ perplexity အတွက် အလွန်မြင့်မားတဲ့ တန်ဖိုးတွေဖြစ်ပေမယ့်၊ model ကို မtrain ရသေးတာကြောင့် အံ့သြစရာ မဟုတ်ပါဘူး။ ဒါတွေနဲ့ training script ရဲ့ core အပိုင်းဖြစ်တဲ့ training loop ကို ရေးဖို့ အရာအားလုံး အဆင်သင့်ဖြစ်ပါပြီ။ training loop ထဲမှာ ကျွန်တော်တို့ dataloader ကို iterate လုပ်ပြီး batches တွေကို model ကို ပေးပို့ပါတယ်။ logits တွေနဲ့၊ ကျွန်တော်တို့ရဲ့ custom loss function ကို evaluate လုပ်နိုင်ပါတယ်။ gradient accumulation steps အရေအတွက်နဲ့ loss ကို scale လုပ်ပါတယ်၊ ဒါမှ steps တွေ ပိုများများ aggregate လုပ်တဲ့အခါ losses တွေ ပိုကြီးလာတာ မဖြစ်အောင်လို့ပါ။ optimize မလုပ်ခင်၊ ပိုမိုကောင်းမွန်တဲ့ convergence အတွက် gradients တွေကို clip လုပ်ပါတယ်။ နောက်ဆုံးအနေနဲ့၊ steps အနည်းငယ်တိုင်းမှာ evaluation set ပေါ်မှာ model ကို ကျွန်တော်တို့ရဲ့ `evaluate()` function အသစ်နဲ့ evaluate လုပ်ပါတယ်။
+
+```py
+from tqdm.notebook import tqdm
+
+gradient_accumulation_steps = 8
+eval_steps = 5_000
+
+model.train()
+completed_steps = 0
+for epoch in range(num_train_epochs):
+    for step, batch in tqdm(
+        enumerate(train_dataloader, start=1), total=num_training_steps
+    ):
+        logits = model(batch["input_ids"]).logits
+        loss = keytoken_weighted_loss(batch["input_ids"], logits, keytoken_ids)
+        if step % 100 == 0:
+            accelerator.print(
+                {
+                    "samples": step * samples_per_step,
+                    "steps": completed_steps,
+                    "loss/train": loss.item() * gradient_accumulation_steps,
+                }
+            )
+        loss = loss / gradient_accumulation_steps
+        accelerator.backward(loss)
+        if step % gradient_accumulation_steps == 0:
+            accelerator.clip_grad_norm_(model.parameters(), 1.0)
+            optimizer.step()
+            lr_scheduler.step()
+            optimizer.zero_grad()
+            completed_steps += 1
+        if (step % (eval_steps * gradient_accumulation_steps)) == 0:
+            eval_loss, perplexity = evaluate()
+            accelerator.print({"loss/eval": eval_loss, "perplexity": perplexity})
+            model.train()
+            accelerator.wait_for_everyone()
+            unwrapped_model = accelerator.unwrap_model(model)
+            unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)
+            if accelerator.is_main_process:
+                tokenizer.save_pretrained(output_dir)
+                repo.push_to_hub(
+                    commit_message=f"Training in progress step {step}", blocking=False
+                )
+```
+
+ပြီးပါပြီ။ အခု သင်ကိုယ်ပိုင် causal language models တွေဖြစ်တဲ့ GPT-2 လို models တွေအတွက် custom training loop တစ်ခု ရရှိခဲ့ပါပြီ၊ ဒါကို သင့်လိုအပ်ချက်တွေအတိုင်း ထပ်မံ customize လုပ်နိုင်ပါတယ်။
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** သင့် use case နဲ့ ကိုက်ညီတဲ့ သင့်ကိုယ်ပိုင် custom loss function တစ်ခု ဖန်တီးပါ၊ ဒါမှမဟုတ် training loop ထဲကို အခြား custom step တစ်ခု ထည့်ပါ။
+
+> [!TIP]
+> ✏️ **စမ်းသပ်ကြည့်ပါ။** training experiments တွေကို အကြာကြီး run တဲ့အခါ TensorBoard ဒါမှမဟုတ် Weights & Biases လို tools တွေကို အသုံးပြုပြီး အရေးကြီးတဲ့ metrics တွေကို log လုပ်တာက ကောင်းမွန်တဲ့ အကြံဥာဏ်တစ်ခုပါ။ training ဘယ်လိုသွားနေလဲဆိုတာ အမြဲစစ်ဆေးနိုင်ဖို့ training loop ထဲကို သင့်လျော်တဲ့ logging ကို ထည့်ပါ။
+
+{/if}
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **Causal Language Model**: စာသား sequence တစ်ခုရှိ token တစ်ခုစီ၏ နောက်ဆက်တွဲ token ကို ခန့်မှန်းရန် လေ့ကျင့်ထားသော language model အမျိုးအစား။ ၎င်းသည် auto-regressive model တစ်ခုဖြစ်ပြီး GPT-2, GPT-3 ကဲ့သို့ models တွေမှာ အသုံးပြုသည်။
+*   **From Scratch**: Model (သို့မဟုတ် tokenizer) တစ်ခုကို မည်သည့် အစောပိုင်းလေ့ကျင့်မှုမျှ မရှိဘဲ လုံးဝအသစ်ကနေ စတင်တည်ဆောက်ခြင်းနှင့် လေ့ကျင့်ခြင်း။
+*   **Pretrained Models**: အကြီးစား ဒေတာအမြောက်အမြားဖြင့် ကြိုတင်လေ့ကျင့်ထားပြီးဖြစ်သော AI (Artificial Intelligence) မော်ဒယ်။
+*   **Fine-tuning**: ကြိုတင်လေ့ကျင့်ထားပြီးသား (pre-trained) မော်ဒယ်တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (specific task) အတွက် အနည်းငယ်သော ဒေတာနဲ့ ထပ်မံလေ့ကျင့်ပေးခြင်း။
+*   **Weights**: Neural network model တစ်ခု၏ layers များကြားရှိ ဆက်သွယ်မှုများ၏ အားသာချက်များကို ကိုယ်စားပြုသော တန်ဖိုးများ။
+*   **Pretraining**: Model ကို large-scale datasets များဖြင့် အစောပိုင်းလေ့ကျင့်ခြင်း လုပ်ငန်းစဉ်။
+*   **Transfer Learning**: ကြိုတင်လေ့ကျင့်ထားသော model တစ်ခုမှ သင်ယူထားသော ဗဟုသုတများကို အခြားဆက်စပ်လုပ်ငန်းတစ်ခုသို့ လွှဲပြောင်းအသုံးပြုခြင်း။
+*   **Transformer Models**: Natural Language Processing (NLP) မှာ အောင်မြင်မှုများစွာရရှိခဲ့တဲ့ deep learning architecture တစ်မျိုးပါ။
+*   **Labeled Data**: အဖြေမှန်များ သို့မဟုတ် categories များနှင့် သက်ဆိုင်သော labels များ ပါဝင်သော data။
+*   **Sparse (Data)**: အချက်အလက်နည်းပါးသော သို့မဟုတ် ပြည့်စုံမှုမရှိသော ဒေတာ။
+*   **Compute Resources**: AI/ML models များကို လေ့ကျင့်ရန်နှင့် အသုံးပြုရန်အတွက် လိုအပ်သော ကွန်ပျူတာစွမ်းအား (ဥပမာ- CPUs, GPUs, TPUs)။
+*   **Language Model**: လူသားဘာသာစကား၏ ဖြန့်ဝေမှုကို နားလည်ရန် လေ့ကျင့်ထားသော AI မော်ဒယ်တစ်ခု။
+*   **Musical Notes**: ဂီတသံစဉ်များကို ကိုယ်စားပြုသော သင်္ကေတများ။
+*   **Molecular Sequences**: DNA သို့မဟုတ် ပရိုတင်းများကဲ့သို့ မော်လီကျူးဖွဲ့စည်းပုံများ၏ အစီအစဉ်များ။
+*   **Programming Languages**: ကွန်ပျူတာပရိုဂရမ်များကို ရေးသားရန်အတွက် အသုံးပြုသော ဘာသာစကားများ။
+*   **TabNine**: AI-powered code completion tool။
+*   **GitHub Copilot**: OpenAI ၏ Codex model က ပံ့ပိုးပေးသော AI-powered code completion tool။
+*   **OpenAI Codex Model**: OpenAI မှ code generation အတွက် လေ့ကျင့်ထားသော LLM။
+*   **Text Generation**: AI မော်ဒယ်များကို အသုံးပြု၍ လူသားကဲ့သို့သော စာသားအသစ်များ ဖန်တီးခြင်း။
+*   **Auto-regressive Models**: input sequence ၏ ယခင် tokens များပေါ်တွင် အခြေခံပြီး နောက်ဆက်တွဲ token များကို တစ်ခုပြီးတစ်ခု ခန့်မှန်းသော model များ။
+*   **GPT-2**: OpenAI မှ ထုတ်လုပ်ထားသော Transformer-based causal language model။
+*   **Scaled-down Version**: မူရင်းစနစ် သို့မဟုတ် model ၏ အရွယ်အစား သို့မဟုတ် စွမ်းဆောင်ရည်ကို လျှော့ချထားသော version။
+*   **One-line Completions**: code ၏ တစ်ကြောင်းတည်းသော အပိုင်းများကို အလိုအလျောက် ဖြည့်စွက်ပေးခြင်း။
+*   **Python Code**: Python programming language ဖြင့် ရေးသားထားသော code များ။
+*   **Python Data Science Stack**: Python တွင် data science လုပ်ငန်းများအတွက် အသုံးပြုသော libraries များ (ဥပမာ- matplotlib, seaborn, pandas, scikit-learn)။
+*   **`matplotlib`**: Python အတွက် plotting library။
+*   **`seaborn`**: `matplotlib` ပေါ်တွင် အခြေခံထားသော data visualization library။
+*   **`pandas`**: Python အတွက် data analysis library။
+*   **`scikit-learn`**: Python အတွက် machine learning library။
+*   **Tokenizer**: စာသား (သို့မဟုတ် အခြားဒေတာ) ကို AI မော်ဒယ်များ စီမံဆောင်ရွက်နိုင်ရန် tokens တွေအဖြစ် ပိုင်းခြားပေးသည့် ကိရိယာ သို့မဟုတ် လုပ်ငန်းစဉ်။
+*   **Large-scale Dataset**: အရွယ်အစား ကြီးမားသော dataset။
+*   **Corpus of Python Code**: Python code များစွာ ပါဝင်သော စာသားအစုအဝေး။
+*   **GitHub Repositories**: Git version control system ကို အသုံးပြု၍ code များကို သိမ်းဆည်းထားသော online repository များ။
+*   **`Trainer` API**: Hugging Face Transformers library မှ model များကို ထိရောက်စွာ လေ့ကျင့်ရန်အတွက် ဒီဇိုင်းထုတ်ထားသော မြင့်မားသောအဆင့် API။
+*   **🤗 Accelerate**: Hugging Face က ထုတ်လုပ်ထားတဲ့ library တစ်ခုဖြစ်ပြီး PyTorch code တွေကို မတူညီတဲ့ training environment (ဥပမာ - GPU အများအပြား၊ distributed training) တွေမှာ အလွယ်တကူ run နိုင်အောင် ကူညီပေးပါတယ်။
+*   **Gradio App**: Gradio library ကို အသုံးပြုပြီး တည်ဆောက်ထားသော machine learning model ၏ web demo။
+*   **Model Hub**: Hugging Face Hub ကို ရည်ညွှန်းပြီး AI မော်ဒယ်များ ရှာဖွေ၊ မျှဝေ၊ အသုံးပြုနိုင်သော ဗဟို platform။
+*   **Scraping**: ဝဘ်ဆိုဒ်များမှ အချက်အလက်များကို အလိုအလျောက် ထုတ်ယူခြင်း။
+*   **GitHub Dump**: GitHub repositories များမှ data များကို စုဆောင်းထားသော အစုံလိုက် (bulk) ဒေတာ။
+*   **`codeparrot`**: GitHub မှ Python code များဖြင့် ဖွဲ့စည်းထားသော dataset။
+*   **Streaming Feature**: Dataset တစ်ခုလုံးကို memory ထဲသို့ load မလုပ်ဘဲ လိုအပ်သလို အပိုင်းလိုက် stream လုပ်ခြင်း။
+*   **On the Fly**: လုပ်ငန်းစဉ်တစ်ခု ဖြစ်ပေါ်နေစဉ်အတွင်း ချက်ချင်း လုပ်ဆောင်ခြင်း။
+*   **Keywords**: စာသားတစ်ခု၏ အဓိကအချက်အလက်ကို ကိုယ်စားပြုသော စကားလုံးများ။
+*   **`defaultdict`**: `collections` module မှ dictionary subclass တစ်ခုဖြစ်ပြီး key တစ်ခု မရှိပါက default value တစ်ခုကို အလိုအလျောက် ဖန်တီးပေးသည်။
+*   **`tqdm`**: Python library တစ်ခုဖြစ်ပြီး loops များအတွက် progress bar များကို လှပစွာ ဖော်ပြပေးသည်။
+*   **`Dataset` (Hugging Face)**: 🤗 Datasets library တွင် dataset တစ်ခုကို ကိုယ်စားပြုသော class။
+*   **`filter_streaming_dataset()` Function**: streaming dataset မှ အချို့သော အခြေအနေများနှင့် ကိုက်ညီသော data များကို filter လုပ်ရန် ဒီဇိုင်းထုတ်ထားသော function။
+*   **`raw_datasets`**: preprocessing မလုပ်ရသေးသော dataset။
+*   **Python Scripts**: Python programming language ဖြင့် ရေးသားထားသော code file များ။
+*   **Pretraining the Language Model**: language model ကို ဒေတာများဖြင့် အစောပိုင်းလေ့ကျင့်ခြင်း။
+*   **Training Loop**: model တစ်ခုကို လေ့ကျင့်ရန်အတွက် iterations များစွာဖြင့် လုပ်ဆောင်သော အဓိက code အပိုင်း။
+*   **Model Card**: Hugging Face Hub တွင် မော်ဒယ်တစ်ခုစီအတွက် ပါရှိသော အချက်အလက်များပါသည့် စာမျက်နှာ။
+*   **`content` Field**: dataset မှ code content ပါဝင်သော field။
+*   **Truncating Inputs**: input sequence ၏ အရှည်ကို သတ်မှတ်ထားသော maximum length သို့ လျှော့ချခြင်း။
+*   **Context Size**: model တစ်ခုက prediction ပြုလုပ်ရာတွင် ထည့်သွင်းစဉ်းစားသော input sequence ၏ အရှည် (tokens အရေအတွက်)။
+*   **GPU Memory Footprint**: GPU memory ပေါ်တွင် model တစ်ခုက သိမ်းပိုက်ထားသော နေရာ။
+*   **Tokens**: စာသားကို ပိုင်းခြားထားသော အသေးငယ်ဆုံးယူနစ်များ။
+*   **`return_overflowing_tokens` Option**: tokenizer ကို input sequence ကို chunks များစွာအဖြစ် ပိုင်းခြားရန် ညွှန်ကြားသော option။
+*   **`return_length` Option**: tokenizer ကို ဖန်တီးထားသော chunk တစ်ခုစီ၏ length ကို ပြန်ပေးရန် ညွှန်ကြားသော option။
+*   **Padding Issues**: batch အတွင်းရှိ sequences များကို အရှည်တူညီအောင် ဖြည့်စွက်ရာတွင် ဖြစ်ပေါ်နိုင်သော ပြဿနာများ။
+*   **`overflow_to_sample_mapping` Field**: chunk တစ်ခုစီသည် မူရင်း input sample မည်သည့်တစ်ခုနှင့် သက်ဆိုင်သည်ကို ဖော်ပြပေးသော field။
+*   **`Dataset.map()` Function**: 🤗 Datasets library မှာ ပါဝင်တဲ့ method တစ်ခုဖြစ်ပြီး dataset ရဲ့ element တစ်ခုစီ ဒါမှမဟုတ် batch တစ်ခုစီပေါ်မှာ function တစ်ခုကို အသုံးပြုနိုင်စေသည်။
+*   **One-to-one Maps**: input element တစ်ခုစီအတွက် output element တစ်ခုသာ ထုတ်ပေးသော mapping။
+*   **Data Augmentation**: datasets ၏ အရွယ်အစားကို တိုးမြှင့်ရန်အတွက် လက်ရှိ data မှ ပြောင်းလဲထားသော မိတ္တူအသစ်များ ဖန်တီးခြင်း။
+*   **Data Filtering**: dataset မှ သတ်မှတ်ထားသော အခြေအနေများနှင့် ကိုက်ညီသော data များကို ရွေးထုတ်ခြင်း။
+*   **Conflicting Size**: columns များ၏ အရွယ်အစားများ မကိုက်ညီခြင်း။
+*   **`remove_columns` Argument**: `Dataset.map()` method တွင် dataset မှ columns များကို ဖယ်ရှားရန် အသုံးပြုသော argument။
+*   **`input_ids`**: Tokenizer မှ ထုတ်ပေးသော tokens တစ်ခုစီ၏ ထူးခြားသော ဂဏန်းဆိုင်ရာ ID များ။
+*   **GPT-3**: OpenAI မှ ထုတ်လုပ်ထားသော အလွန်ကြီးမားသည့် Transformer-based causal language model။
+*   **Autocomplete Function**: စာရိုက်နေစဉ် စကားလုံးများ သို့မဟုတ် code များကို အလိုအလျောက် ဖြည့်စွက်ပေးသော လုပ်ဆောင်ချက်။
+*   **Context Windows**: model က prediction လုပ်ရာတွင် ထည့်သွင်းစဉ်းစားသော input ၏ အပိုင်းအစ။
+*   **`eos_token_id` Token**: sequence ၏ အဆုံးကို ကိုယ်စားပြုသော end-of-sequence token ၏ ID။
+*   **Concatenated Sequences**: sequences များစွာကို တစ်ခုတည်းအဖြစ် ပေါင်းစပ်ထားခြင်း။
+*   **`truncation=False`**: tokenizer ကို input sequence ကို truncate မလုပ်ရန် ညွှန်ကြားခြင်း။
+*   **`AutoTokenizer`**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး မော်ဒယ်အမည်ကို အသုံးပြုပြီး သက်ဆိုင်ရာ tokenizer ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **`GPT2LMHeadModel`**: GPT-2 model ၏ causal language modeling head ပါဝင်သော class။
+*   **`AutoConfig`**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး model အမည်ကို အသုံးပြုပြီး သက်ဆိုင်ရာ configuration ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **`vocab_size`**: tokenizer ၏ vocabulary အတွင်းရှိ ထူးခြားသော tokens အရေအတွက်။
+*   **`n_ctx`**: context window ၏ အများဆုံး tokens အရေအတွက် (sequence length)။
+*   **`bos_token_id`**: beginning-of-sequence token ၏ ID။
+*   **`eos_token_id`**: end-of-sequence token ၏ ID။
+*   **`from_pretrained()` Function**: pretrained model သို့မဟုတ် tokenizer ကို load လုပ်ရန် အသုံးပြုသော function။
+*   **`model.parameters()`**: model ၏ လေ့ကျင့်နိုင်သော parameters (weights နှင့် biases) များကို ပြန်ပေးသော method။
+*   **Parameters (Model)**: model ၏ လုပ်ဆောင်ချက်ကို သတ်မှတ်ပေးသော အတွင်းပိုင်းတန်ဖိုးများ (weights, biases)။
+*   **`TFGPT2LMHeadModel`**: TensorFlow အတွက် GPT-2 model ၏ causal language modeling head ပါဝင်သော class။
+*   **`model.dummy_inputs`**: model ကို build လုပ်ရန်အတွက် အသုံးပြုသော dummy inputs များ။
+*   **`model.summary()`**: TensorFlow Keras model ၏ layers များ၊ output shapes များ၊ parameter အရေအတွက်တို့ကို ဖော်ပြပေးသော method။
+*   **Data Collator**: Dataloader မှ ရရှိသော samples များကို batch တစ်ခုအဖြစ် စုစည်းပေးသော function သို့မဟုတ် class။
+*   **`DataCollatorForLanguageModeling`**: language modeling tasks များအတွက် batch များကို ဖန်တီးပေးရန် Hugging Face Transformers library မှ class။
+*   **Stacking**: multiple tensors များကို တန်ဖိုးအသစ်တစ်ခုအဖြစ် ပေါင်းစပ်ခြင်း။
+*   **Padding**: batch အတွင်းရှိ sequences များကို အရှည်တူညီအောင် ဖြည့်စွက်ခြင်း။
+*   **Language Model Labels**: language model training တွင် input ၏ နောက်ဆက်တွဲ token အဖြစ် အသုံးပြုသော target labels များ။
+*   **Masked Language Modeling (MLM)**: စာကြောင်းတစ်ခုထဲမှ စကားလုံးအချို့ကို ဝှက်ထားပြီး ၎င်းတို့ကို ခန့်မှန်းစေခြင်းဖြင့် model ကို လေ့ကျင့်သော task။
+*   **Causal Language Modeling (CLM)**: စာကြောင်းတစ်ခု၏ နောက်ဆက်တွဲ token ကို ခန့်မှန်းခြင်းဖြင့် model ကို လေ့ကျင့်သော task။
+*   **`mlm=False` Argument**: `DataCollatorForLanguageModeling` ကို causal language modeling အတွက် data ပြင်ဆင်ရန် ညွှန်ကြားသော argument။
+*   **`return_tensors="tf"`**: TensorFlow tensors များကို ပြန်ပေးရန် သတ်မှတ်ခြင်း။
+*   **Tensor Shapes**: tensor တစ်ခု၏ dimensions များ၏ အရွယ်အစား။
+*   **`prepare_tf_dataset()` Method**: Keras model ၏ method တစ်ခုဖြစ်ပြီး 🤗 Datasets dataset ကို TensorFlow dataset သို့ ပြောင်းလဲပေးသည်။
+*   **`collate_fn`**: `prepare_tf_dataset()` တွင် data collator ကို သတ်မှတ်ရန် argument။
+*   **`shuffle=True`**: dataset ကို shuffle လုပ်ရန် ညွှန်ကြားခြင်း။
+*   **`batch_size`**: training သို့မဟုတ် evaluation အတွက် တစ်ပြိုင်နက်တည်း လုပ်ဆောင်မည့် samples အရေအတွက်။
+*   **`labels`**: model training အတွက် အဖြေမှန်များ။
+*   **`huggingface_hub.notebook_login()`**: Jupyter/Colab Notebooks များတွင် Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော function။
+*   **Widget**: Graphical User Interface (GUI) တွင် အသုံးပြုသူနှင့် အပြန်အလှန်တုံ့ပြန်နိုင်သော အစိတ်အပိုင်းများ။
+*   **`huggingface-cli login`**: Hugging Face CLI (Command Line Interface) မှ Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော command။
+*   **Training Arguments**: `Trainer` API တွင် training process ကို configure လုပ်ရန် အသုံးပြုသော parameters များ။
+*   **`Trainer`**: Hugging Face Transformers library မှ model များကို လေ့ကျင့်ရန်အတွက် မြင့်မားသောအဆင့် (high-level) API။
+*   **Cosine Learning Rate Schedule**: learning rate ကို cosine function ပုံစံဖြင့် အချိန်ကြာလာသည်နှင့်အမျှ လျှော့ချသော schedule။
+*   **Warmup**: training အစပိုင်းတွင် learning rate ကို တဖြည်းဖြည်းတိုးမြှင့်သော နည်းလမ်း။
+*   **Effective Batch Size**: `per_device_train_batch_size` ကို `gradient_accumulation_steps` ဖြင့် မြှောက်၍ ရရှိသော စုစုပေါင်း batch size။
+*   **`per_device_train_batch_size`**: GPU သို့မဟုတ် TPU တစ်ခုစီတွင် training အတွက် အသုံးပြုသော batch size။
+*   **`gradient_accumulation_steps`**: gradient ကို update မလုပ်ခင် gradient များကို စုဆောင်းမည့် step အရေအတွက်။
+*   **Gradient Accumulation**: GPU memory ကန့်သတ်ချက်များကြောင့် batch size ကြီးကြီးမားမား အသုံးပြု၍မရသောအခါ gradient များကို batch များစွာမှ စုဆောင်းပြီး တစ်ကြိမ်တည်း update လုပ်သော နည်းလမ်း။
+*   **Forward/Backward Passes**: neural network တွင် input data ကို ဖြတ်သန်းစေပြီး output ကို တွက်ချက်ခြင်း (forward pass) နှင့် loss function မှ gradient များကို တွက်ချက်ခြင်း (backward pass)။
+*   **`output_dir`**: trained model, logs, checkpoints တို့ကို သိမ်းဆည်းမည့် directory။
+*   **`per_device_eval_batch_size`**: GPU သို့မဟုတ် TPU တစ်ခုစီတွင် evaluation အတွက် အသုံးပြုသော batch size။
+*   **`evaluation_strategy="steps"`**: သတ်မှတ်ထားသော steps အရေအတွက်အလိုက် evaluation လုပ်ရန် ညွှန်ကြားခြင်း။
+*   **`eval_steps`**: evaluation လုပ်မည့် steps အရေအတွက်။
+*   **`logging_steps`**: logs များကို မှတ်တမ်းတင်မည့် steps အရေအတွက်။
+*   **`num_train_epochs`**: training dataset တစ်ခုလုံးဖြင့် model ကို လေ့ကျင့်မည့် အကြိမ်အရေအတွက် (epochs)။
+*   **`weight_decay`**: overfitting ကို လျှော့ချရန်အတွက် model ၏ weights များကို ထိန်းချုပ်သော regularization technique။
+*   **`warmup_steps`**: warmup လုပ်မည့် steps အရေအတွက်။
+*   **`lr_scheduler_type="cosine"`**: learning rate scheduler အမျိုးအစားကို cosine အဖြစ် သတ်မှတ်ခြင်း။
+*   **`learning_rate`**: training လုပ်ငန်းစဉ်အတွင်း model ၏ weights များကို မည်မျှပြောင်းလဲရမည်ကို ထိန်းချုပ်သော parameter။
+*   **`save_steps`**: model ကို သိမ်းဆည်းမည့် steps အရေအတွက်။
+*   **`fp16=True`**: training ကို float16 (half-precision) ဖြင့် လုပ်ဆောင်ရန် ညွှန်ကြားခြင်း (memory နှင့် speed ကို တိုးတက်စေသည်)။
+*   **`push_to_hub=True`**: training ပြီးဆုံးပြီးနောက် model ကို Hugging Face Hub သို့ push လုပ်ရန် ညွှန်ကြားခြင်း။
+*   **`eval_dataset`**: evaluation အတွက် အသုံးပြုမည့် dataset။
+*   **`trainer.train()`**: `Trainer` ကို အသုံးပြု၍ model ကို train လုပ်ရန်။
+*   **`trainer.push_to_hub()`**: `Trainer` ကို အသုံးပြု၍ model နှင့် tokenizer ကို Hub သို့ push လုပ်ရန်။
+*   **Training Hyperparameters**: training process ကို ထိန်းချုပ်သော parameters များ (ဥပမာ- learning rate, batch size)။
+*   **`compile()` Method**: Keras model ကို training အတွက် ပြင်ဆင်ရန် (optimizer, loss function စသည်)။
+*   **`fit()` Method**: Keras model ကို train လုပ်ရန်။
+*   **`create_optimizer()`**: Hugging Face Transformers library မှ optimizer နှင့် learning rate schedule ကို ဖန်တီးသော function။
+*   **`init_lr`**: စတင် learning rate။
+*   **`num_warmup_steps`**: warmup steps အရေအတွက်။
+*   **`num_train_steps`**: စုစုပေါင်း training steps အရေအတွက်။
+*   **`weight_decay_rate`**: weight decay ၏နှုန်း။
+*   **`tf.keras.mixed_precision.set_global_policy("mixed_float16")`**: TensorFlow Keras တွင် mixed-precision (float16) training ကို ဖွင့်ရန်။
+*   **`tf_train_dataset`**: TensorFlow format ဖြင့် training dataset။
+*   **`tf_eval_dataset`**: TensorFlow format ဖြင့် evaluation dataset။
+*   **`PushToHubCallback`**: Keras model ကို training လုပ်နေစဉ် Hugging Face Hub သို့ update လုပ်ရန် Hugging Face Transformers library မှ callback။
+*   **`output_dir`**: trained model, logs, checkpoints တို့ကို သိမ်းဆည်းမည့် directory။
+*   **`callbacks`**: Keras `fit()` method တွင် training လုပ်နေစဉ် လုပ်ဆောင်ချက်များ (ဥပမာ- logging, saving) ကို ထည့်သွင်းရန် argument။
+*   **`model.fit()`**: Keras model ကို train လုပ်ရန်။
+*   **Multiple GPUs**: ကွန်ပျူတာစနစ်တစ်ခုတွင် GPUs များစွာ အသုံးပြုခြင်း။
+*   **`MirroredStrategy`**: TensorFlow ၏ distributed training strategy တစ်ခုဖြစ်ပြီး multiple GPUs ပေါ်တွင် data-parallel training ကို လုပ်ဆောင်ရန်။
+*   **`scope()` Context**: TensorFlow distributed training strategy ၏ context manager တစ်ခုဖြစ်ပြီး၊ ၎င်းအတွင်းရှိ code ကို strategy ၏ စည်းမျဉ်းများအတိုင်း လုပ်ဆောင်စေသည်။
+*   **`text-generation` Pipeline**: text generation task အတွက် ဒီဇိုင်းထုတ်ထားသော pipeline။
+*   **GPU (Graphics Processing Unit)**: ဂရပ်ဖစ်လုပ်ဆောင်မှုအတွက် အထူးဒီဇိုင်းထုတ်ထားသော processor တစ်မျိုးဖြစ်သော်လည်း AI/ML လုပ်ငန်းများတွင် အရှိန်မြှင့်ရန် အသုံးများသည်။
+*   **`torch.device("cuda")`**: PyTorch တွင် CUDA (GPU) device ကို သတ်မှတ်ခြင်း။
+*   **`torch.device("cpu")`**: PyTorch တွင် CPU device ကို သတ်မှတ်ခြင်း။
+*   **`pipeline()` Function**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ လုပ်ဆောင်ချက်တစ်ခုဖြစ်ပြီး မော်ဒယ်တွေကို သီးခြားလုပ်ငန်းတာဝန်များ (ဥပမာ- စာသားခွဲခြားသတ်မှတ်ခြင်း၊ စာသားထုတ်လုပ်ခြင်း) အတွက် အသုံးပြုရလွယ်ကူအောင် ပြုလုပ်ပေးပါတယ်။
+*   **`num_return_sequences`**: generate လုပ်မည့် sequences အရေအတွက်။
+*   **`generated_text`**: model မှ generate လုပ်ထားသော စာသား။
+*   **Scatter Plot**: data points များကို x-axis နှင့် y-axis ပေါ်တွင် ပြသသော graph အမျိုးအစား။
+*   **`np.random.randn()`**: NumPy မှ standard normal distribution မှ ကျပန်းနံပါတ်များ ထုတ်လုပ်သော function။
+*   **`plt.scatter(x, y)`**: Matplotlib မှ scatter plot ကို ဖန်တီးသော function။
+*   **`pd.DataFrame`**: Pandas မှ DataFrame object ကို ဖန်တီးသော class။
+*   **`df.insert()`**: Pandas DataFrame တွင် column အသစ်တစ်ခု ထည့်သွင်းသော method။
+*   **`groupby()` Operation**: Pandas DataFrame တွင် columns များကို အုပ်စုဖွဲ့ပြီး aggregate လုပ်ဆောင်ချက်များ လုပ်ဆောင်သော method။
+*   **`sklearn.ensemble.RandomForestRegressor`**: scikit-learn မှ Random Forest Regressor model class။
+*   **`n_estimators`**: Random Forest model တွင် အသုံးပြုမည့် trees အရေအတွက်။
+*   **`random_state`**: ကျပန်းနံပါတ် generator အတွက် seed။
+*   **`max_depth`**: tree ၏ အများဆုံး အနက်။
+*   **`rf.fit(X, y)`**: Random Forest model ကို data `X` နှင့် `y` ဖြင့် train လုပ်ရန်။
+*   **Syntax (Python)**: Python programming language ၏ စည်းမျဉ်းများ။
+*   **Prototype**: ထုတ်ကုန်တစ်ခု၏ ကနဦးမူကြမ်း သို့မဟုတ် စမ်းသပ်ဗားရှင်း။
+*   **Conditional Training Loop**: သတ်မှတ်ထားသော အခြေအနေများပေါ်မူတည်၍ training steps များကို ကျော်သွားနိုင်သော training loop။
+*   **Subclass**: လက်ရှိ class တစ်ခုမှ အင်္ဂါရပ်များကို အမွေခံယူပြီး ပြင်ဆင်နိုင်သော class အသစ်တစ်ခု ဖန်တီးခြင်း။
+*   **Exotic Changes**: ပုံမှန်မဟုတ်သော သို့မဟုတ် ထူးခြားသော ပြောင်းလဲမှုများ။
+*   **Weighted Loss Function**: data points အချို့ကို အခြား data points များထက် ပိုအလေးထားရန် weights များကို အသုံးပြုသော loss function။
+*   **`plt` (matplotlib.pyplot)**: Matplotlib library ၏ commonly imported alias။
+*   **`pd` (pandas)**: Pandas library ၏ commonly imported alias။
+*   **`sk` (sklearn)**: scikit-learn library ၏ commonly imported alias (တခါတလေ သုံးသည်)။
+*   **`fit` / `predict` Pattern**: machine learning model များကို train လုပ်ရန် `fit()` method နှင့် ခန့်မှန်းချက်များ ပြုလုပ်ရန် `predict()` method ကို အသုံးပြုသော ပုံစံ။
+*   **Whitespace Prefix**: token ၏ အရှေ့တွင် ပါဝင်သော space character။
+*   **Tokenizer Vocabulary**: tokenizer သိရှိသော ထူးခြားသော tokens များစာရင်း။
+*   **`tokenizer([keyword]).input_ids[0]`**: keyword ကို tokenize လုပ်ပြီး ၎င်း၏ input IDs များကို ရယူခြင်း။
+*   **`CrossEntropyLoss`**: PyTorch တွင် classification tasks အတွက် အသုံးများသော loss function။
+*   **`torch`**: PyTorch library။
+*   **`inputs[..., 1:].contiguous()`**: input tensor ၏ ဒုတိယ element မှ စတင်၍ slice လုပ်ပြီး memory တွင် ဆက်စပ်နေစေရန်။
+*   **`logits[..., :-1, :].contiguous()`**: logits tensor ၏ နောက်ဆုံး element ကို ဖယ်ရှားပြီး memory တွင် ဆက်စပ်နေစေရန်။
+*   **`loss_fct = CrossEntropyLoss(reduce=False)`**: per-token loss များကို ပြန်ပေးရန် `reduce=False` ဖြင့် CrossEntropyLoss ကို ဖန်တီးခြင်း။
+*   **`loss.view(-1, shift_logits.size(1)).mean(axis=1)`**: per-sample loss များကို တွက်ချက်ခြင်း။
+*   **`torch.stack()`**: tensors များစွာကို အတူတကွ stacking လုပ်ခြင်း။
+*   **`torch.nn.CrossEntropyLoss`**: PyTorch တွင် classification tasks အတွက် အသုံးများသော loss function။
+*   **`torch.optim.AdamW`**: PyTorch မှာ အသုံးပြုတဲ့ AdamW optimizer။
+*   **Dataloaders**: batch အလိုက် data ကို load လုပ်ပေးသော PyTorch utility။
+*   **Weight Decay Parameters**: model ၏ weights များကို ထိန်းချုပ်ရန် weight decay ကို အသုံးပြုသော parameters များ။
+*   **Evaluation Code**: model ၏ စွမ်းဆောင်ရည်ကို တိုင်းတာရန်အတွက် code။
+*   **`tokenized_datasets.set_format("torch")`**: dataset ၏ format ကို PyTorch tensors အဖြစ် သတ်မှတ်ခြင်း။
+*   **`torch.utils.data.dataloader.DataLoader`**: PyTorch တွင် dataset မှ batch အလိုက် data များကို load လုပ်ပေးသော class။
+*   **`get_grouped_params()` Function**: model ၏ parameters များကို weight decay လုပ်ရန် သို့မဟုတ် မလုပ်ရန် ခွဲခြားပေးသော function။
+*   **`model.named_parameters()`**: model ၏ parameters များနှင့် ၎င်းတို့၏ နာမည်များကို ပြန်ပေးသော method။
+*   **`model.eval()`**: model ကို evaluation mode သို့ ပြောင်းလဲခြင်း။
+*   **`torch.no_grad()`**: gradient တွက်ချက်မှုကို ပိတ်ထားရန် PyTorch context manager။
+*   **`accelerator.gather()`**: multiple processes မှ tensors များကို စုစည်းရန် 🤗 Accelerate method။
+*   **`torch.cat()`**: multiple tensors များကို တစ်ခုတည်းအဖြစ် ပေါင်းစပ်ရန်။
+*   **`torch.exp()`**: tensor ၏ element တစ်ခုစီ၏ exponential ကို တွက်ချက်ရန်။
+*   **OverflowError**: Python တွင် ဂဏန်းတန်ဖိုးများ အလွန်ကြီးမားသောအခါ ဖြစ်ပေါ်သော error။
+*   **Perplexity**: language model တစ်ခု၏ စွမ်းဆောင်ရည်ကို တိုင်းတာသော metric (ပိုနည်းလေ ပိုကောင်းလေ)။
+*   **`accelerator.prepare()`**: 🤗 Accelerate တွင် model, optimizer, dataloaders များကို distributed training အတွက် ပြင်ဆင်ရန် method။
+*   **TPU (Tensor Processing Unit)**: Google မှ AI/ML workloads များအတွက် အထူးဒီဇိုင်းထုတ်ထားသော processor တစ်မျိုး။
+*   **Dedicated Training Function**: training logic အားလုံးပါဝင်သော သီးခြား function။
+*   **Linear Schedule**: learning rate ကို linear ပုံစံဖြင့် အချိန်ကြာလာသည်နှင့်အမျှ လျှော့ချသော schedule။
+*   **`get_scheduler()`**: Hugging Face Transformers library မှ learning rate scheduler ကို ရယူသော function။
+*   **`Repository` Object**: `huggingface_hub` library မှ Git repository များကို ကိုင်တွယ်ရန်အတွက် object။
+*   **Working Folder**: project files များကို သိမ်းဆည်းထားသော folder။
+*   **`get_full_repo_name()` Function**: Hugging Face Hub ပေါ်တွင် repository ၏ full name (username/repo_name) ကို ရယူသော function။
+*   **`clone_from` Argument**: `Repository` object ကို ဖန်တီးသောအခါ remote repository မှ clone လုပ်ရန် ညွှန်ကြားသော argument။
+*   **`repo.push_to_hub()` Method**: local repository ၏ ပြောင်းလဲမှုများကို Hugging Face Hub သို့ push လုပ်ရန်။
+*   **Intermediate Models**: training လုပ်နေစဉ် သိမ်းဆည်းထားသော model versions များ။
+*   **Perplexity**: language model တစ်ခု၏ စွမ်းဆောင်ရည်ကို တိုင်းတာသော metric (ပိုနည်းလေ ပိုကောင်းလေ)။
+*   **`model.train()`**: model ကို training mode သို့ ပြောင်းလဲခြင်း။
+*   **`tqdm.notebook`**: Jupyter Notebooks အတွက် `tqdm` progress bar။
+*   **`enumerate()`**: list သို့မဟုတ် iterable တစ်ခု၏ element တစ်ခုစီကို index နှင့်အတူ ပြန်ပေးသော Python function။
+*   **`accelerator.print()`**: distributed training ပတ်ဝန်းကျင်တွင် logs များကို print ထုတ်ရန် 🤗 Accelerate utility။
+*   **`loss.item()`**: PyTorch tensor မှ Python float တန်ဖိုးကို ရယူခြင်း။
+*   **`accelerator.backward(loss)`**: distributed training တွင် loss မှ gradients များကို တွက်ချက်ရန် 🤗 Accelerate method။
+*   **`accelerator.clip_grad_norm_()`**: gradients များကို clip လုပ်ရန် 🤗 Accelerate method။
+*   **`optimizer.step()`**: တွက်ချက်ထားသော gradients များကို အသုံးပြုပြီး model ၏ parameters များကို update လုပ်သော optimizer method။
+*   **`lr_scheduler.step()`**: learning rate scheduler ကို တစ်ဆင့်ချင်းစီ update လုပ်ရန်။
+*   **`optimizer.zero_grad()`**: gradients များကို သုညသို့ ပြန်လည်သတ်မှတ်ရန်။
+*   **`accelerator.wait_for_everyone()`**: distributed training တွင် processes အားလုံး အမှတ်တစ်ခုသို့ ရောက်သည်အထိ စောင့်ဆိုင်းရန် 🤗 Accelerate method။
+*   **`accelerator.unwrap_model()`**: distributed training အတွက် wrap လုပ်ထားသော model မှ မူရင်း model ကို ပြန်လည်ရယူရန် 🤗 Accelerate method။
+*   **`unwrapped_model.save_pretrained()`**: model ကို pretrained format ဖြင့် disk ပေါ်တွင် သိမ်းဆည်းရန်။
+*   **`accelerator.save()`**: distributed training တွင် model ကို သိမ်းဆည်းရန် 🤗 Accelerate utility။
+*   **`accelerator.is_main_process`**: လက်ရှိ process က main process ဟုတ်မဟုတ် စစ်ဆေးရန် 🤗 Accelerate property။
+*   **`tokenizer.save_pretrained()`**: tokenizer ကို disk ပေါ်တွင် သိမ်းဆည်းရန်။
+*   **`commit_message`**: Git commit အတွက် ပေးသော မက်ဆေ့ချ်။
+*   **`blocking=False`**: `push_to_hub()` ကို asynchronous အဖြစ် run ရန် ညွှန်ကြားခြင်း (main thread ကို မပိတ်မိစေရန်)။
+*   **TensorBoard**: Google မှ ဖန်တီးထားသော machine learning experiments များကို visualization လုပ်ရန် ကိရိယာ။
+*   **Weights & Biases**: machine learning experiments များကို ခြေရာခံ၊ visualization လုပ်ရန်နှင့် ပူးပေါင်းဆောင်ရွက်ရန် platform။

--- a/chapters/my/chapter7/7.mdx
+++ b/chapters/my/chapter7/7.mdx
@@ -1,0 +1,1370 @@
+<FrameworkSwitchCourse {fw} />
+
+# မေးခွန်းဖြေဆိုခြင်း[[question-answering]]
+
+{#if fw === 'pt'}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section7_pt.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section7_pt.ipynb"},
+]} />
+
+{:else}
+
+<CourseFloatingBanner chapter={7}
+  classNames="absolute z-10 right-0 top-0"
+  notebooks={[
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter7/section7_tf.ipynb"},
+    {label: "Aws Studio", value: "https://studiolab.sagemaker.aws/import/github/huggingface/notebooks/blob/master/course/en/chapter7/section7_tf.ipynb"},
+]} />
+
+{/if}
+
+မေးခွန်းဖြေဆိုခြင်းကို ကြည့်ရအောင်။ ဒီ task မှာ ပုံစံအမျိုးမျိုးရှိပေမယ့်၊ ဒီအပိုင်းမှာ ကျွန်တော်တို့ အာရုံစိုက်မယ့် ပုံစံကို *extractive* question answering လို့ ခေါ်ပါတယ်။ ဒါက document တစ်ခုအကြောင်း မေးခွန်းတွေမေးပြီး အဖြေတွေကို document ထဲက *စာသားအပိုင်းများ (spans of text)* အဖြစ် ဖော်ထုတ်တာကို ဆိုလိုပါတယ်။
+
+<Youtube id="ajPx5LwJD-I"/>
+
+Wikipedia ဆောင်းပါးများအစုအဝေးပေါ်တွင် crowdworkers များက မေးထားသော မေးခွန်းများပါဝင်သည့် [SQuAD dataset](https://rajpurkar.github.io/SQuAD-explorer/) ပေါ်မှာ BERT model တစ်ခုကို ကျွန်တော်တို့ fine-tune လုပ်ပါမယ်။ ဒါက အခုလိုမျိုး predictions တွေကို တွက်ချက်နိုင်တဲ့ model တစ်ခုကို ရရှိစေပါလိမ့်မယ်။
+
+<iframe src="https://course-demos-bert-finetuned-squad.hf.space" frameBorder="0" height="450" title="Gradio app" class="block dark:hidden container p-0 flex-grow space-iframe" allow="accelerometer; ambient-light-sensor; autoplay; battery; camera; document-domain; encrypted-media; fullscreen; geolocation; gyroscope; layout-animations; legacy-image-formats; magnetometer; microphone; midi; oversized-images; payment; picture-in-picture; publickey-credentials-get; sync-xhr; usb; vr ; wake-lock; xr-spatial-tracking" sandbox="allow-forms allow-modals allow-popups allow-popups-to-escape-sandbox allow-same-origin allow-scripts allow-downloads"></iframe>
+
+ဒါက ဒီအပိုင်းမှာ ပြထားတဲ့ code ကို အသုံးပြုပြီး Hub ကို train လုပ်ပြီး upload လုပ်ထားတဲ့ model ကို လက်တွေ့ပြသနေတာပါ။ သင် ဒါကို [ဒီမှာ](https://huggingface.co/huggingface-course/bert-finetuned-squad?context=%F0%9F%A4%97+Transformers+is+backed+by+the+three+most+popular+deep+learning+libraries+%E2%80%94+Jax%2C+PyTorch+and+TensorFlow+%E2%80%94+with+a+seamless+integration+between+them.+It%27s+straightforward+to+train+your+models+with+one+before+loading+them+for+inference+with+the+other.&question=Which+deep+learning+libraries+back+%F0%9F%A4%97+Transformers%3F) ရှာဖွေပြီး predictions တွေကို ထပ်မံစစ်ဆေးနိုင်ပါတယ်။
+
+> [!TIP]
+> 💡 BERT လို Encoder-only models တွေက "Transformer architecture ကို ဘယ်သူ တီထွင်ခဲ့တာလဲ" လို factoid မေးခွန်းတွေရဲ့ အဖြေတွေကို ထုတ်ယူရာမှာ အထူးကောင်းမွန်ပေမယ့် "ကောင်းကင်က ဘာလို့ အပြာရောင်ဖြစ်တာလဲ" လို open-ended မေးခွန်းတွေအတွက်တော့ အလုပ်ဖြစ်တာ နည်းပါတယ်။ ဒီလို ပိုမိုခက်ခဲတဲ့ အခြေအနေတွေမှာတော့ T5 နဲ့ BART လို encoder-decoder models တွေကို အချက်အလက်တွေကို စုစည်းရာမှာ ပုံမှန်အားဖြင့် အသုံးပြုပြီး [text summarization](/course/chapter7/5) နဲ့ အတော်လေး ဆင်တူပါတယ်။ ဒီလို *generative* question answering အမျိုးအစားကို စိတ်ဝင်စားတယ်ဆိုရင်၊ [ELI5 dataset](https://huggingface.co/datasets/eli5) ပေါ်အခြေခံထားတဲ့ ကျွန်တော်တို့ရဲ့ [demo](https://yjernite.github.io/lfqa.html) ကို ကြည့်ရှုဖို့ ကျွန်တော်တို့ အကြံပြုပါတယ်။
+
+## Data ကို ပြင်ဆင်ခြင်း[[preparing-the-data]]
+
+extractive question answering အတွက် academic benchmark အဖြစ် အများဆုံး အသုံးပြုတဲ့ dataset က [SQuAD](https://rajpurkar.github.io/SQuAD-explorer/) ဖြစ်ပါတယ်။ ဒါကြောင့် ဒီနေရာမှာ အဲဒါကိုပဲ ကျွန်တော်တို့ အသုံးပြုပါမယ်။ SQuAD v2 benchmark [ပိုမိုခက်ခဲတဲ့ SQuAD v2](https://huggingface.co/datasets/squad_v2) လည်း ရှိပြီး၊ အဖြေမရှိတဲ့ မေးခွန်းတွေ ပါဝင်ပါတယ်။ သင့်ရဲ့ dataset မှာ contexts အတွက် column တစ်ခု၊ questions အတွက် column တစ်ခုနဲ့ answers အတွက် column တစ်ခု ပါဝင်နေသရွေ့ အောက်ပါအဆင့်တွေကို အသုံးပြုနိုင်ပါလိမ့်မယ်။
+
+### SQuAD Dataset[[the-squad-dataset]]
+
+ပုံမှန်အတိုင်းပါပဲ၊ `load_dataset()` ကြောင့် dataset ကို တစ်ဆင့်တည်း download လုပ်ပြီး cache လုပ်နိုင်ပါတယ်။
+
+```py
+from datasets import load_dataset
+
+raw_datasets = load_dataset("squad")
+```
+
+ပြီးရင် SQuAD dataset အကြောင်း ပိုမိုသိရှိနိုင်ဖို့ ဒီ object ကို ကြည့်နိုင်ပါတယ်။
+
+```py
+raw_datasets
+```
+
+```python out
+DatasetDict({
+    train: Dataset({
+        features: ['id', 'title', 'context', 'question', 'answers'],
+        num_rows: 87599
+    })
+    validation: Dataset({
+        features: ['id', 'title', 'context', 'question', 'answers'],
+        num_rows: 10570
+    })
+})
+```
+
+`context`, `question`, နဲ့ `answers` fields တွေနဲ့ ကျွန်တော်တို့ လိုအပ်သမျှ အားလုံးရှိနေပုံရပါတယ်။ ဒါကြောင့် training set ရဲ့ ပထမဆုံး element အတွက် ဒါတွေကို print ထုတ်ကြည့်ရအောင်။
+
+```py
+print("Context: ", raw_datasets["train"][0]["context"])
+print("Question: ", raw_datasets["train"][0]["question"])
+print("Answer: ", raw_datasets["train"][0]["answers"])
+```
+
+```python out
+Context: 'Architecturally, the school has a Catholic character. Atop the Main Building\'s gold dome is a golden statue of the Virgin Mary. Immediately in front of the Main Building and facing it, is a copper statue of Christ with arms upraised with the legend "Venite Ad Me Omnes". Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basilica is the Grotto, a Marian place of prayer and reflection. It is a replica of the grotto at Lourdes, France where the Virgin Mary reputedly appeared to Saint Bernadette Soubirous in 1858. At the end of the main drive (and in a direct line that connects through 3 statues and the Gold Dome), is a simple, modern stone statue of Mary.'
+Question: 'To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France?'
+Answer: {'text': ['Saint Bernadette Soubirous'], 'answer_start': [515]}
+```
+
+`context` နဲ့ `question` fields တွေက အသုံးပြုရတာ အလွန်ရိုးရှင်းပါတယ်။ `answers` field ကတော့ အနည်းငယ် ပိုရှုပ်ထွေးပါတယ်။ ဘာလို့လဲဆိုတော့ fields နှစ်ခုစလုံးက lists တွေပါဝင်တဲ့ dictionary တစ်ခု ပါဝင်နေလို့ပါ။ ဒါက evaluation လုပ်နေစဉ် `squad` metric က မျှော်လင့်ထားတဲ့ format ဖြစ်ပါတယ်၊ သင်ကိုယ်ပိုင် data ကို အသုံးပြုနေတယ်ဆိုရင် အဖြေတွေကို ဒီ format အတိုင်း ထည့်စရာမလိုပါဘူး။ `text` field ကတော့ ရှင်းပါတယ်၊ `answer_start` field ကတော့ context ထဲက အဖြေတစ်ခုစီရဲ့ စတင်တဲ့ character index ကို ပါဝင်ပါတယ်။
+
+training လုပ်နေစဉ်မှာ၊ ဖြစ်နိုင်တဲ့ အဖြေတစ်ခုပဲ ရှိပါတယ်။ ဒါကို `Dataset.filter()` method ကို အသုံးပြုပြီး ထပ်မံစစ်ဆေးနိုင်ပါတယ်။
+
+```py
+raw_datasets["train"].filter(lambda x: len(x["answers"]["text"]) != 1)
+```
+
+```python out
+Dataset({
+    features: ['id', 'title', 'context', 'question', 'answers'],
+    num_rows: 0
+})
+```
+
+သို့သော်လည်း၊ evaluation အတွက်၊ sample တစ်ခုစီအတွက် ဖြစ်နိုင်တဲ့ အဖြေများစွာရှိနိုင်ပြီး၊ ဒါတွေက တူညီနိုင်သလို ကွဲပြားနိုင်ပါတယ်။
+
+```py
+print(raw_datasets["validation"][0]["answers"])
+print(raw_datasets["validation"][2]["answers"])
+```
+
+```python out
+{'text': ['Denver Broncos', 'Denver Broncos', 'Denver Broncos'], 'answer_start': [177, 177, 177]}
+{'text': ['Santa Clara, California', "Levi's Stadium", "Levi's Stadium in the San Francisco Bay Area at Santa Clara, California."], 'answer_start': [403, 355, 355]}
+```
+
+evaluation script ကို ကျွန်တော်တို့ နက်နက်နဲနဲ လေ့လာသွားမှာ မဟုတ်ပါဘူး၊ ဘာလို့လဲဆိုတော့ 🤗 Datasets metric က ဒါတွေအားလုံးကို ကျွန်တော်တို့အတွက် လုပ်ဆောင်ပေးမှာမို့လို့ပါ။ ဒါပေမယ့် အတိုချုပ်ပြောရရင် မေးခွန်းအချို့မှာ ဖြစ်နိုင်တဲ့ အဖြေများစွာရှိနိုင်ပြီး၊ ဒီ script က ခန့်မှန်းထားတဲ့ အဖြေကို လက်ခံနိုင်တဲ့ အဖြေအားလုံးနဲ့ နှိုင်းယှဉ်ပြီး အကောင်းဆုံး score ကို ရယူမှာပါ။ ဥပမာ၊ index 2 မှာရှိတဲ့ sample ကို ကြည့်မယ်ဆိုရင်...
+
+```py
+print(raw_datasets["validation"][2]["context"])
+print(raw_datasets["validation"][2]["question"])
+```
+
+```python out
+'Super Bowl 50 was an American football game to determine the champion of the National Football League (NFL) for the 2015 season. The American Football Conference (AFC) champion Denver Broncos defeated the National Football Conference (NFC) champion Carolina Panthers 24–10 to earn their third Super Bowl title. The game was played on February 7, 2016, at Levi\'s Stadium in the San Francisco Bay Area at Santa Clara, California. As this was the 50th Super Bowl, the league emphasized the "golden anniversary" with various gold-themed initiatives, as well as temporarily suspending the tradition of naming each Super Bowl game with Roman numerals (under which the game would have been known as "Super Bowl L"), so that the logo could prominently feature the Arabic numerals 50.'
+'Where did Super Bowl 50 take place?'
+```
+
+အဖြေက ကျွန်တော်တို့ အရင်ကတွေ့ခဲ့ရတဲ့ ဖြစ်နိုင်တဲ့ အဖြေသုံးခုထဲက တစ်ခု ဖြစ်နိုင်တယ်ဆိုတာ တွေ့ရပါတယ်။
+
+### Training Data ကို စီမံဆောင်ရွက်ခြင်း[[processing-the-training-data]]
+
+<Youtube id="qgaM0weJHpA"/>
+
+training data ကို preprocessing လုပ်ခြင်းဖြင့် စတင်ကြရအောင်။ အခက်ခဲဆုံး အပိုင်းကတော့ question ရဲ့ အဖြေအတွက် labels တွေကို ဖန်တီးဖို့ပါပဲ။ အဲဒီ labels တွေက context ထဲက အဖြေနဲ့ ကိုက်ညီတဲ့ tokens တွေရဲ့ စတင်တဲ့နဲ့ အဆုံးသတ်တဲ့ position တွေ ဖြစ်ပါလိမ့်မယ်။
+
+ဒါပေမယ့် အလျင်စလို မလုပ်ပါနဲ့။ ပထမဆုံး၊ input ထဲက text ကို model က နားလည်နိုင်တဲ့ IDs တွေအဖြစ် tokenizer ကို အသုံးပြုပြီး ပြောင်းလဲဖို့ လိုအပ်ပါတယ်။
+
+```py
+from transformers import AutoTokenizer
+
+model_checkpoint = "bert-base-cased"
+tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
+```
+
+ယခင်က ဖော်ပြခဲ့တဲ့အတိုင်း၊ ကျွန်တော်တို့ BERT model တစ်ခုကို fine-tuning လုပ်မှာဖြစ်ပေမယ့်၊ fast tokenizer ကို အကောင်အထည်ဖော်ထားသရွေ့ မည်သည့် model type ကိုမဆို အသုံးပြုနိုင်ပါတယ်။ fast version ပါရှိတဲ့ architectures အားလုံးကို [ဒီဇယားကြီးမှာ](https://huggingface.co/transformers/#supported-frameworks) ကြည့်နိုင်ပြီး၊ သင်အသုံးပြုနေတဲ့ `tokenizer` object က 🤗 Tokenizers က ထောက်ပံ့ပေးထားခြင်းရှိမရှိ စစ်ဆေးဖို့အတွက် ၎င်းရဲ့ `is_fast` attribute ကို ကြည့်နိုင်ပါတယ်။
+
+```py
+tokenizer.is_fast
+```
+
+```python out
+True
+```
+
+ကျွန်တော်တို့ရဲ့ tokenizer ကို question နဲ့ context ကို အတူတကွ ပေးနိုင်ပြီး၊ အဲဒါက အခုလိုမျိုး sentence တစ်ခုကို ဖန်တီးဖို့ special tokens တွေကို မှန်ကန်စွာ ထည့်သွင်းပေးပါလိမ့်မယ်။
+
+```
+[CLS] question [SEP] context [SEP]
+```
+
+ထပ်မံစစ်ဆေးကြည့်ရအောင်...
+
+```py
+context = raw_datasets["train"][0]["context"]
+question = raw_datasets["train"][0]["question"]
+
+inputs = tokenizer(question, context)
+tokenizer.decode(inputs["input_ids"])
+```
+
+```python out
+'[CLS] To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France? [SEP] Architecturally, '
+'the school has a Catholic character. Atop the Main Building\'s gold dome is a golden statue of the Virgin '
+'Mary. Immediately in front of the Main Building and facing it, is a copper statue of Christ with arms '
+'upraised with the legend " Venite Ad Me Omnes ". Next to the Main Building is the Basilica of the Sacred '
+'Heart. Immediately behind the basilica is the Grotto, a Marian place of prayer and reflection. It is a '
+'replica of the grotto at Lourdes, France where the Virgin Mary reputedly appeared to Saint Bernadette '
+'Soubirous in 1858. At the end of the main drive ( and in a direct line that connects through 3 statues '
+'and the Gold Dome ), is a simple, modern stone statue of Mary. [SEP]'
+```
+
+labels တွေကတော့ အဖြေစတင်တဲ့နဲ့ အဆုံးသတ်တဲ့ tokens တွေရဲ့ index တွေ ဖြစ်ပါလိမ့်မယ်။ model က input ထဲက token တစ်ခုစီအတွက် start နဲ့ end logit တစ်ခုကို ခန့်မှန်းဖို့ တာဝန်ပေးခံရမှာဖြစ်ပြီး၊ သီအိုရီအရ labels တွေက အောက်ပါအတိုင်း ဖြစ်ပါလိမ့်မယ်။
+
+<div class="flex justify-center">
+<img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/qa_labels.svg" alt="One-hot encoded labels for question answering."/>
+<img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter7/qa_labels-dark.svg" alt="One-hot encoded labels for question answering."/>
+</div>
+
+ဒီကိစ္စမှာ context က မရှည်လွန်းပါဘူး၊ ဒါပေမယ့် dataset ထဲက ဥပမာအချို့မှာ အလွန်ရှည်လျားတဲ့ contexts တွေ ပါဝင်ပြီး ကျွန်တော်တို့ သတ်မှတ်ထားတဲ့ maximum length (ဒီကိစ္စမှာ 384) ကို ကျော်လွန်သွားပါလိမ့်မယ်။ [Chapter 6](/course/chapter6/4) မှာ `question-answering` pipeline ရဲ့ အတွင်းပိုင်းကို လေ့လာခဲ့တုန်းက တွေ့ခဲ့ရတဲ့အတိုင်း၊ ရှည်လျားတဲ့ contexts တွေကို dataset ရဲ့ sample တစ်ခုကနေ training features များစွာ ဖန်တီးခြင်းဖြင့် ကိုင်တွယ်ဖြေရှင်းပါမယ်။ features တွေကြားမှာ sliding window တစ်ခု ထားရှိပါမယ်။
+
+လက်ရှိဥပမာကို အသုံးပြုပြီး ဒါဘယ်လိုအလုပ်လုပ်လဲဆိုတာ ကြည့်ဖို့အတွက်၊ length ကို 100 အထိ ကန့်သတ်ပြီး 50 tokens ရဲ့ sliding window တစ်ခုကို အသုံးပြုနိုင်ပါတယ်။ အမှတ်ရစေဖို့အတွက်၊ ကျွန်တော်တို့ အသုံးပြုတာက...
+
+- `max_length` က maximum length ကို သတ်မှတ်ဖို့ (ဒီနေရာမှာ 100)
+- `truncation="only_second"` က question နဲ့ context က အတူတူရှည်လွန်းတဲ့အခါ context (ဒုတိယနေရာမှာရှိတာ) ကို truncate လုပ်ဖို့
+- `stride` က ဆက်တိုက် chunks နှစ်ခုကြား ထပ်နေတဲ့ tokens အရေအတွက်ကို သတ်မှတ်ဖို့ (ဒီနေရာမှာ 50)
+- `return_overflowing_tokens=True` က tokenizer ကို overflowing tokens တွေ လိုချင်တယ်လို့ သိစေဖို့
+
+```py
+inputs = tokenizer(
+    question,
+    context,
+    max_length=100,
+    truncation="only_second",
+    stride=50,
+    return_overflowing_tokens=True,
+)
+
+for ids in inputs["input_ids"]:
+    print(tokenizer.decode(ids))
+```
+
+```python out
+'[CLS] To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France? [SEP] Architecturally, the school has a Catholic character. Atop the Main Building\'s gold dome is a golden statue of the Virgin Mary. Immediately in front of the Main Building and facing it, is a copper statue of Christ with arms upraised with the legend " Venite Ad Me Omnes ". Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basi [SEP]'
+'[CLS] To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France? [SEP] the Main Building and facing it, is a copper statue of Christ with arms upraised with the legend " Venite Ad Me Omnes ". Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basilica is the Grotto, a Marian place of prayer and reflection. It is a replica of the grotto at Lourdes, France where the Virgin [SEP]'
+'[CLS] To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France? [SEP] Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basilica is the Grotto, a Marian place of prayer and reflection. It is a replica of the grotto at Lourdes, France where the Virgin Mary reputedly appeared to Saint Bernadette Soubirous in 1858. At the end of the main drive ( and in a direct line that connects through 3 [SEP]'
+'[CLS] To whom did the Virgin Mary allegedly appear in 1858 in Lourdes France? [SEP]. It is a replica of the grotto at Lourdes, France where the Virgin Mary reputedly appeared to Saint Bernadette Soubirous in 1858. At the end of the main drive ( and in a direct line that connects through 3 statues and the Gold Dome ), is a simple, modern stone statue of Mary. [SEP]'
+```
+
+ကျွန်တော်တို့ တွေ့ရတဲ့အတိုင်း၊ ကျွန်တော်တို့ရဲ့ ဥပမာကို inputs လေးခုအဖြစ် ပိုင်းဖြတ်ထားပြီး၊ တစ်ခုစီမှာ question နဲ့ context ရဲ့ အစိတ်အပိုင်းအချို့ ပါဝင်ပါတယ်။ question ရဲ့ အဖြေ ("Bernadette Soubirous") ဟာ တတိယနဲ့ နောက်ဆုံး inputs တွေမှာပဲ ပေါ်လာတယ်ဆိုတာ သတိပြုပါ။ ဒါကြောင့် ဒီနည်းလမ်းနဲ့ ရှည်လျားတဲ့ contexts တွေကို ကိုင်တွယ်ခြင်းက context ထဲမှာ အဖြေမပါဝင်တဲ့ training examples အချို့ကို ဖန်တီးပေးပါလိမ့်မယ်။ အဲဒီ examples တွေအတွက် labels တွေက `start_position = end_position = 0` (ဒါကြောင့် ကျွန်တော်တို့ `[CLS]` token ကို ခန့်မှန်းတာ) ဖြစ်ပါလိမ့်မယ်။ အဖြေကို truncate လုပ်ထားတာကြောင့် အစ (သို့မဟုတ် အဆုံး) ပဲ ကျန်တော့တဲ့ ကံမကောင်းတဲ့ အခြေအနေမှာလည်း အဲဒီ labels တွေကို သတ်မှတ်ပေးပါမယ်။ အဖြေက context ထဲမှာ အပြည့်အစုံပါဝင်တဲ့ examples တွေအတွက်တော့ labels တွေက အဖြေစတင်တဲ့ token ရဲ့ index နဲ့ အဖြေဆုံးသတ်တဲ့ token ရဲ့ index ဖြစ်ပါလိမ့်မယ်။
+
+dataset က ကျွန်တော်တို့ကို context ထဲက အဖြေစတင်တဲ့ character ကို ပေးထားပြီး၊ အဖြေရဲ့ အရှည်ကို ပေါင်းထည့်ခြင်းဖြင့် context ထဲက အဆုံးသတ်တဲ့ character ကို ရှာဖွေနိုင်ပါတယ်။ ဒါတွေကို token indices တွေနဲ့ map လုပ်ဖို့အတွက်၊ [Chapter 6](/course/chapter6/4) မှာ ကျွန်တော်တို့ လေ့လာခဲ့တဲ့ offset mappings တွေကို အသုံးပြုဖို့ လိုအပ်ပါလိမ့်မယ်။ `return_offsets_mapping=True` ကို ပေးပို့ခြင်းဖြင့် ကျွန်တော်တို့ရဲ့ tokenizer ကို ဒါတွေ ပြန်ပေးနိုင်ပါတယ်။
+
+```py
+inputs = tokenizer(
+    question,
+    context,
+    max_length=100,
+    truncation="only_second",
+    stride=50,
+    return_overflowing_tokens=True,
+    return_offsets_mapping=True,
+)
+inputs.keys()
+```
+
+```python out
+dict_keys(['input_ids', 'token_type_ids', 'attention_mask', 'offset_mapping', 'overflow_to_sample_mapping'])
+```
+
+ကျွန်တော်တို့ တွေ့ရတဲ့အတိုင်း၊ ပုံမှန် input IDs, token type IDs, နဲ့ attention mask တွေအပြင်၊ ကျွန်တော်တို့ လိုအပ်တဲ့ offset mapping နဲ့ အပို key ဖြစ်တဲ့ `overflow_to_sample_mapping` တို့ကို ပြန်ရပါတယ်။ သက်ဆိုင်ရာ value ကတော့ ကျွန်တော်တို့ texts များစွာကို တစ်ပြိုင်နက်တည်း tokenize လုပ်တဲ့အခါ အသုံးဝင်ပါလိမ့်မယ် (ကျွန်တော်တို့ရဲ့ tokenizer က Rust က ထောက်ပံ့ထားတာဖြစ်တဲ့အတွက် ဒါကို အကျိုးယူသင့်ပါတယ်)။ sample တစ်ခုက features များစွာကို ပေးနိုင်တဲ့အတွက်၊ ဒါက feature တစ်ခုစီကို ၎င်းစတင်ရာ example သို့ map လုပ်ပေးပါတယ်။ ဒီနေရာမှာ ကျွန်တော်တို့ example တစ်ခုတည်းကိုပဲ tokenize လုပ်ခဲ့တာကြောင့် `0` တွေရဲ့ list တစ်ခုကို ရရှိပါတယ်။
+
+```py
+inputs["overflow_to_sample_mapping"]
+```
+
+```python out
+[0, 0, 0, 0]
+```
+
+ဒါပေမယ့် ကျွန်တော်တို့ examples ပိုများများ tokenize လုပ်ရင် ဒါက ပိုအသုံးဝင်လာပါလိမ့်မယ်။
+
+```py
+inputs = tokenizer(
+    raw_datasets["train"][2:6]["question"],
+    raw_datasets["train"][2:6]["context"],
+    max_length=100,
+    truncation="only_second",
+    stride=50,
+    return_overflowing_tokens=True,
+    return_offsets_mapping=True,
+)
+
+print(f"The 4 examples gave {len(inputs['input_ids'])} features.")
+print(f"Here is where each comes from: {inputs['overflow_to_sample_mapping']}.")
+```
+
+```python out
+'The 4 examples gave 19 features.'
+'Here is where each comes from: [0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3].'
+```
+
+ကျွန်တော်တို့ တွေ့ရတဲ့အတိုင်း၊ ပထမဆုံး examples သုံးခု (training set မှာ index 2, 3, 4 မှာရှိတဲ့) တစ်ခုစီက features လေးခုစီ ပေးခဲ့ပြီး နောက်ဆုံး example (training set မှာ index 5 မှာရှိတဲ့) က features ၇ ခု ပေးခဲ့ပါတယ်။
+
+ဒီအချက်အလက်တွေက ကျွန်တော်တို့ ရရှိတဲ့ feature တစ်ခုစီကို ၎င်းရဲ့ သက်ဆိုင်ရာ label နဲ့ map လုပ်ဖို့ အသုံးဝင်ပါလိမ့်မယ်။ အစောပိုင်းက ဖော်ပြခဲ့တဲ့အတိုင်း၊ အဲဒီ labels တွေက...
+
+- အဖြေက context ရဲ့ သက်ဆိုင်ရာ span မှာ မပါဝင်ရင် `(0, 0)`
+- အဖြေက context ရဲ့ သက်ဆိုင်ရာ span မှာ ပါဝင်ရင် `(start_position, end_position)`၊ `start_position` က အဖြေရဲ့ အစမှာရှိတဲ့ token (input IDs ထဲက) ရဲ့ index ဖြစ်ပြီး `end_position` က အဖြေဆုံးသတ်တဲ့ token (input IDs ထဲက) ရဲ့ index ဖြစ်ပါတယ်။
+
+ဒါတွေထဲက ဘယ်ကိစ္စဖြစ်လဲဆိုတာ ဆုံးဖြတ်ဖို့နဲ့၊ သက်ဆိုင်ရာ tokens တွေရဲ့ position တွေကို သိဖို့၊ ပထမဆုံး input IDs ထဲက context ကို စတင်တဲ့နဲ့ အဆုံးသတ်တဲ့ indices တွေကို ရှာဖွေရပါမယ်။ ဒါကိုလုပ်ဖို့ token type IDs တွေကို အသုံးပြုနိုင်ပေမယ့်၊ အဲဒါတွေက models အားလုံးအတွက် မရှိနိုင်တာကြောင့် (ဥပမာ - DistilBERT က အဲဒါတွေ မလိုအပ်ပါဘူး)၊ ကျွန်တော်တို့ရဲ့ tokenizer က ပြန်ပေးတဲ့ `BatchEncoding` ရဲ့ `sequence_ids()` method ကို အစားအသုံးပြုပါမယ်။
+
+အဲဒီ token indices တွေ ရရှိပြီဆိုတာနဲ့၊ သက်ဆိုင်ရာ offsets တွေကို ကြည့်ပါမယ်။ အဲဒါတွေက original context ထဲက characters တွေရဲ့ span ကို ကိုယ်စားပြုတဲ့ integer နှစ်ခုပါဝင်တဲ့ tuples တွေ ဖြစ်ပါတယ်။ ဒါကြောင့် ဒီ feature ထဲက context ရဲ့ chunk က အဖြေစတင်ပြီးမှ စတာလား ဒါမှမဟုတ် အဖြေစတင်တာထက် စောပြီး ဆုံးတာလားဆိုတာကို သိနိုင်ပါတယ် (ဒီကိစ္စမှာ label က `(0, 0)` ဖြစ်ပါလိမ့်မယ်)။ အဲဒီလိုမဟုတ်ဘူးဆိုရင်၊ အဖြေရဲ့ ပထမဆုံးနဲ့ နောက်ဆုံး tokens တွေကို ရှာဖို့ loop လုပ်ပါမယ်။
+
+```py
+answers = raw_datasets["train"][2:6]["answers"]
+start_positions = []
+end_positions = []
+
+for i, offset in enumerate(inputs["offset_mapping"]):
+    sample_idx = inputs["overflow_to_sample_mapping"][i]
+    answer = answers[sample_idx]
+    start_char = answer["answer_start"][0]
+    end_char = answer["answer_start"][0] + len(answer["text"][0])
+    sequence_ids = inputs.sequence_ids(i)
+
+    # Find the start and end of the context
+    idx = 0
+    while sequence_ids[idx] != 1:
+        idx += 1
+    context_start = idx
+    while sequence_ids[idx] == 1:
+        idx += 1
+    context_end = idx - 1
+
+    # If the answer is not fully inside the context, label is (0, 0)
+    if offset[context_start][0] > start_char or offset[context_end][1] < end_char:
+        start_positions.append(0)
+        end_positions.append(0)
+    else:
+        # Otherwise it's the start and end token positions
+        idx = context_start
+        while idx <= context_end and offset[idx][0] <= start_char:
+            idx += 1
+        start_positions.append(idx - 1)
+
+        idx = context_end
+        while idx >= context_start and offset[idx][1] >= end_char:
+            idx -= 1
+        end_positions.append(idx + 1)
+
+start_positions, end_positions
+```
+
+```python out
+([83, 51, 19, 0, 0, 64, 27, 0, 34, 0, 0, 0, 67, 34, 0, 0, 0, 0, 0],
+ [85, 53, 21, 0, 0, 70, 33, 0, 40, 0, 0, 0, 68, 35, 0, 0, 0, 0, 0])
+```
+
+ကျွန်တော်တို့ရဲ့ နည်းလမ်းက မှန်ကန်ခြင်းရှိမရှိ စစ်ဆေးဖို့ ရလဒ်အနည်းငယ်ကို ကြည့်ရအောင်။ ပထမဆုံး feature အတွက် `(83, 85)` ကို labels အဖြစ် တွေ့ရပါတယ်၊ ဒါကြောင့် သီအိုရီအရ အဖြေကို 83 ကနေ 85 (ပါဝင်) အထိ tokens တွေရဲ့ decoded span နဲ့ နှိုင်းယှဉ်ကြည့်ရအောင်။
+
+```py
+idx = 0
+sample_idx = inputs["overflow_to_sample_mapping"][idx]
+answer = answers[sample_idx]["text"][0]
+
+start = start_positions[idx]
+end = end_positions[idx]
+labeled_answer = tokenizer.decode(inputs["input_ids"][idx][start : end + 1])
+
+print(f"Theoretical answer: {answer}, labels give: {labeled_answer}")
+```
+
+```python out
+'Theoretical answer: the Main Building, labels give: the Main Building'
+```
+
+ဒါဆိုရင် ကိုက်ညီပါတယ်။ အခု index 4 ကို စစ်ဆေးကြည့်ရအောင်၊ အဲဒီမှာ labels တွေကို `(0, 0)` လို့ သတ်မှတ်ထားပါတယ်။ ဒါက အဖြေက အဲဒီ feature ရဲ့ context chunk မှာ မပါဝင်ဘူးလို့ ဆိုလိုပါတယ်။
+
+```py
+idx = 4
+sample_idx = inputs["overflow_to_sample_mapping"][idx]
+answer = answers[sample_idx]["text"][0]
+
+decoded_example = tokenizer.decode(inputs["input_ids"][idx])
+print(f"Theoretical answer: {answer}, decoded example: {decoded_example}")
+```
+
+```python out
+'Theoretical answer: a Marian place of prayer and reflection, decoded example: [CLS] What is the Grotto at Notre Dame? [SEP] Architecturally, the school has a Catholic character. Atop the Main Building\'s gold dome is a golden statue of the Virgin Mary. Immediately in front of the Main Building and facing it, is a copper statue of Christ with arms upraised with the legend " Venite Ad Me Omnes ". Next to the Main Building is the Basilica of the Sacred Heart. Immediately behind the basilica is the Grot [SEP]'
+```
+
+တကယ်ပါပဲ၊ context ထဲမှာ အဖြေကို ကျွန်တော်တို့ မတွေ့ရပါဘူး။
+
+> [!TIP]
+> ✏️ **သင့်အလှည့်ပါ။** XLNet architecture ကို အသုံးပြုတဲ့အခါ၊ padding ကို ဘယ်ဘက်မှာ အသုံးပြုပြီး question နဲ့ context ကို ပြောင်းပြန်လှန်ထားပါတယ်။ ကျွန်တော်တို့ အခုမြင်တွေ့ခဲ့ရတဲ့ code အားလုံးကို XLNet architecture နဲ့ အံဝင်ခွင်ကျ ဖြစ်အောင် ပြောင်းလဲပါ (ပြီးတော့ `padding=True` ကို ထည့်သွင်းပါ)။ padding ကို အသုံးပြုတဲ့အခါ `[CLS]` token က 0 position မှာ မရှိနိုင်ဘူးဆိုတာ သတိပြုပါ။
+
+အခု training data ကို တစ်ဆင့်ချင်းစီ ဘယ်လို preprocess လုပ်ရမယ်ဆိုတာ ကျွန်တော်တို့ တွေ့ခဲ့ရပြီဆိုတော့၊ ဒါကို function တစ်ခုထဲမှာ အုပ်စုဖွဲ့ပြီး training dataset တစ်ခုလုံးပေါ်မှာ အသုံးပြုနိုင်ပါပြီ။ ကျွန်တော်တို့ သတ်မှတ်ထားတဲ့ maximum length အထိ feature တိုင်းကို pad လုပ်ပါမယ်။ ဘာလို့လဲဆိုတော့ contexts အများစုက ရှည်လျားပြီး (သက်ဆိုင်ရာ samples တွေကို features အများအပြားအဖြစ် ခွဲထုတ်ပါလိမ့်မယ်)၊ ဒီနေရာမှာ dynamic padding ကို အသုံးပြုတာက တကယ်တော့ အကျိုးကျေးဇူး မရှိပါဘူး။
+
+```py
+max_length = 384
+stride = 128
+
+
+def preprocess_training_examples(examples):
+    questions = [q.strip() for q in examples["question"]]
+    inputs = tokenizer(
+        questions,
+        examples["context"],
+        max_length=max_length,
+        truncation="only_second",
+        stride=stride,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        padding="max_length",
+    )
+
+    offset_mapping = inputs.pop("offset_mapping")
+    sample_map = inputs.pop("overflow_to_sample_mapping")
+    answers = examples["answers"]
+    start_positions = []
+    end_positions = []
+
+    for i, offset in enumerate(offset_mapping):
+        sample_idx = sample_map[i]
+        answer = answers[sample_idx]
+        start_char = answer["answer_start"][0]
+        end_char = answer["answer_start"][0] + len(answer["text"][0])
+        sequence_ids = inputs.sequence_ids(i)
+
+        # Find the start and end of the context
+        idx = 0
+        while sequence_ids[idx] != 1:
+            idx += 1
+        context_start = idx
+        while sequence_ids[idx] == 1:
+            idx += 1
+        context_end = idx - 1
+
+        # If the answer is not fully inside the context, label is (0, 0)
+        if offset[context_start][0] > start_char or offset[context_end][1] < end_char:
+            start_positions.append(0)
+            end_positions.append(0)
+        else:
+            # Otherwise it's the start and end token positions
+            idx = context_start
+            while idx <= context_end and offset[idx][0] <= start_char:
+                idx += 1
+            start_positions.append(idx - 1)
+
+            idx = context_end
+            while idx >= context_start and offset[idx][1] >= end_char:
+                idx -= 1
+            end_positions.append(idx + 1)
+
+    inputs["start_positions"] = start_positions
+    inputs["end_positions"] = end_positions
+    return inputs
+```
+
+ကျွန်တော်တို့ maximum length နဲ့ sliding window ရဲ့ length ကို သတ်မှတ်ဖို့ constants နှစ်ခုကို သတ်မှတ်ခဲ့ပြီး၊ tokenize မလုပ်ခင် သန့်ရှင်းရေးအနည်းငယ် ထပ်ထည့်ခဲ့တယ်ဆိုတာ သတိပြုပါ။ SQuAD dataset ထဲက မေးခွန်းအချို့မှာ အစနဲ့အဆုံးမှာ အပို spaces တွေ ပါဝင်ပြီး ဒါတွေက ဘာမှ ထပ်မံထည့်သွင်းခြင်းမရှိသလို (RoBERTa လို model ကို အသုံးပြုရင် tokenize လုပ်တဲ့အခါ နေရာယူပါတယ်)၊ ဒါကြောင့် အဲဒီအပို spaces တွေကို ဖယ်ရှားခဲ့ပါတယ်။
+
+ဒီ function ကို training set တစ်ခုလုံးပေါ်မှာ အသုံးပြုဖို့အတွက်၊ `batched=True` flag နဲ့ `Dataset.map()` method ကို အသုံးပြုပါတယ်။ ဒီနေရာမှာ ဒါက လိုအပ်ပါတယ်၊ ဘာလို့လဲဆိုတော့ dataset ရဲ့ length ကို ကျွန်တော်တို့ ပြောင်းလဲနေလို့ပါ (sample တစ်ခုက training features များစွာ ပေးနိုင်တာကြောင့်)။
+
+```py
+train_dataset = raw_datasets["train"].map(
+    preprocess_training_examples,
+    batched=True,
+    remove_columns=raw_datasets["train"].column_names,
+)
+len(raw_datasets["train"]), len(train_dataset)
+```
+
+```python out
+(87599, 88729)
+```
+
+ကျွန်တော်တို့ တွေ့ရတဲ့အတိုင်း၊ preprocessing က features ၁,၀၀၀ ခန့် ထပ်မံထည့်သွင်းခဲ့ပါတယ်။ ကျွန်တော်တို့ရဲ့ training set က အခုဆိုရင် အသုံးပြုဖို့ အဆင်သင့်ဖြစ်ပါပြီ -- validation set ရဲ့ preprocessing ကို လေ့လာကြည့်ရအောင်။
+
+### Validation Data ကို စီမံဆောင်ရွက်ခြင်း[[processing-the-validation-data]]
+
+validation data ကို preprocessing လုပ်တာက အနည်းငယ် ပိုလွယ်ကူပါလိမ့်မယ်။ ဘာလို့လဲဆိုတော့ labels တွေ ဖန်တီးဖို့ မလိုအပ်လို့ပါပဲ (validation loss ကို တွက်ချက်ချင်တယ်ဆိုရင်တော့ လိုအပ်ပေမယ့်၊ အဲဒီဂဏန်းက model ဘယ်လောက်ကောင်းလဲဆိုတာ နားလည်ဖို့ တကယ်အကူအညီဖြစ်မှာ မဟုတ်ပါဘူး)။ တကယ့် ပျော်ရွှင်စရာကတော့ model ရဲ့ predictions တွေကို original context ရဲ့ spans တွေအဖြစ် အဓိပ္ပာယ်ဖွင့်ဆိုဖို့ပါပဲ။ ဒီအတွက်၊ ကျွန်တော်တို့ offset mappings တွေနဲ့ ဖန်တီးထားတဲ့ feature တစ်ခုစီကို ၎င်းစတင်ရာ original example နဲ့ ကိုက်ညီစေမယ့် နည်းလမ်းအချို့ကို သိမ်းဆည်းထားဖို့ပဲ လိုအပ်ပါလိမ့်မယ်။ original dataset ထဲမှာ ID column တစ်ခုရှိတဲ့အတွက်၊ အဲဒီ ID ကို ကျွန်တော်တို့ အသုံးပြုပါမယ်။
+
+ဒီနေရာမှာ ကျွန်တော်တို့ ထပ်ထည့်မယ့် တစ်ခုတည်းသောအရာကတော့ offset mappings တွေကို သန့်ရှင်းရေးလုပ်တာ အနည်းငယ်ပါ။ ၎င်းတို့မှာ question နဲ့ context အတွက် offsets တွေ ပါဝင်ပါလိမ့်မယ်၊ ဒါပေမယ့် post-processing အဆင့်ရောက်တာနဲ့ input IDs ရဲ့ ဘယ်အပိုင်းက context နဲ့ ကိုက်ညီပြီး ဘယ်အပိုင်းက question ဖြစ်တယ်ဆိုတာကို သိဖို့ နည်းလမ်းမရှိတော့ပါဘူး (ကျွန်တော်တို့ အသုံးပြုခဲ့တဲ့ `sequence_ids()` method က tokenizer ရဲ့ output အတွက်ပဲ ရရှိနိုင်ပါတယ်)။ ဒါကြောင့်၊ question နဲ့ ကိုက်ညီတဲ့ offsets တွေကို `None` လို့ သတ်မှတ်ပါမယ်။
+
+```py
+def preprocess_validation_examples(examples):
+    questions = [q.strip() for q in examples["question"]]
+    inputs = tokenizer(
+        questions,
+        examples["context"],
+        max_length=max_length,
+        truncation="only_second",
+        stride=stride,
+        return_overflowing_tokens=True,
+        return_offsets_mapping=True,
+        padding="max_length",
+    )
+
+    sample_map = inputs.pop("overflow_to_sample_mapping")
+    example_ids = []
+
+    for i in range(len(inputs["input_ids"])):
+        sample_idx = sample_map[i]
+        example_ids.append(examples["id"][sample_idx])
+
+        sequence_ids = inputs.sequence_ids(i)
+        offset = inputs["offset_mapping"][i]
+        inputs["offset_mapping"][i] = [
+            o if sequence_ids[k] == 1 else None for k, o in enumerate(offset)
+        ]
+
+    inputs["example_id"] = example_ids
+    return inputs
+```
+
+ဒီ function ကို ယခင်ကလိုပဲ validation dataset တစ်ခုလုံးပေါ်မှာ အသုံးပြုနိုင်ပါတယ်။
+
+```py
+validation_dataset = raw_datasets["validation"].map(
+    preprocess_validation_examples,
+    batched=True,
+    remove_columns=raw_datasets["validation"].column_names,
+)
+len(raw_datasets["validation"]), len(validation_dataset)
+```
+
+```python out
+(10570, 10822)
+```
+
+ဒီကိစ္စမှာ ကျွန်တော်တို့ samples ရာဂဏန်းအနည်းငယ်သာ ထပ်ထည့်ခဲ့တာကြောင့် validation dataset ထဲက contexts တွေက အနည်းငယ် တိုတောင်းပုံရပါတယ်။
+
+data အားလုံးကို preprocess လုပ်ပြီးပြီဆိုတော့ training ကို စတင်နိုင်ပါပြီ။
+
+{#if fw === 'pt'}
+
+## `Trainer` API ဖြင့် Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model-with-the-trainer-api]]
+
+ဒီဥပမာအတွက် training code က ယခင်အပိုင်းတွေက code နဲ့ အများကြီး ဆင်တူပါလိမ့်မယ် -- အခက်ခဲဆုံးအရာကတော့ `compute_metrics()` function ကို ရေးသားဖို့ပါပဲ။ ကျွန်တော်တို့ samples အားလုံးကို သတ်မှတ်ထားတဲ့ maximum length အထိ padding လုပ်ခဲ့တာကြောင့်၊ သတ်မှတ်ဖို့ data collator မရှိပါဘူး။ ဒါကြောင့် ဒီ metric computation က ကျွန်တော်တို့ စိုးရိမ်ရမယ့် တစ်ခုတည်းသော အရာပါပဲ။ အခက်ခဲဆုံး အပိုင်းကတော့ model predictions တွေကို original examples ထဲက text spans တွေအဖြစ် post-process လုပ်ဖို့ပါပဲ၊ ဒါပြီးရင် 🤗 Datasets library ကနေ metric က အလုပ်အများစုကို ကျွန်တော်တို့အတွက် လုပ်ပေးပါလိမ့်မယ်။
+
+{:else}
+
+## Keras ဖြင့် Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model-with-keras]]
+
+ဒီဥပမာအတွက် training code က ယခင်အပိုင်းတွေက code နဲ့ အများကြီး ဆင်တူပါလိမ့်မယ်၊ ဒါပေမယ့် metrics တွေကို တွက်ချက်တာကတော့ အလွန် စိန်ခေါ်မှုရှိပါလိမ့်မယ်။ ကျွန်တော်တို့ samples အားလုံးကို သတ်မှတ်ထားတဲ့ maximum length အထိ padding လုပ်ခဲ့တာကြောင့်၊ သတ်မှတ်ဖို့ data collator မရှိပါဘူး။ ဒါကြောင့် ဒီ metric computation က ကျွန်တော်တို့ စိုးရိမ်ရမယ့် တစ်ခုတည်းသော အရာပါပဲ။ အခက်ခဲဆုံး အပိုင်းကတော့ model predictions တွေကို original examples ထဲက text spans တွေအဖြစ် post-process လုပ်ဖို့ပါပဲ၊ ဒါပြီးရင် 🤗 Datasets library ကနေ metric က အလုပ်အများစုကို ကျွန်တော်တို့အတွက် လုပ်ပေးပါလိမ့်မယ်။
+
+{/if}
+
+### Post-processing[[post-processing]]
+
+{#if fw === 'pt'}
+
+<Youtube id="BNy08iIWVJM"/>
+
+{:else}
+
+<Youtube id="VN67ZpN33Ss"/>
+
+{/if}
+
+model က input IDs ထဲက အဖြေရဲ့ start နဲ့ end positions အတွက် logits တွေကို ထုတ်ပေးပါလိမ့်မယ်။ [Chapter 6](/course/chapter6/3b) မှာ `question-answering` pipeline ကို လေ့လာခဲ့စဉ်က ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့အတိုင်းပါပဲ။ post-processing အဆင့်က အဲဒီမှာ လုပ်ခဲ့တာနဲ့ ဆင်တူပါလိမ့်မယ်။ ဒါကြောင့် ကျွန်တော်တို့ လုပ်ခဲ့တဲ့ လုပ်ဆောင်ချက်တွေကို အတိုချုပ် ပြန်ပြောရရင်...
+
+- context ပြင်ပ tokens တွေနဲ့ ကိုက်ညီတဲ့ start နဲ့ end logits တွေကို ကျွန်တော်တို့ mask လုပ်ခဲ့ပါတယ်။
+- ပြီးရင် start နဲ့ end logits တွေကို softmax အသုံးပြုပြီး probabilities တွေအဖြစ် ပြောင်းလဲခဲ့ပါတယ်။
+- သက်ဆိုင်ရာ probabilities နှစ်ခုရဲ့ product ကို ယူခြင်းဖြင့် `(start_token, end_token)` အတွဲတစ်ခုစီကို score တစ်ခု သတ်မှတ်ခဲ့ပါတယ်။
+- အကောင်းဆုံး score ရှိတဲ့ အဖြေမှန် (ဥပမာ - `start_token` က `end_token` ထက် နည်းပါးတာ) ပေးတဲ့ အတွဲကို ရှာဖွေခဲ့ပါတယ်။
+
+ဒီနေရာမှာတော့ ဒီလုပ်ငန်းစဉ်ကို အနည်းငယ် ပြောင်းလဲပါမယ်။ ဘာလို့လဲဆိုတော့ တကယ့် scores တွေကို တွက်ချက်ဖို့ မလိုအပ်လို့ပါ (ခန့်မှန်းထားတဲ့ အဖြေကိုပဲ လိုအပ်လို့ပါ)။ ဒါက softmax အဆင့်ကို ကျော်ဖြတ်နိုင်တယ်လို့ ဆိုလိုပါတယ်။ ပိုမြန်အောင်လုပ်ဖို့၊ ဖြစ်နိုင်တဲ့ `(start_token, end_token)` အတွဲအားလုံးကိုလည်း score လုပ်မှာ မဟုတ်ပါဘူး၊ အမြင့်ဆုံး `n_best` logits (with `n_best=20`) နဲ့ ကိုက်ညီတဲ့ အတွဲတွေကိုပဲ score လုပ်ပါမယ်။ ကျွန်တော်တို့ softmax ကို ကျော်ဖြတ်မှာဖြစ်တဲ့အတွက်၊ အဲဒီ scores တွေက logit scores တွေဖြစ်ပြီး start နဲ့ end logits တွေရဲ့ sum ကို ယူခြင်းဖြင့် ရရှိပါလိမ့်မယ် (product အစား၊ ဘာလို့လဲဆိုတော့ \\(\log(ab) = \log(a) + \log(b)\\) စည်းမျဉ်းကြောင့်ပါ)။
+
+ဒါတွေအားလုံးကို ပြသဖို့အတွက်၊ predictions အချို့ လိုအပ်ပါလိမ့်မယ်။ ကျွန်တော်တို့ model ကို မ train ရသေးတာကြောင့်၊ validation set ရဲ့ အပိုင်းအနည်းငယ်ပေါ်မှာ predictions တွေ ထုတ်ပေးဖို့ QA pipeline အတွက် default model ကို အသုံးပြုပါမယ်။ ယခင်ကလို preprocessing function ကို အသုံးပြုနိုင်ပါတယ်၊ global constant `tokenizer` ပေါ်မှာ မှီခိုနေတာကြောင့်၊ အဲဒီ object ကို ယာယီအသုံးပြုချင်တဲ့ model ရဲ့ tokenizer ကို ပြောင်းလဲဖို့ပဲ လိုအပ်ပါတယ်။
+
+```python
+small_eval_set = raw_datasets["validation"].select(range(100))
+trained_checkpoint = "distilbert-base-cased-distilled-squad"
+
+tokenizer = AutoTokenizer.from_pretrained(trained_checkpoint)
+eval_set = small_eval_set.map(
+    preprocess_validation_examples,
+    batched=True,
+    remove_columns=raw_datasets["validation"].column_names,
+)
+```
+
+preprocessing လုပ်ပြီးပြီဆိုတော့၊ tokenizer ကို ကျွန်တော်တို့ မူလက ရွေးချယ်ခဲ့တဲ့ တစ်ခုကို ပြန်ပြောင်းပါမယ်။
+
+```python
+tokenizer = AutoTokenizer.from_pretrained(model_checkpoint)
+```
+
+ပြီးရင် model က မမျှော်လင့်ထားတဲ့ `eval_set` ရဲ့ columns တွေကို ဖယ်ရှားပြီး၊ အဲဒီ small validation set အားလုံးနဲ့ batch တစ်ခု တည်ဆောက်ကာ model ကနေတစ်ဆင့် ပေးပို့ပါတယ်။ GPU ရရှိနိုင်ရင် ပိုမြန်အောင် အသုံးပြုပါတယ်။
+
+{#if fw === 'pt'}
+
+```python
+import torch
+from transformers import AutoModelForQuestionAnswering
+
+eval_set_for_model = eval_set.remove_columns(["example_id", "offset_mapping"])
+eval_set_for_model.set_format("torch")
+
+device = torch.device("cuda") if torch.cuda.is_available() else torch.device("cpu")
+batch = {k: eval_set_for_model[k].to(device) for k in eval_set_for_model.column_names}
+trained_model = AutoModelForQuestionAnswering.from_pretrained(trained_checkpoint).to(
+    device
+)
+
+with torch.no_grad():
+    outputs = trained_model(**batch)
+```
+
+`Trainer` က ကျွန်တော်တို့ကို predictions တွေကို NumPy arrays အဖြစ် ပေးမှာဖြစ်တဲ့အတွက်၊ start နဲ့ end logits တွေကို ယူပြီး အဲဒီ format အဖြစ် ပြောင်းလဲပါမယ်။
+
+```python
+start_logits = outputs.start_logits.cpu().numpy()
+end_logits = outputs.end_logits.cpu().numpy()
+```
+
+{:else}
+
+```python
+import tensorflow as tf
+from transformers import TFAutoModelForQuestionAnswering
+
+eval_set_for_model = eval_set.remove_columns(["example_id", "offset_mapping"])
+eval_set_for_model.set_format("numpy")
+
+batch = {k: eval_set_for_model[k] for k in eval_set_for_model.column_names}
+trained_model = TFAutoModelForQuestionAnswering.from_pretrained(trained_checkpoint)
+
+outputs = trained_model(**batch)
+```
+
+စမ်းသပ်မှုလွယ်ကူစေရန်အတွက်၊ ဒီ outputs တွေကို NumPy arrays တွေအဖြစ် ပြောင်းလဲကြည့်ရအောင်။
+
+```python
+start_logits = outputs.start_logits.numpy()
+end_logits = outputs.end_logits.numpy()
+```
+
+{/if}
+
+အခု၊ `small_eval_set` ထဲက example တစ်ခုစီအတွက် ခန့်မှန်းထားတဲ့ အဖြေကို ရှာဖို့ လိုအပ်ပါတယ်။ example တစ်ခုကို `eval_set` ထဲမှာ features များစွာအဖြစ် ခွဲထုတ်ခဲ့နိုင်တာကြောင့်၊ ပထမအဆင့်က `small_eval_set` ထဲက example တစ်ခုစီကို `eval_set` ထဲက သက်ဆိုင်ရာ features တွေနဲ့ map လုပ်ဖို့ပါပဲ။
+
+```python
+import collections
+
+example_to_features = collections.defaultdict(list)
+for idx, feature in enumerate(eval_set):
+    example_to_features[feature["example_id"]].append(idx)
+```
+
+ဒီအချက်အလက်တွေ ရရှိပြီဆိုတာနဲ့၊ examples အားလုံးကို loop လုပ်ပြီး၊ example တစ်ခုစီအတွက် သက်ဆိုင်ရာ features အားလုံးကို loop လုပ်ခြင်းဖြင့် တကယ်အလုပ်လုပ်နိုင်ပါပြီ။ အရင်က ပြောခဲ့တဲ့အတိုင်း၊ `n_best` start logits နဲ့ end logits တွေအတွက် logit scores တွေကို ကြည့်ပါမယ်။ အောက်ပါအခြေအနေတွေနဲ့ ကိုက်ညီတဲ့ positions တွေကိုတော့ ချန်လှပ်ထားပါမယ်။
+
+- context ထဲမှာ မပါဝင်တဲ့ အဖြေတစ်ခု
+- အနှုတ်တန်ဖိုးရှိတဲ့ အရှည်ရှိတဲ့ အဖြေတစ်ခု
+- အလွန်ရှည်လျားတဲ့ အဖြေတစ်ခု (ဖြစ်နိုင်ချေရှိတဲ့ အဖြေတွေကို `max_answer_length=30` နဲ့ ကန့်သတ်ထားပါတယ်)
+
+example တစ်ခုအတွက် အမှတ်ပေးထားတဲ့ ဖြစ်နိုင်တဲ့ အဖြေအားလုံး ရရှိပြီဆိုတာနဲ့၊ အကောင်းဆုံး logit score ရှိတဲ့ တစ်ခုကို ရွေးလိုက်ရုံပါပဲ။
+
+```python
+import numpy as np
+
+n_best = 20
+max_answer_length = 30
+predicted_answers = []
+
+for example in small_eval_set:
+    example_id = example["id"]
+    context = example["context"]
+    answers = []
+
+    for feature_index in example_to_features[example_id]:
+        start_logit = start_logits[feature_index]
+        end_logit = end_logits[feature_index]
+        offsets = eval_set["offset_mapping"][feature_index]
+
+        start_indexes = np.argsort(start_logit)[-1 : -n_best - 1 : -1].tolist()
+        end_indexes = np.argsort(end_logit)[-1 : -n_best - 1 : -1].tolist()
+        for start_index in start_indexes:
+            for end_index in end_indexes:
+                # context ထဲမှာ အပြည့်အဝ မပါဝင်တဲ့ အဖြေတွေကို ကျော်ဖြတ်ပါ
+                if offsets[start_index] is None or offsets[end_index] is None:
+                    continue
+                # length က < 0 ဒါမှမဟုတ် > max_answer_length ဖြစ်တဲ့ အဖြေတွေကို ကျော်ဖြတ်ပါ။
+                if (
+                    end_index < start_index
+                    or end_index - start_index + 1 > max_answer_length
+                ):
+                    continue
+
+                answers.append(
+                    {
+                        "text": context[offsets[start_index][0] : offsets[end_index][1]],
+                        "logit_score": start_logit[start_index] + end_logit[end_index],
+                    }
+                )
+
+    best_answer = max(answers, key=lambda x: x["logit_score"])
+    predicted_answers.append({"id": example_id, "prediction_text": best_answer["text"]})
+```
+
+ခန့်မှန်းထားတဲ့ အဖြေတွေရဲ့ နောက်ဆုံး format က ကျွန်တော်တို့ အသုံးပြုမယ့် metric က မျှော်လင့်ထားတဲ့ ပုံစံပါပဲ။ ပုံမှန်အတိုင်းပါပဲ၊ 🤗 Evaluate library ရဲ့ အကူအညီနဲ့ ဒါကို load လုပ်နိုင်ပါတယ်။
+
+```python
+import evaluate
+
+metric = evaluate.load("squad")
+```
+
+ဒီ metric က အထက်မှာ ကျွန်တော်တို့ တွေ့ခဲ့ရတဲ့ ပုံစံ (example ရဲ့ ID အတွက် key တစ်ခုနဲ့ ခန့်မှန်းထားတဲ့ text အတွက် key တစ်ခုပါဝင်တဲ့ dictionaries စာရင်း) နဲ့ အောက်ပါပုံစံ (example ရဲ့ ID အတွက် key တစ်ခုနဲ့ ဖြစ်နိုင်တဲ့ အဖြေတွေအတွက် key တစ်ခုပါဝင်တဲ့ dictionaries စာရင်း) တို့ကို မျှော်လင့်ထားပါတယ်။
+
+```python
+theoretical_answers = [
+    {"id": ex["id"], "answers": ex["answers"]} for ex in small_eval_set
+]
+```
+
+အခု lists နှစ်ခုလုံးရဲ့ ပထမဆုံး element ကို ကြည့်ခြင်းဖြင့် sensible results တွေ ရမရ စစ်ဆေးနိုင်ပါပြီ။
+
+```python
+print(predicted_answers[0])
+print(theoretical_answers[0])
+```
+
+```python out
+{'id': '56be4db0acb8001400a502ec', 'prediction_text': 'Denver Broncos'}
+{'id': '56be4db0acb8001400a502ec', 'answers': {'text': ['Denver Broncos', 'Denver Broncos', 'Denver Broncos'], 'answer_start': [177, 177, 177]}}
+```
+
+မဆိုးဘူး! အခု metric က ကျွန်တော်တို့ကို ပေးတဲ့ score ကို ကြည့်ရအောင်...
+
+```python
+metric.compute(predictions=predicted_answers, references=theoretical_answers)
+```
+
+```python out
+{'exact_match': 83.0, 'f1': 88.25}
+```
+
+ထပ်ပြီး၊ အဲဒါက တော်တော်လေး ကောင်းမွန်ပါတယ်။ [၎င်းရဲ့ paper](https://arxiv.org/abs/1910.01108v2) အရ SQuAD ပေါ်မှာ fine-tune လုပ်ထားတဲ့ DistilBERT က dataset တစ်ခုလုံးပေါ်မှာ 79.1 နဲ့ 86.9 ကို ရရှိတာကြောင့် ကျွန်တော်တို့ မှန်ကန်တဲ့ နေရာမှာ ရှိနေပါတယ်။
+
+{#if fw === 'pt'}
+
+အခု ကျွန်တော်တို့ လုပ်ခဲ့တာတွေအားလုံးကို `compute_metrics()` function တစ်ခုထဲမှာ ထည့်ပြီး `Trainer` မှာ အသုံးပြုပါမယ်။ ပုံမှန်အားဖြင့်၊ အဲဒီ `compute_metrics()` function က logits နဲ့ labels တွေပါဝင်တဲ့ tuple `eval_preds` ကိုပဲ လက်ခံပါတယ်။ ဒီနေရာမှာတော့ အနည်းငယ် ထပ်လိုအပ်ပါလိမ့်မယ်။ ဘာလို့လဲဆိုတော့ offsets တွေအတွက် features dataset ထဲမှာ ကြည့်ရမှာဖြစ်ပြီး၊ original contexts တွေအတွက် examples dataset ထဲမှာ ကြည့်ရမှာမို့လို့ပါ။ ဒါကြောင့် training လုပ်နေစဉ် ပုံမှန် evaluation results တွေရဖို့ ဒီ function ကို အသုံးပြုနိုင်မှာ မဟုတ်ပါဘူး။ training ပြီးဆုံးမှသာ ရလဒ်တွေကို စစ်ဆေးဖို့ အသုံးပြုပါမယ်။
+
+`compute_metrics()` function က ယခင်က လုပ်ခဲ့တဲ့ အဆင့်တွေ အတူတူကို အုပ်စုဖွဲ့ထားပါတယ်။ ကျွန်တော်တို့က valid answers တွေ မထွက်လာတဲ့အခါ (ဒီကိစ္စမှာ empty string ကို ခန့်မှန်းတာ) အနည်းငယ် စစ်ဆေးခြင်းကို ထပ်ထည့်လိုက်ပါတယ်။
+
+{:else}
+
+အခု ကျွန်တော်တို့ လုပ်ခဲ့တာတွေအားလုံးကို `compute_metrics()` function တစ်ခုထဲမှာ ထည့်ပြီး model ကို train ပြီးနောက် အသုံးပြုပါမယ်။ output logits တွေထက် အနည်းငယ် ပိုပေးဖို့ လိုအပ်ပါလိမ့်မယ်။ ဘာလို့လဲဆိုတော့ offsets တွေအတွက် features dataset ထဲမှာ ကြည့်ရမှာဖြစ်ပြီး၊ original contexts တွေအတွက် examples dataset ထဲမှာ ကြည့်ရမှာမို့လို့ပါ။
+
+{/if}
+
+```python
+from tqdm.auto import tqdm
+
+
+def compute_metrics(start_logits, end_logits, features, examples):
+    example_to_features = collections.defaultdict(list)
+    for idx, feature in enumerate(features):
+        example_to_features[feature["example_id"]].append(idx)
+
+    predicted_answers = []
+    for example in tqdm(examples):
+        example_id = example["id"]
+        context = example["context"]
+        answers = []
+
+        # အဲဒီ example နဲ့ ဆက်စပ်နေတဲ့ features အားလုံးကို loop လုပ်ပါ
+        for feature_index in example_to_features[example_id]:
+            start_logit = start_logits[feature_index]
+            end_logit = end_logits[feature_index]
+            offsets = features[feature_index]["offset_mapping"]
+
+            start_indexes = np.argsort(start_logit)[-1 : -n_best - 1 : -1].tolist()
+            end_indexes = np.argsort(end_logit)[-1 : -n_best - 1 : -1].tolist()
+            for start_index in start_indexes:
+                for end_index in end_indexes:
+                    # context ထဲမှာ အပြည့်အဝ မပါဝင်တဲ့ အဖြေတွေကို ကျော်ဖြတ်ပါ
+                    if offsets[start_index] is None or offsets[end_index] is None:
+                        continue
+                    # length က < 0 ဒါမှမဟုတ် > max_answer_length ဖြစ်တဲ့ အဖြေတွေကို ကျော်ဖြတ်ပါ။
+                    if (
+                        end_index < start_index
+                        or end_index - start_index + 1 > max_answer_length
+                    ):
+                        continue
+
+                    answer = {
+                        "text": context[offsets[start_index][0] : offsets[end_index][1]],
+                        "logit_score": start_logit[start_index] + end_logit[end_index],
+                    }
+                    answers.append(answer)
+
+        # အကောင်းဆုံး score ရှိတဲ့ အဖြေကို ရွေးပါ
+        if len(answers) > 0:
+            best_answer = max(answers, key=lambda x: x["logit_score"])
+            predicted_answers.append(
+                {"id": example_id, "prediction_text": best_answer["text"]}
+            )
+        else:
+            predicted_answers.append({"id": example_id, "prediction_text": ""})
+
+    theoretical_answers = [{"id": ex["id"], "answers": ex["answers"]} for ex in examples]
+    return metric.compute(predictions=predicted_answers, references=theoretical_answers)
+```
+
+ကျွန်တော်တို့ရဲ့ predictions တွေပေါ်မှာ ဒါက အလုပ်လုပ်မလုပ် စစ်ဆေးနိုင်ပါတယ်။
+
+```python
+compute_metrics(start_logits, end_logits, eval_set, small_eval_set)
+```
+
+```python out
+{'exact_match': 83.0, 'f1': 88.25}
+```
+
+ကောင်းပါတယ်။ အခု ဒါကို အသုံးပြုပြီး ကျွန်တော်တို့ model ကို fine-tune လုပ်ရအောင်။
+
+### Model ကို Fine-tuning လုပ်ခြင်း[[fine-tuning-the-model]]
+
+{#if fw === 'pt'}
+
+ကျွန်တော်တို့ model ကို train ဖို့ အဆင်သင့်ဖြစ်ပါပြီ။ ပထမဆုံး `AutoModelForQuestionAnswering` class ကို ယခင်ကလို အသုံးပြုပြီး model ကို ဖန်တီးပါ။
+
+```python
+model = AutoModelForQuestionAnswering.from_pretrained(model_checkpoint)
+```
+
+{:else}
+
+ကျွန်တော်တို့ model ကို train ဖို့ အဆင်သင့်ဖြစ်ပါပြီ။ ပထမဆုံး `TFAutoModelForQuestionAnswering` class ကို ယခင်ကလို အသုံးပြုပြီး model ကို ဖန်တီးပါ။
+
+```python
+model = TFAutoModelForQuestionAnswering.from_pretrained(model_checkpoint)
+```
+
+{/if}
+
+ပုံမှန်အတိုင်းပါပဲ၊ weights အချို့ (pretrained head ကနေရတဲ့) ကို အသုံးမပြုကြောင်းနဲ့ အခြားအချို့ကို (question answering head အတွက်) ကျပန်း စတင်သတ်မှတ်ထားကြောင်း သတိပေးချက်တစ်ခု ရရှိပါလိမ့်မယ်။ အခုဆိုရင် ဒါနဲ့ ရင်းနှီးပြီးသားဖြစ်သင့်ပေမယ့်၊ ဒါက ဒီ model ကို အခုချက်ချင်း အသုံးပြုဖို့ အဆင်သင့်မဖြစ်သေးဘဲ fine-tuning လုပ်ဖို့ လိုအပ်တယ်လို့ ဆိုလိုပါတယ် — ဒါကို အခုလုပ်တော့မှာမို့ ကောင်းပါတယ်။
+
+ကျွန်တော်တို့ model ကို Hub ကို push လုပ်နိုင်ဖို့ Hugging Face ကို log in ဝင်ဖို့ လိုအပ်ပါလိမ့်မယ်။ သင် ဒီ code ကို notebook မှာ run နေတယ်ဆိုရင်၊ login credentials တွေကို ထည့်သွင်းနိုင်မယ့် widget တစ်ခုကို ပြသပေးမယ့် အောက်ပါ utility function နဲ့ ဒါကို လုပ်ဆောင်နိုင်ပါတယ်။
+
+```python
+from huggingface_hub import notebook_login
+
+notebook_login()
+```
+
+သင် notebook မှာ အလုပ်မလုပ်ဘူးဆိုရင်၊ သင့် terminal မှာ အောက်ပါစာကြောင်းကို ရိုက်ထည့်လိုက်ပါ။
+
+```bash
+huggingface-cli login
+```
+
+{#if fw === 'pt'}
+
+ဒါပြီးတာနဲ့၊ ကျွန်တော်တို့ရဲ့ `TrainingArguments` တွေကို သတ်မှတ်နိုင်ပါတယ်။ metric ကို တွက်ချက်ဖို့ function ကို သတ်မှတ်ခဲ့စဉ်က ပြောခဲ့တဲ့အတိုင်း၊ `compute_metrics()` function ရဲ့ signature ကြောင့် ပုံမှန် evaluation loop တစ်ခု ရှိနိုင်မှာ မဟုတ်ပါဘူး။ ဒါကိုလုပ်ဖို့ `Trainer` ရဲ့ ကိုယ်ပိုင် subclass တစ်ခုကို ရေးသားနိုင်ပါတယ် (ဒီနည်းလမ်းကို [question answering example script](https://github.com/huggingface/transformers/blob/master/examples/pytorch/question-answering/trainer_qa.py) မှာ တွေ့နိုင်ပါတယ်)၊ ဒါပေမယ့် ဒီအပိုင်းအတွက်ကတော့ နည်းနည်း ရှည်လျားပါတယ်။ အစား၊ ဒီနေရာမှာ training ပြီးဆုံးမှ model ကိုသာ evaluate လုပ်ပြီး၊ "A custom training loop" အောက်မှာ ပုံမှန် evaluation လုပ်နည်းကို ပြသပေးပါမယ်။
+
+ဒါက `Trainer` API ရဲ့ ကန့်သတ်ချက်တွေကို ပြသပြီး 🤗 Accelerate library က ဘယ်လောက် အစွမ်းထက်တယ်ဆိုတာကို ပြသတဲ့နေရာပါပဲ။ class ကို သီးခြား use case တစ်ခုအတွက် customize လုပ်တာက ခက်ခဲနိုင်ပေမယ့်၊ အပြည့်အဝ ဖော်ပြထားတဲ့ training loop ကို ပြင်ဆင်တာက လွယ်ကူပါတယ်။
+
+ကျွန်တော်တို့ရဲ့ `TrainingArguments` တွေကို ကြည့်ရအောင်...
+
+```python
+from transformers import TrainingArguments
+
+args = TrainingArguments(
+    "bert-finetuned-squad",
+    evaluation_strategy="no",
+    save_strategy="epoch",
+    learning_rate=2e-5,
+    num_train_epochs=3,
+    weight_decay=0.01,
+    fp16=True,
+    push_to_hub=True,
+)
+```
+
+ဒါတွေအများစုကို ကျွန်တော်တို့ အရင်က မြင်ဖူးပါတယ်၊ hyperparameters အချို့ (learning rate, training epochs အရေအတွက်နဲ့ weight decay အချို့) ကို သတ်မှတ်ပြီး၊ epoch တိုင်းအဆုံးမှာ model ကို save လုပ်ချင်တယ်၊ evaluation ကို ကျော်ဖြတ်ပြီး၊ ကျွန်တော်တို့ရဲ့ ရလဒ်တွေကို Model Hub ကို upload လုပ်ချင်တယ်ဆိုတာ ဖော်ပြပါတယ်။ `fp16=True` နဲ့ mixed-precision training ကိုလည်း ဖွင့်ထားပါတယ်။ ဘာလို့လဲဆိုတော့ ဒါက မကြာသေးမီက ထုတ်ထားတဲ့ GPU ပေါ်မှာ training ကို ကောင်းကောင်း အရှိန်မြှင့်ပေးနိုင်လို့ပါ။
+
+{:else}
+
+ဒါပြီးတာနဲ့၊ ကျွန်တော်တို့ TF Datasets တွေကို ဖန်တီးနိုင်ပါတယ်။ ဒီတစ်ခါတော့ ရိုးရှင်းတဲ့ default data collator ကို အသုံးပြုနိုင်ပါတယ်။
+
+```python
+from transformers import DefaultDataCollator
+
+data_collator = DefaultDataCollator(return_tensors="tf")
+```
+
+ပြီးရင် ပုံမှန်အတိုင်း datasets တွေကို ဖန်တီးပါတယ်။
+
+```python
+tf_train_dataset = model.prepare_tf_dataset(
+    train_dataset,
+    collate_fn=data_collator,
+    shuffle=True,
+    batch_size=16,
+)
+tf_eval_dataset = model.prepare_tf_dataset(
+    validation_dataset,
+    collate_fn=data_collator,
+    shuffle=False,
+    batch_size=16,
+)
+```
+
+နောက်တစ်ဆင့်အနေနဲ့၊ ကျွန်တော်တို့ training hyperparameters တွေကို သတ်မှတ်ပြီး model ကို compile လုပ်ပါမယ်။
+
+```python
+from transformers import create_optimizer
+from transformers.keras_callbacks import PushToHubCallback
+import tensorflow as tf
+
+# The number of training steps is the number of samples in the dataset, divided by the batch size then multiplied
+# by the total number of epochs. Note that the tf_train_dataset here is a batched tf.data.Dataset,
+# not the original Hugging Face Dataset, so its len() is already num_samples // batch_size.
+num_train_epochs = 3
+num_train_steps = len(tf_train_dataset) * num_train_epochs
+optimizer, schedule = create_optimizer(
+    init_lr=2e-5,
+    num_warmup_steps=0,
+    num_train_steps=num_train_steps,
+    weight_decay_rate=0.01,
+)
+model.compile(optimizer=optimizer)
+
+# mixed-precision float16 ဖြင့် train လုပ်ပါ
+tf.keras.mixed_precision.set_global_policy("mixed_float16")
+```
+
+နောက်ဆုံးအနေနဲ့၊ `model.fit()` နဲ့ train ဖို့ အဆင်သင့်ဖြစ်ပါပြီ။ epoch တစ်ခုစီပြီးတဲ့အခါ model ကို Hub ကို upload လုပ်ဖို့ `PushToHubCallback` ကို အသုံးပြုပါတယ်။
+
+{/if}
+
+default အားဖြင့်၊ အသုံးပြုတဲ့ repository က သင့် namespace ထဲမှာရှိပြီး သင်သတ်မှတ်ထားတဲ့ output directory အတိုင်း နာမည်ပေးထားပါလိမ့်မယ်။ ဒါကြောင့် ကျွန်တော်တို့ရဲ့ ကိစ္စမှာ `"sgugger/bert-finetuned-squad"` ဖြစ်ပါလိမ့်မယ်။ `hub_model_id` ကို ပေးပို့ခြင်းဖြင့် ဒါကို override လုပ်နိုင်ပါတယ်၊ ဥပမာ၊ model ကို `huggingface_course` organization ကို push လုပ်ဖို့အတွက် `hub_model_id="huggingface_course/bert-finetuned-squad"` (ဒါက ဒီအပိုင်းရဲ့ အစမှာ ကျွန်တော်တို့ link ချိတ်ထားတဲ့ model ပါ) ကို အသုံးပြုခဲ့ပါတယ်။
+
+{#if fw === 'pt'}
+
+> [!TIP]
+> 💡 သင်အသုံးပြုနေတဲ့ output directory က ရှိပြီးသားဆိုရင်၊ ဒါက သင် push လုပ်ချင်တဲ့ repository ရဲ့ local clone ဖြစ်ဖို့ လိုပါတယ်။ (ဒါကြောင့် သင့် `Trainer` ကို သတ်မှတ်တဲ့အခါ error ရရင် နာမည်အသစ်တစ်ခု သတ်မှတ်ပါ)။
+
+နောက်ဆုံးအနေနဲ့၊ အရာအားလုံးကို `Trainer` class ကို ပေးပို့ပြီး training ကို စတင်လိုက်ရုံပါပဲ။
+
+```python
+from transformers import Trainer
+
+trainer = Trainer(
+    model=model,
+    args=args,
+    train_dataset=train_dataset,
+    eval_dataset=validation_dataset,
+    tokenizer=tokenizer,
+)
+trainer.train()
+```
+
+{:else}
+
+```python
+from transformers.keras_callbacks import PushToHubCallback
+
+callback = PushToHubCallback(output_dir="bert-finetuned-squad", tokenizer=tokenizer)
+
+# validation ကို နောက်မှ လုပ်မှာဖြစ်တဲ့အတွက် training လုပ်နေစဉ် validation မလုပ်ပါဘူး။
+model.fit(tf_train_dataset, callbacks=[callback], epochs=num_train_epochs)
+```
+
+{/if}
+
+training လုပ်နေစဉ်မှာ၊ model ကို save လုပ်တဲ့အခါတိုင်း (ဒီနေရာမှာတော့ epoch တိုင်း) background မှာ Hub ကို upload လုပ်တယ်ဆိုတာ သတိပြုပါ။ ဒီနည်းနဲ့၊ လိုအပ်ရင် အခြား machine တစ်ခုပေါ်မှာ training ကို ပြန်လည်စတင်နိုင်ပါလိမ့်မယ်။ training အားလုံးက အချိန်ယူရပါတယ် (Titan RTX ပေါ်မှာ တစ်နာရီကျော်ကြာပါတယ်)။ ဒါကြောင့် အဲဒါလုပ်ဆောင်နေချိန်မှာ သင် ကော်ဖီသောက်နိုင်ပါတယ် ဒါမှမဟုတ် သင်တန်းရဲ့ ပိုခက်ခဲတယ်လို့ ယူဆရတဲ့ အပိုင်းအချို့ကို ပြန်လည်ဖတ်ရှုနိုင်ပါတယ်။ ပထမဆုံး epoch ပြီးတာနဲ့၊ Hub ကို upload လုပ်ထားတဲ့ weights တွေကို မြင်ရမှာဖြစ်ပြီး သင်ရဲ့ model ကို ၎င်းရဲ့ page မှာ စတင်ကစားနိုင်ပါပြီ။
+
+{#if fw === 'pt'}
+
+training ပြီးဆုံးတာနဲ့၊ နောက်ဆုံးမှာ ကျွန်တော်တို့ model ကို evaluate လုပ်နိုင်ပါပြီ (ပြီးတော့ အဲဒီ compute time အားလုံးကို အလဟဿ မသုံးခဲ့မိဖို့ ဆုတောင်းရပါမယ်)။ `Trainer` ရဲ့ `predict()` method က model ရဲ့ predictions တွေကို (ဒီနေရာမှာ start နဲ့ end logits တွေပါဝင်တဲ့ အတွဲ) ပြန်ပေးပါလိမ့်မယ်။ ဒါကို ကျွန်တော်တို့ရဲ့ `compute_metrics()` function ကို ပေးပို့ပါတယ်။
+
+```python
+predictions, _, _ = trainer.predict(validation_dataset)
+start_logits, end_logits = predictions
+compute_metrics(start_logits, end_logits, validation_dataset, raw_datasets["validation"])
+```
+
+{:else}
+
+training ပြီးဆုံးတာနဲ့၊ နောက်ဆုံးမှာ ကျွန်တော်တို့ model ကို evaluate လုပ်နိုင်ပါပြီ (ပြီးတော့ အဲဒီ compute time အားလုံးကို အလဟဿ မသုံးခဲ့မိဖို့ ဆုတောင်းရပါမယ်)။ ကျွန်တော်တို့ `model` ရဲ့ `predict()` method က predictions တွေရယူတာကို တာဝန်ယူမှာဖြစ်ပြီး၊ `compute_metrics()` function ကို အရင်ကတည်းက သတ်မှတ်ထားတဲ့ ခက်ခဲတဲ့အလုပ်အားလုံးကို လုပ်ခဲ့ပြီးပြီဖြစ်တဲ့အတွက်၊ ကျွန်တော်တို့ရဲ့ ရလဒ်တွေကို တစ်ကြောင်းတည်းနဲ့ ရယူနိုင်ပါပြီ။
+
+```python
+predictions = model.predict(tf_eval_dataset)
+compute_metrics(
+    predictions["start_logits"],
+    predictions["end_logits"],
+    validation_dataset,
+    raw_datasets["validation"],
+)
+```
+
+{/if}
+
+```python out
+{'exact_match': 81.18259224219489, 'f1': 88.67381321905516}
+```
+
+ကောင်းပါတယ်။ နှိုင်းယှဉ်ချက်အနေနဲ့၊ ဒီ model အတွက် BERT article မှာ ဖော်ပြထားတဲ့ baseline scores တွေက 80.8 နဲ့ 88.5 ဖြစ်တာကြောင့် ကျွန်တော်တို့ ရှိသင့်တဲ့ နေရာမှာပဲ ရှိနေပါတယ်။
+
+{#if fw === 'pt'}
+
+နောက်ဆုံးအနေနဲ့၊ model ရဲ့ နောက်ဆုံး version ကို upload လုပ်ဖို့ `push_to_hub()` method ကို အသုံးပြုပါတယ်။
+
+```py
+trainer.push_to_hub(commit_message="Training complete")
+```
+
+ဒါက သင်စစ်ဆေးချင်တယ်ဆိုရင် ဒါက အခုပဲ လုပ်ခဲ့တဲ့ commit ရဲ့ URL ကို ပြန်ပေးပါလိမ့်မယ်။
+
+```python out
+'https://huggingface.co/sgugger/bert-finetuned-squad/commit/9dcee1fbc25946a6ed4bb32efb1bd71d5fa90b68'
+```
+
+`Trainer` က evaluation results အားလုံးပါဝင်တဲ့ model card draft တစ်ခုကိုလည်း ဖန်တီးပြီး upload လုပ်ပါတယ်။
+
+{/if}
+
+ဒီအဆင့်မှာ၊ Model Hub ပေါ်က inference widget ကို အသုံးပြုပြီး model ကို စမ်းသပ်နိုင်ပြီး သင့်သူငယ်ချင်းတွေ၊ မိသားစုနဲ့ အိမ်မွေးတိရစ္ဆာန်တွေကို မျှဝေနိုင်ပါတယ်။ သင်ဟာ question answering task တစ်ခုပေါ်မှာ model တစ်ခုကို အောင်မြင်စွာ fine-tune လုပ်ခဲ့ပါပြီ — ဂုဏ်ယူပါတယ်!
+
+> [!TIP]
+> ✏️ **သင့်အလှည့်ပါ။** ဒီ task မှာ ပိုကောင်းတဲ့ စွမ်းဆောင်ရည်ရှိမရှိ သိဖို့ အခြား model architecture တစ်ခုကို စမ်းသပ်ကြည့်ပါ။
+
+{#if fw === 'pt'}
+
+training loop ကို နက်နက်နဲနဲ လေ့လာချင်တယ်ဆိုရင်၊ အခု 🤗 Accelerate ကို အသုံးပြုပြီး အတူတူကို ဘယ်လိုလုပ်ရမလဲဆိုတာ ကျွန်တော်တို့ ပြသပေးပါမယ်။
+
+## Custom Training Loop တစ်ခု[[a-custom-training-loop]]
+
+အခု training loop အပြည့်အစုံကို ကြည့်ရအောင်၊ ဒါမှ သင်လိုအပ်တဲ့ အပိုင်းတွေကို လွယ်ကူစွာ customize လုပ်နိုင်ပါလိမ့်မယ်။ ဒါက [Chapter 3](/course/chapter3/4) မှာရှိတဲ့ training loop နဲ့ အများကြီး ဆင်တူပါလိမ့်မယ်၊ evaluation loop မှာတော့ ကွဲပြားပါလိမ့်မယ်။ ကျွန်တော်တို့ `Trainer` class ရဲ့ ကန့်သတ်ချက်တွေ မရှိတော့တဲ့အတွက် model ကို ပုံမှန် evaluate လုပ်နိုင်ပါလိမ့်မယ်။
+
+### Training အတွက် အားလုံးကို ပြင်ဆင်ခြင်း[[preparing-everything-for-training]]
+
+ပထမဆုံး ကျွန်တော်တို့ datasets တွေကနေ `DataLoader`s တွေကို တည်ဆောက်ဖို့ လိုအပ်ပါတယ်။ အဲဒီ datasets တွေရဲ့ format ကို `"torch"` လို့ သတ်မှတ်ပြီး၊ model က အသုံးမပြုတဲ့ validation set ထဲက columns တွေကို ဖယ်ရှားပါတယ်။ ပြီးရင်၊ Transformers က ပံ့ပိုးပေးတဲ့ `default_data_collator` ကို `collate_fn` အဖြစ် အသုံးပြုပြီး training set ကို shuffle လုပ်နိုင်ပါတယ်၊ ဒါပေမယ့် validation set ကိုတော့ shuffle မလုပ်ပါဘူး။
+
+```py
+from torch.utils.data import DataLoader
+from transformers import default_data_collator
+
+train_dataset.set_format("torch")
+validation_set = validation_dataset.remove_columns(["example_id", "offset_mapping"])
+validation_set.set_format("torch")
+
+train_dataloader = DataLoader(
+    train_dataset,
+    shuffle=True,
+    collate_fn=default_data_collator,
+    batch_size=8,
+)
+eval_dataloader = DataLoader(
+    validation_set, collate_fn=default_data_collator, batch_size=8
+)
+```
+
+နောက်တစ်ဆင့်အနေနဲ့ model ကို ပြန်လည် instantiate လုပ်ပါမယ်။ ဒါက အရင်က fine-tuning လုပ်တာကို ဆက်မလုပ်ဘဲ BERT pretrained model ကနေ အသစ်ပြန်စတာကို သေချာစေဖို့ပါပဲ-
+
+```py
+model = AutoModelForQuestionAnswering.from_pretrained(model_checkpoint)
+```
+
+ပြီးရင် optimizer တစ်ခု လိုအပ်ပါလိမ့်မယ်။ ပုံမှန်အတိုင်းပါပဲ၊ weight decay ကို အသုံးပြုတဲ့ နည်းလမ်းမှာ fix ပါဝင်တဲ့ Adam နဲ့တူတဲ့ classic `AdamW` ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။
+
+```py
+from torch.optim import AdamW
+
+optimizer = AdamW(model.parameters(), lr=2e-5)
+```
+
+အဲဒီ objects တွေအားလုံး ရရှိပြီဆိုတာနဲ့၊ ဒါတွေကို `accelerator.prepare()` method ကို ပေးပို့နိုင်ပါတယ်။ Colab notebook မှာ TPUs တွေပေါ်မှာ train လုပ်ချင်တယ်ဆိုရင်၊ ဒီ code အားလုံးကို training function တစ်ခုထဲကို ရွှေ့ဖို့ လိုအပ်မှာဖြစ်ပြီး၊ အဲဒါက `Accelerator` တစ်ခုကို instantiate လုပ်တဲ့ cell ကို execute မလုပ်သင့်ဘူးဆိုတာ သတိရပါ။ `fp16=True` ကို `Accelerator` ကို ပေးပို့ခြင်းဖြင့် mixed-precision training ကို အတင်းအကျပ် လုပ်ဆောင်နိုင်ပါတယ် (ဒါမှမဟုတ်၊ သင် code ကို script အဖြစ် execute လုပ်နေတယ်ဆိုရင်၊ 🤗 Accelerate `config` ကို သင့်လျော်စွာ ဖြည့်စွက်ထားဖို့ သေချာပါစေ)။
+
+```py
+from accelerate import Accelerator
+
+accelerator = Accelerator(fp16=True)
+model, optimizer, train_dataloader, eval_dataloader = accelerator.prepare(
+    model, optimizer, train_dataloader, eval_dataloader
+)
+```
+
+ယခင်အပိုင်းတွေကနေ သင်သိထားသင့်တဲ့အတိုင်း၊ `accelerator.prepare()` method ကနေ ပြီးသွားမှသာ `train_dataloader` length ကို အသုံးပြုပြီး training steps အရေအတွက်ကို တွက်ချက်နိုင်ပါတယ်။ ယခင်အပိုင်းတွေကလို တူညီတဲ့ linear schedule ကို ကျွန်တော်တို့ အသုံးပြုပါတယ်။
+
+```py
+from transformers import get_scheduler
+
+num_train_epochs = 3
+num_update_steps_per_epoch = len(train_dataloader)
+num_training_steps = num_train_epochs * num_update_steps_per_epoch
+
+lr_scheduler = get_scheduler(
+    "linear",
+    optimizer=optimizer,
+    num_warmup_steps=0,
+    num_training_steps=num_training_steps,
+)
+```
+
+ကျွန်တော်တို့ model ကို Hub ကို push လုပ်နိုင်ဖို့အတွက် working folder တစ်ခုမှာ `Repository` object တစ်ခု ဖန်တီးဖို့ လိုအပ်ပါလိမ့်မယ်။ ပထမဆုံး Hugging Face Hub ကို log in ဝင်ပါ၊ အကယ်၍ သင် log in မဝင်ရသေးဘူးဆိုရင်။ ကျွန်တော်တို့ model ကို ပေးချင်တဲ့ model ID ကနေ repository name ကို ဆုံးဖြတ်ပါမယ် (သင့်ရဲ့ username ပါဝင်ရမယ့် `get_full_repo_name()` function က လုပ်ဆောင်တဲ့အတိုင်း `repo_name` ကို သင့်စိတ်ကြိုက် ပြောင်းလဲနိုင်ပါတယ်)။
+
+```py
+from huggingface_hub import Repository, get_full_repo_name
+
+model_name = "bert-finetuned-squad-accelerate"
+repo_name = get_full_repo_name(model_name)
+repo_name
+```
+
+```python out
+'sgugger/bert-finetuned-squad-accelerate'
+```
+
+ပြီးရင် အဲဒီ repository ကို local folder တစ်ခုမှာ clone လုပ်နိုင်ပါတယ်။ အကယ်၍ ဒါက ရှိပြီးသားဆိုရင်၊ ဒီ local folder က ကျွန်တော်တို့ အလုပ်လုပ်နေတဲ့ repository ရဲ့ clone ဖြစ်ရပါမယ်။
+
+```py
+output_dir = "bert-finetuned-squad-accelerate"
+repo = Repository(output_dir, clone_from=repo_name)
+```
+
+အခု `output_dir` ထဲမှာ save လုပ်ထားတာတွေကို `repo.push_to_hub()` method ကို ခေါ်ခြင်းဖြင့် upload လုပ်နိုင်ပါပြီ။ ဒါက epoch တစ်ခုစီအဆုံးမှာ ကြားခံ models တွေကို upload လုပ်ဖို့ ကူညီပါလိမ့်မယ်။
+
+## Training Loop[[training-loop]]
+
+အခု training loop အပြည့်အစုံကို ရေးဖို့ အဆင်သင့်ဖြစ်ပါပြီ။ training ဘယ်လိုသွားလဲဆိုတာကို လိုက်ကြည့်ဖို့ progress bar တစ်ခု သတ်မှတ်ပြီးနောက်၊ loop မှာ အပိုင်းသုံးပိုင်း ပါဝင်ပါတယ်။
+
+- training လုပ်ငန်းစဉ် သူ့ဘာသာသူ၊ ဒါက `train_dataloader`၊ model ကနေတစ်ဆင့် forward pass၊ ပြီးရင် backward pass နဲ့ optimizer step တွေအပေါ် classic iteration ပါပဲ။
+- evaluation၊ ဒီမှာ `start_logits` နဲ့ `end_logits` တွေအတွက် values အားလုံးကို စုစည်းပြီးမှ NumPy arrays တွေအဖြစ် ပြောင်းလဲပါတယ်။ evaluation loop ပြီးသွားတာနဲ့၊ ရလဒ်အားလုံးကို concatenate လုပ်ပါတယ်။ `Accelerator` က process တစ်ခုစီမှာ examples အရေအတွက် တူညီအောင် သေချာစေဖို့အတွက် အဆုံးမှာ samples အနည်းငယ် ထပ်ထည့်နိုင်တာကြောင့် truncate လုပ်ဖို့ လိုအပ်တယ်ဆိုတာ သတိပြုပါ။
+- saving နဲ့ uploading၊ ဒီမှာ ပထမဆုံး model နဲ့ tokenizer ကို save လုပ်ပြီးမှ `repo.push_to_hub()` ကို ခေါ်ပါတယ်။ အရင်က လုပ်ခဲ့သလိုပဲ၊ `blocking=False` argument ကို အသုံးပြုပြီး 🤗 Hub library ကို asynchronous process တစ်ခုမှာ push လုပ်ဖို့ ပြောပါတယ်။ ဒီနည်းနဲ့ training က ပုံမှန်အတိုင်း ဆက်လက်လုပ်ဆောင်ပြီး ဒီ (ကြာမြင့်တဲ့) instruction ကို background မှာ execute လုပ်ပါလိမ့်မယ်။
+
+ဒီမှာ training loop အတွက် code အပြည့်အစုံပါ။
+
+```py
+from tqdm.auto import tqdm
+import torch
+
+progress_bar = tqdm(range(num_training_steps))
+
+for epoch in range(num_train_epochs):
+    # Training
+    model.train()
+    for step, batch in enumerate(train_dataloader):
+        outputs = model(**batch)
+        loss = outputs.loss
+        accelerator.backward(loss)
+
+        optimizer.step()
+        lr_scheduler.step()
+        optimizer.zero_grad()
+        progress_bar.update(1)
+
+    # Evaluation
+    model.eval()
+    start_logits = []
+    end_logits = []
+    accelerator.print("Evaluation!")
+    for batch in tqdm(eval_dataloader):
+        with torch.no_grad():
+            outputs = model(**batch)
+
+        start_logits.append(accelerator.gather(outputs.start_logits).cpu().numpy())
+        end_logits.append(accelerator.gather(outputs.end_logits).cpu().numpy())
+
+    start_logits = np.concatenate(start_logits)
+    end_logits = np.concatenate(end_logits)
+    start_logits = start_logits[: len(validation_dataset)]
+    end_logits = end_logits[: len(validation_dataset)]
+
+    metrics = compute_metrics(
+        start_logits, end_logits, validation_dataset, raw_datasets["validation"]
+    )
+    print(f"epoch {epoch}:", metrics)
+
+    # Save and upload
+    accelerator.wait_for_everyone()
+    unwrapped_model = accelerator.unwrap_model(model)
+    unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)
+    if accelerator.is_main_process:
+        tokenizer.save_pretrained(output_dir)
+        repo.push_to_hub(
+            commit_message=f"Training in progress epoch {epoch}", blocking=False
+        )
+```
+
+🤗 Accelerate နဲ့ model ကို save လုပ်တာကို ပထမဆုံးအကြိမ် မြင်ဖူးတယ်ဆိုရင်၊ အဲဒါနဲ့ တွဲဖက်ပါဝင်တဲ့ code လိုင်းသုံးခုကို ခဏလောက် စစ်ဆေးကြည့်ရအောင်။
+
+```py
+accelerator.wait_for_everyone()
+unwrapped_model = accelerator.unwrap_model(model)
+unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)
+```
+
+ပထမစာကြောင်းက သူ့ဘာသာသူ ရှင်းပြပြီးသားပါ။ ဒါက processes အားလုံးကို ဆက်မလုပ်ဆောင်ခင် အဲဒီအဆင့်ရောက်သည်အထိ အားလုံးကို စောင့်ဆိုင်းဖို့ ပြောပါတယ်။ ဒါက save မလုပ်ခင် processes တိုင်းမှာ model တူတူရှိနေတာကို သေချာစေဖို့ပါပဲ။ ပြီးရင် ကျွန်တော်တို့ သတ်မှတ်ခဲ့တဲ့ base model ဖြစ်တဲ့ `unwrapped_model` ကို ယူလိုက်ပါတယ်။ `accelerator.prepare()` method က distributed training မှာ အလုပ်လုပ်အောင် model ကို ပြောင်းလဲပေးတာကြောင့်၊ ၎င်းမှာ `save_pretrained()` method ရှိတော့မှာ မဟုတ်ပါဘူး၊ `accelerator.unwrap_model()` method က အဲဒီအဆင့်ကို ပြန်လည်လုပ်ဆောင်ပေးပါတယ်။ နောက်ဆုံးအနေနဲ့၊ `save_pretrained()` ကို ခေါ်ပေမယ့် `torch.save()` အစား `accelerator.save()` ကို အသုံးပြုဖို့ အဲဒီ method ကို ပြောပါတယ်။
+
+ဒါပြီးတာနဲ့၊ `Trainer` နဲ့ train ထားတဲ့ တစ်ခုနဲ့ အလွန်ဆင်တူတဲ့ ရလဒ်တွေ ထုတ်ပေးတဲ့ model တစ်ခုကို သင်ရရှိပါလိမ့်မယ်။ ဒီ code ကို အသုံးပြုပြီး ကျွန်တော်တို့ train ထားတဲ့ model ကို [*huggingface-course/bert-finetuned-squad-accelerate*](https://huggingface.co/huggingface-course/bert-finetuned-squad-accelerate) မှာ စစ်ဆေးနိုင်ပါတယ်။ training loop မှာ ပြင်ဆင်မှုအချို့ကို စမ်းသပ်ချင်တယ်ဆိုရင်၊ အထက်မှာ ပြသထားတဲ့ code ကို တိုက်ရိုက် edit လုပ်ပြီး implement လုပ်နိုင်ပါတယ်!
+
+{/if}
+
+## Fine-tuned Model ကို အသုံးပြုခြင်း[[using-the-fine-tuned-model]]
+
+ကျွန်တော်တို့ fine-tune လုပ်ထားတဲ့ model ကို inference widget နဲ့ Model Hub ပေါ်မှာ ဘယ်လိုအသုံးပြုရမယ်ဆိုတာကို အရင်က ပြသခဲ့ပြီးပါပြီ။ ဒါကို `pipeline` တစ်ခုထဲမှာ locally အသုံးပြုဖို့အတွက်၊ model identifier ကို သတ်မှတ်ပေးရုံပါပဲ။
+
+```py
+from transformers import pipeline
+
+# ဒါကို သင့်ကိုယ်ပိုင် checkpoint နဲ့ အစားထိုးပါ
+model_checkpoint = "huggingface-course/bert-finetuned-squad"
+question_answerer = pipeline("question-answering", model=model_checkpoint)
+
+context = """
+🤗 Transformers is backed by the three most popular deep learning libraries — Jax, PyTorch and TensorFlow — with a seamless integration
+between them. It's straightforward to train your models with one before loading them for inference with the other.
+"""
+question = "Which deep learning libraries back 🤗 Transformers?"
+question_answerer(question=question, context=context)
+```
+
+```python out
+{'score': 0.9979003071784973,
+ 'start': 78,
+ 'end': 105,
+ 'answer': 'Jax, PyTorch and TensorFlow'}
+```
+
+ကောင်းပါတယ်။ ကျွန်တော်တို့ model က ဒီ pipeline အတွက် default model အတိုင်း ကောင်းကောင်း အလုပ်လုပ်နေပါတယ်။
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **Question Answering (QA)**: ပေးထားသော စာသားတစ်ခုမှ မေးခွန်းတစ်ခု၏ အဖြေကို ရှာဖွေခြင်း။
+*   **Extractive Question Answering**: မေးခွန်းတစ်ခု၏ အဖြေကို ပေးထားသော document ထဲမှ စာသားအပိုင်း (span of text) အဖြစ် တိုက်ရိုက်ထုတ်ယူသည့် QA အမျိုးအစား။
+*   **Spans of Text**: စာသားတစ်ခုအတွင်းရှိ စကားလုံးများ သို့မဟုတ် စာလုံးများ၏ အဆက်မပြတ်သော အပိုင်း။
+*   **Document**: စာသားအချက်အလက်များပါဝင်သော အရင်းအမြစ်။
+*   **BERT Model**: Google မှ ဖန်တီးခဲ့သော Bidirectional Encoder Representations from Transformers (BERT) မော်ဒယ်။ Transformer architecture ပေါ်တွင် အခြေခံထားသော pre-trained language model တစ်ခု။
+*   **Fine-tune**: ကြိုတင်လေ့ကျင့်ထားပြီးသား (pre-trained) မော်ဒယ်တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (specific task) အတွက် အနည်းငယ်သော ဒေတာနဲ့ ထပ်မံလေ့ကျင့်ပေးခြင်း။
+*   **SQuAD Dataset (Stanford Question Answering Dataset)**: မေးခွန်းဖြေဆိုခြင်းအတွက် ကျယ်ပြန့်စွာ အသုံးပြုသော dataset တစ်ခု။ Wikipedia ဆောင်းပါးများပေါ်တွင် မေးခွန်းများနှင့် အဖြေများ ပါဝင်သည်။
+*   **Crowdworkers**: အွန်လိုင်း platform များမှတစ်ဆင့် အသေးစား၊ ထပ်တလဲလဲ လုပ်ငန်းများကို လုပ်ဆောင်ပေးသော လူများ။
+*   **Wikipedia Articles**: Wikipedia စွယ်စုံကျမ်းမှ ဆောင်းပါးများ။
+*   **Predictions**: Machine Learning မော်ဒယ်တစ်ခုက input data ကို အခြေခံပြီး ခန့်မှန်းထုတ်ပေးသော ရလဒ်များ။
+*   **Model Hub**: Hugging Face Hub ကို ရည်ညွှန်းပြီး AI မော်ဒယ်များ ရှာဖွေ၊ မျှဝေ၊ အသုံးပြုနိုင်သော ဗဟို platform။
+*   **Encoder-only Models**: Transformer architecture ၏ encoder အပိုင်းကိုသာ အသုံးပြုသော မော်ဒယ်များ (ဥပမာ- BERT)။ ၎င်းတို့သည် input ကို နားလည်ပြီး contextual representations များ ထုတ်လုပ်ရာတွင် ကောင်းမွန်သည်။
+*   **Factoid Questions**: အချက်အလက်အခြေခံသော၊ တိုက်ရိုက်အဖြေရှိသော မေးခွန်းများ။
+*   **Open-ended Questions**: တိကျသော အဖြေမရှိဘဲ၊ ပိုမိုကျယ်ပြန့်သော ဆွေးနွေးမှု သို့မဟုတ် ရှင်းလင်းချက်လိုအပ်သော မေးခွန်းများ။
+*   **Encoder-decoder Models**: Transformer architecture ၏ encoder နှင့် decoder နှစ်ခုစလုံးကို အသုံးပြုသော မော်ဒယ်များ (ဥပမာ- T5, BART)။ ၎င်းတို့သည် input ကို နားလည်ပြီး output sequence ကို ဖန်တီးရာတွင် ကောင်းမွန်သည်။
+*   **Synthesize Information**: အချက်အလက်အမျိုးမျိုးကို စုစည်းပေါင်းစပ်ခြင်း။
+*   **Text Summarization**: ရှည်လျားသော စာသားတစ်ခု၏ အနှစ်ချုပ်ကို ထုတ်လုပ်ခြင်း။
+*   **Generative Question Answering**: အဖြေကို ပေးထားသော document ထဲမှ တိုက်ရိုက်ထုတ်ယူခြင်းမဟုတ်ဘဲ၊ မော်ဒယ်က အဖြေအသစ်တစ်ခုကို ဖန်တီးထုတ်လုပ်သည့် QA အမျိုးအစား။
+*   **ELI5 Dataset (Explain Like I'm 5)**: ရှည်လျားသော၊ ရှင်းလင်းချက်လိုအပ်သော မေးခွန်းများနှင့် အဖြေများပါဝင်သည့် dataset။
+*   **Academic Benchmark**: သုတေသနပရောဂျက်များတွင် မော်ဒယ်များ၏ စွမ်းဆောင်ရည်ကို နှိုင်းယှဉ်ရန် အသုံးပြုသော စံ dataset သို့မဟုတ် task။
+*   **SQuAD v2 Benchmark**: မဖြေနိုင်သော မေးခွန်းများ ပါဝင်သော SQuAD dataset ၏ ပိုမိုခက်ခဲသော version။
+*   **Contexts**: မေးခွန်း၏ အဖြေပါဝင်နိုင်သည့် စာသားအပိုင်း။
+*   **Questions**: မေးမြန်းထားသော မေးခွန်းများ။
+*   **Answers**: မေးခွန်းများ၏ အဖြေများ။
+*   **Column**: Dataset ၏ ဒေတာတစ်ခုစီတွင် ပါဝင်သည့် feature သို့မဟုတ် attribute။
+*   **`load_dataset()` Function**: Hugging Face Datasets library မှ dataset များကို download လုပ်ပြီး cache လုပ်ရန် အသုံးပြုသော function။
+*   **`DatasetDict` Object**: Training set, validation set, နှင့် test set ကဲ့သို့သော dataset အများအပြားကို dictionary ပုံစံဖြင့် သိမ်းဆည်းထားသော object။
+*   **`train` Split**: Model ကို လေ့ကျင့်ရန်အတွက် အသုံးပြုသော dataset အပိုင်း။
+*   **`validation` Split**: Training လုပ်နေစဉ် model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် အသုံးပြုသော dataset အပိုင်း။
+*   **`features`**: Dataset ၏ columns များ၏ အမျိုးအစားများနှင့် အချက်အလက်များကို ဖော်ပြသော dictionary။
+*   **`num_rows`**: Dataset ၏ rows အရေအတွက် (ဥပမာများ)။
+*   **`context` Field**: SQuAD dataset တွင် မေးခွန်း၏ အဖြေပါဝင်နိုင်သည့် စာသားအပိုင်း။
+*   **`question` Field**: SQuAD dataset တွင် မေးမြန်းထားသော မေးခွန်း။
+*   **`answers` Field**: SQuAD dataset တွင် မေးခွန်း၏ အဖြေများ (text နှင့် start character index ပါဝင်သည်)။
+*   **`text` Field (in `answers`)**: အဖြေ၏ စာသား။
+*   **`answer_start` Field (in `answers`)**: context ထဲက အဖြေစတင်သည့် character index။
+*   **`squad` Metric**: SQuAD dataset အတွက် evaluation metrics (Exact Match နှင့် F1 Score) ကို တွက်ချက်သော metric။
+*   **`Dataset.filter()` Method**: 🤗 Datasets library မှာ ပါဝင်တဲ့ method တစ်ခုဖြစ်ပြီး သတ်မှတ်ထားသော အခြေအနေများနှင့် ကိုက်ညီသော ဒေတာများကိုသာ dataset မှ ရွေးထုတ်ရန် အသုံးပြုသည်။
+*   **Evaluation Script**: Model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် အသုံးပြုသော code။
+*   **Preprocessing**: ဒေတာများကို model က နားလည်ပြီး လုပ်ဆောင်နိုင်တဲ့ ပုံစံအဖြစ် ပြောင်းလဲပြင်ဆင်ခြင်း လုပ်ငန်းစဉ်။
+*   **Labels**: training data တွင် မော်ဒယ်က ခန့်မှန်းရန် လိုအပ်သော မှန်ကန်သည့် အဖြေများ။
+*   **Tokens**: စာသားကို ပိုင်းခြားထားသော အသေးငယ်ဆုံးယူနစ်များ။
+*   **`AutoTokenizer`**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး မော်ဒယ်အမည်ကို အသုံးပြုပြီး သက်ဆိုင်ရာ tokenizer ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **`model_checkpoint`**: pretrained model ၏ identifier (ဥပမာ- "bert-base-cased")။
+*   **Fast Tokenizer**: Rust ဘာသာစကားဖြင့် အကောင်အထည်ဖော်ထားသော tokenizer ဖြစ်ပြီး Python-based tokenizers များထက် အလွန်မြန်ဆန်သည်။
+*   **`is_fast` Attribute**: tokenizer object က fast tokenizer ဟုတ်မဟုတ်ကို ပြသသော attribute။
+*   **🤗 Tokenizers**: Rust ဘာသာနဲ့ ရေးသားထားတဲ့ Hugging Face library တစ်ခုဖြစ်ပြီး မြန်ဆန်ထိရောက်တဲ့ tokenization ကို လုပ်ဆောင်ပေးသည်။
+*   **Special Tokens**: Transformer models များက စာသားကို စီမံဆောင်ရွက်ရာတွင် အထူးအဓိပ္ပာယ်ရှိသော tokens များ (ဥပမာ- `[CLS]`, `[SEP]`)။
+*   **`[CLS]` Token**: BERT model တွင် sequence ၏ အစကို ကိုယ်စားပြုသော special token။
+*   **`[SEP]` Token**: BERT model တွင် sentence တစ်ခု၏ အဆုံး သို့မဟုတ် sentence နှစ်ခုကြား ပိုင်းခြားရန် အသုံးပြုသော special token။
+*   **`inputs` (from Tokenizer)**: tokenizer က စီမံဆောင်ရွက်ပြီးနောက် ရရှိသော dictionary (input IDs, attention mask, token type IDs စသည်)။
+*   **`tokenizer.decode()` Method**: token IDs များကို မူရင်းစာသားအဖြစ် ပြန်ပြောင်းပေးသော tokenizer method။
+*   **`input_ids`**: Tokenizer မှ ထုတ်ပေးသော tokens တစ်ခုစီ၏ ထူးခြားသော ဂဏန်းဆိုင်ရာ ID များ။
+*   **Logit**: Neural network ၏ နောက်ဆုံး layer မှ output ဖြစ်သော raw, unnormalized score။
+*   **Start Position Logit**: အဖြေ၏ စတင်သည့် token အတွက် model က ခန့်မှန်းသော logit။
+*   **End Position Logit**: အဖြေ၏ အဆုံးသတ်သည့် token အတွက် model က ခန့်မှန်းသော logit။
+*   **Max Length**: Tokenized sequence တစ်ခု၏ အမြင့်ဆုံးခွင့်ပြုထားသော အရှည်။
+*   **Sliding Window**: ရှည်လျားသော စာသားများကို သေးငယ်သော၊ ထပ်နေသော အပိုင်းများ (chunks) အဖြစ် ပိုင်းခြားခြင်း။
+*   **`max_length` (Argument)**: tokenizer တွင် အမြင့်ဆုံး sequence length ကို သတ်မှတ်ရန် argument။
+*   **`truncation="only_second"`**: tokenizer တွင် input sequence နှစ်ခုရှိသည့်အခါ ဒုတိယ sequence ကိုသာ truncate လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`stride`**: Sliding window တွင် နောက်ဆက်တွဲ chunks များကြား ထပ်နေသော tokens အရေအတွက်။
+*   **`return_overflowing_tokens=True`**: tokenizer ကို truncation လုပ်ပြီးနောက် ကျန်ရှိသော tokens များကို ပြန်ပေးရန် သတ်မှတ်ခြင်း။
+*   **`return_offsets_mapping=True`**: tokenizer ကို offset mappings များကို ပြန်ပေးရန် သတ်မှတ်ခြင်း။
+*   **Offset Mappings**: input sequence ရှိ tokens တစ်ခုစီ၏ မူရင်းစာသားထဲမှ စတင်သည့်နှင့် အဆုံးသတ်သည့် character indices များ။
+*   **`overflow_to_sample_mapping`**: မူရင်း sample တစ်ခုကနေ features များစွာ ထုတ်လုပ်တဲ့အခါ၊ feature တစ်ခုစီကို မူရင်း sample နဲ့ map လုပ်ပေးတဲ့ key။
+*   **`sequence_ids()` Method**: tokenizer output (BatchEncoding) မှ token တစ်ခုစီသည် မည်သည့် input sequence (question သို့မဟုတ် context) နှင့် သက်ဆိုင်သည်ကို ပြန်ပေးသော method။
+*   **`BatchEncoding`**: tokenizer output ၏ class။
+*   **DistilBERT**: BERT model ၏ ပိုမိုသေးငယ်ပြီး မြန်ဆန်သော version။
+*   **`strip()` Method**: string ၏ အစနှင့်အဆုံးမှ spaces များကို ဖယ်ရှားသော Python string method။
+*   **RoBERTa**: BERT ကို အခြေခံထားသော language model တစ်ခုဖြစ်ပြီး pretraining လုပ်ငန်းစဉ်ကို ပြောင်းလဲထားသည်။
+*   **`Dataset.map()` Method**: 🤗 Datasets library မှာ ပါဝင်တဲ့ method တစ်ခုဖြစ်ပြီး dataset ရဲ့ element တစ်ခုစီ ဒါမှမဟုတ် batch တစ်ခုစီပေါ်မှာ function တစ်ခုကို အသုံးပြုနိုင်စေသည်။
+*   **`batched=True`**: `map()` method မှာ အသုံးပြုသော argument တစ်ခုဖြစ်ပြီး function ကို dataset ရဲ့ element အများအပြားပေါ်မှာ တစ်ပြိုင်နက်တည်း အသုံးပြုစေသည်။
+*   **`remove_columns`**: `map()` method တွင် ပြန်ပေးသော dataset မှ ဖယ်ရှားလိုသော columns များ။
+*   **Validation Loss**: Validation set ပေါ်တွင် တွက်ချက်ထားသော loss function တန်ဖိုး။
+*   **Post-processing**: Model ၏ output များကို နောက်ဆုံးအသုံးပြုမှုအတွက် ပြင်ဆင်ခြင်း လုပ်ငန်းစဉ်။
+*   **`example_id`**: မူရင်း dataset ထဲက example တစ်ခုစီအတွက် ထူးခြားသော ID။
+*   **`enumerate()`**: iterable တစ်ခုကို loop လုပ်နေစဉ် index နှင့် value နှစ်ခုစလုံးကို ပြန်ပေးသော Python function။
+*   **`AutoModelForQuestionAnswering`**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ class တစ်ခုဖြစ်ပြီး question answering task အတွက် သက်ဆိုင်ရာ model ကို အလိုအလျောက် load လုပ်ပေးသည်။
+*   **`TFAutoModelForQuestionAnswering`**: TensorFlow framework အတွက် `AutoModelForQuestionAnswering` နှင့် တူညီသော class။
+*   **`n_best`**: အကောင်းဆုံး logit scores ရှိသော အဖြေအရေအတွက်။
+*   **`max_answer_length`**: ခန့်မှန်းထားသော အဖြေ၏ အမြင့်ဆုံး token length။
+*   **`np.argsort()`**: NumPy array ၏ elements များကို sort လုပ်ပြီး original indices များကို ပြန်ပေးသော function။
+*   **`tolist()` Method**: NumPy array ကို Python list အဖြစ် ပြောင်းလဲသော method။
+*   **`logit_score`**: start logit နှင့် end logit တို့၏ ပေါင်းလဒ် (သို့မဟုတ် product)။
+*   **`collections.defaultdict(list)`**: Default value အဖြစ် list ကို အသုံးပြုသော dictionary။
+*   **`evaluate.load("squad")`**: 🤗 Evaluate library မှ SQuAD metric ကို load လုပ်ခြင်း။
+*   **`exact_match`**: ခန့်မှန်းထားသော အဖြေသည် ground truth အဖြေနှင့် တိကျစွာ ကိုက်ညီခြင်းရှိမရှိ တိုင်းတာသော metric။
+*   **`f1`**: Precision နှင့် Recall တို့၏ harmonic mean ကို တွက်ချက်သော metric။
+*   **Precision**: positive ဟု ခန့်မှန်းထားသော instances များထဲမှ မှန်ကန်စွာ positive ဖြစ်သော instances အရေအတွက်။
+*   **Recall**: အမှန်တကယ် positive ဖြစ်သော instances များထဲမှ မှန်ကန်စွာ positive ဟု ခန့်မှန်းနိုင်သော instances အရေအတွက်။
+*   **Ground Truth**: dataset တွင် ဖော်ပြထားသော မှန်ကန်သည့် အဖြေများ။
+*   **Baseline Scores**: သုတေသနစာတမ်းများတွင် ဖော်ပြထားသော မော်ဒယ်တစ်ခု၏ အခြေခံစွမ်းဆောင်ရည်။
+*   **`compute_metrics()` Function**: model ၏ predictions များကို အကဲဖြတ်ပြီး metrics များကို တွက်ချက်ပေးသော function။
+*   **`eval_preds`**: `Trainer` မှ `compute_metrics()` function သို့ ပေးပို့သော predictions နှင့် labels များပါဝင်သော tuple။
+*   **`tqdm.auto`**: Progress bar ကို ဖန်တီးရန်အတွက် library။
+*   **`Trainer` Class**: Hugging Face Transformers library မှ model များကို လေ့ကျင့်ရန်အတွက် မြင့်မားသောအဆင့် API။
+*   **Weights**: Neural network model ၏ လေ့ကျင့်နိုင်သော parameters များ။
+*   **Pretraining Head**: pretrained model ၏ နောက်ဆုံး layer များ။
+*   **Question Answering Head**: Question Answering task အတွက် အထူးဒီဇိုင်းထုတ်ထားသော model ၏ နောက်ဆုံး layer များ။
+*   **`huggingface_hub.notebook_login()`**: Jupyter/Colab Notebooks များတွင် Hugging Face Hub သို့ login ဝင်ရန် အသုံးပြုသော function။
+*   **`huggingface-cli login`**: Command line interface မှတစ်ဆင့် Hugging Face Hub သို့ login ဝင်ရန် command။
+*   **`TrainingArguments`**: Hugging Face Transformers library မှ training လုပ်ငန်းစဉ်အတွက် hyperparameters နှင့် အခြား arguments များကို သတ်မှတ်ရန် class။
+*   **`evaluation_strategy="no"`**: training လုပ်နေစဉ် evaluation မလုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`save_strategy="epoch"`**: epoch တိုင်းအဆုံးတွင် model ကို save လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`learning_rate`**: Training လုပ်ငန်းစဉ်အတွင်း model ၏ weights များကို မည်မျှပြောင်းလဲရမည်ကို ထိန်းချုပ်သော parameter။
+*   **`num_train_epochs`**: Model ကို training dataset တစ်ခုလုံးဖြင့် လေ့ကျင့်သည့် အကြိမ်အရေအတွက်။
+*   **`weight_decay`**: Overfitting ကို လျှော့ချရန်အတွက် model ၏ weights များကို ပုံမှန်ပြုလုပ်သော နည်းလမ်း။
+*   **`fp16=True`**: Mixed-precision training ကို ဖွင့်ရန် (floating point 16-bit)။
+*   **Mixed-precision Training**: Floating point formats (ဥပမာ- FP16 နှင့် FP32) နှစ်မျိုးလုံးကို အသုံးပြုပြီး training ကို အရှိန်မြှင့်တင်ခြင်း။
+*   **`push_to_hub=True`**: training ပြီးဆုံးပြီးနောက် model ကို Hugging Face Hub သို့ push လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`DefaultDataCollator`**: Transformers library မှ default data collator ဖြစ်ပြီး inputs များကို batch အလိုက် စုစည်းပေးသည်။
+*   **`return_tensors="tf"`**: `DefaultDataCollator` တွင် output Tensors များကို TensorFlow format အဖြစ် ပြန်ပေးရန် သတ်မှတ်ခြင်း။
+*   **`model.prepare_tf_dataset()`**: TensorFlow model အတွက် Hugging Face dataset ကို TensorFlow `tf.data.Dataset` အဖြစ် ပြင်ဆင်ရန် method။
+*   **`collate_fn`**: `DataLoader` သို့မဟုတ် `prepare_tf_dataset` တွင် batch တစ်ခုအတွင်း samples များကို စုစည်းပေးသော function။
+*   **`shuffle=True`**: dataset ကို shuffle လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`batch_size`**: training လုပ်ငန်းစဉ်တစ်ခုစီတွင် model သို့ ပေးပို့သော input samples အရေအတွက်။
+*   **`create_optimizer`**: Transformers library မှ optimizer နှင့် learning rate schedule ကို ဖန်တီးရန် function။
+*   **`init_lr`**: စတင် learning rate။
+*   **`num_warmup_steps`**: learning rate ကို ဖြည်းဖြည်းချင်း တိုးမြှင့်ပေးမည့် steps အရေအတွက်။
+*   **`num_train_steps`**: စုစုပေါင်း training steps အရေအတွက်။
+*   **`weight_decay_rate`**: weight decay ၏ strength။
+*   **`model.compile()`**: Keras model ကို training အတွက် ပြင်ဆင်ရန် method (optimizer, loss function, metrics များကို သတ်မှတ်သည်)။
+*   **`tf.keras.mixed_precision.set_global_policy("mixed_float16")`**: TensorFlow တွင် global mixed-precision policy ကို float16 အဖြစ် သတ်မှတ်ခြင်း။
+*   **`model.fit()`**: Keras model ကို training လုပ်ရန် method။
+*   **`PushToHubCallback`**: Keras callback တစ်ခုဖြစ်ပြီး training လုပ်နေစဉ်အတွင်း model ကို Hugging Face Hub သို့ upload လုပ်ရန်။
+*   **`output_dir`**: model files များကို သိမ်းဆည်းမည့် directory။
+*   **`hub_model_id`**: Hugging Face Hub ပေါ်ရှိ model repository ၏ ID (ဥပမာ- "sgugger/bert-finetuned-squad")။
+*   **`Trainer.train()`**: `Trainer` class ကို အသုံးပြု၍ model ကို training လုပ်ရန် method။
+*   **Namespace**: Hugging Face Hub တွင် သုံးစွဲသူအမည် သို့မဟုတ် organization အမည်။
+*   **Local Clone**: Git repository တစ်ခု၏ သင့် local machine ပေါ်ရှိ မိတ္တူ။
+*   **Resume Training**: training ကို ရပ်တန့်ခဲ့သော နေရာမှ ပြန်လည်စတင်ခြင်း။
+*   **Compute Time**: training သို့မဟုတ် inference လုပ်ငန်းများအတွက် လိုအပ်သော processor အချိန်။
+*   **Titan RTX**: NVIDIA မှ ထုတ်လုပ်သော မြင့်မားသော စွမ်းဆောင်ရည်ရှိ GPU ကတ်။
+*   **Epoch**: training dataset တစ်ခုလုံးကို model က တစ်ကြိမ် ဖြတ်သန်းခြင်း။
+*   **Trainer.predict()**: `Trainer` class ကို အသုံးပြု၍ model ၏ predictions များကို ရယူရန် method။
+*   **Baseline Scores**: သုတေသနစာတမ်းများတွင် ဖော်ပြထားသော မော်ဒယ်တစ်ခု၏ အခြေခံစွမ်းဆောင်ရည်။
+*   **`trainer.push_to_hub()`**: `Trainer` class မှ model ကို Hugging Face Hub သို့ push လုပ်ရန် method။
+*   **Commit Message**: Git commit တစ်ခုကို ဖော်ပြသော စာသား။
+*   **Inference Widget**: Hugging Face Hub ပေါ်တွင် model ၏ စွမ်းဆောင်ရည်ကို တိုက်ရိုက်စမ်းသပ်နိုင်သော interactive tool။
+*   **`DataLoader`**: Dataset ကနေ data တွေကို batch အလိုက် load လုပ်ပေးတဲ့ PyTorch utility class။
+*   **`default_data_collator`**: Hugging Face Transformers library မှ default data collator ဖြစ်ပြီး inputs များကို batch အလိုက် စုစည်းပေးသည်။
+*   **`collate_fn`**: `DataLoader` တွင် batch တစ်ခုအတွင်း samples များကို စုစည်းပေးသော function။
+*   **`shuffle=True`**: training dataset ကို shuffle လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`AdamW`**: PyTorch မှာ အသုံးပြုတဲ့ AdamW optimizer။ Model ၏ parameters များကို training လုပ်ရာမှာ အသုံးပြုသည်။
+*   **`model.parameters()`**: model ၏ လေ့ကျင့်နိုင်သော parameters (weights နှင့် biases) များကို ပြန်ပေးသော method။
+*   **`lr`**: Learning rate။
+*   **`accelerator.prepare()` Method**: 🤗 Accelerate library တွင် model, optimizer, dataloaders များကို distributed training အတွက် ပြင်ဆင်ရန် method။
+*   **TPUs (Tensor Processing Units)**: Google မှ AI/ML workloads များအတွက် အထူးဒီဇိုင်းထုတ်ထားသော processor တစ်မျိုး။
+*   **`Accelerator`**: 🤗 Accelerate library ၏ အဓိက class။
+*   **`get_scheduler`**: Transformers library မှ learning rate scheduler ကို ဖန်တီးရန် function။
+*   **`linear` (Scheduler Type)**: Learning rate ကို training steps အလိုက် linear ပုံစံဖြင့် လျှော့ချပေးသော scheduler အမျိုးအစား။
+*   **`num_warmup_steps`**: learning rate ကို ဖြည်းဖြည်းချင်း တိုးမြှင့်ပေးမည့် steps အရေအတွက်။
+*   **`Repository` Object**: `huggingface_hub` library မှ Git repository များကို ကိုင်တွယ်ရန်အတွက် class။
+*   **`get_full_repo_name()` Function**: Hugging Face Hub ပေါ်ရှိ repository ၏ full name (username/repo_name) ကို ရယူရန် function။
+*   **`clone_from`**: `Repository` class တွင် remote repository မှ clone လုပ်ရန် သတ်မှတ်ခြင်း။
+*   **`blocking=False`**: `push_to_hub()` method တွင် push လုပ်ငန်းစဉ်ကို asynchronous (background) တွင် လုပ်ဆောင်ရန် သတ်မှတ်ခြင်း။
+*   **Asynchronous Process**: အခြားလုပ်ငန်းများ ဆက်လက်လုပ်ဆောင်နေစဉ် နောက်ခံတွင် လုပ်ဆောင်နေသော လုပ်ငန်းစဉ်။
+*   **`model.train()`**: model ကို training mode သို့ ပြောင်းလဲခြင်း။
+*   **`model.eval()`**: model ကို evaluation mode သို့ ပြောင်းလဲခြင်း။
+*   **`accelerator.backward(loss)`**: `loss` ကို အသုံးပြု၍ backpropagation ကို လုပ်ဆောင်ရန် 🤗 Accelerate method။
+*   **`optimizer.step()`**: တွက်ချက်ထားသော gradients များကို အသုံးပြုပြီး model ၏ parameters များကို update လုပ်သော optimizer method။
+*   **`lr_scheduler.step()`**: Learning rate scheduler ကို update လုပ်သော method။
+*   **`optimizer.zero_grad()`**: optimizer ၏ gradients များကို သုညသို့ သတ်မှတ်ခြင်း။
+*   **`torch.no_grad()`**: PyTorch တွင် gradient တွက်ချက်ခြင်းကို ပိတ်ရန် context manager။
+*   **`accelerator.gather()`**: Distributed training တွင် processes အားလုံးမှ Tensors များကို စုစည်းရန် 🤗 Accelerate method။
+*   **`np.concatenate()`**: NumPy arrays များကို ပေါင်းစပ်ရန် function။
+*   **`accelerator.wait_for_everyone()`**: Distributed training တွင် processes အားလုံးက သတ်မှတ်ထားသော အမှတ်အထိ ရောက်သည်အထိ စောင့်ဆိုင်းရန် 🤗 Accelerate method။
+*   **`accelerator.unwrap_model(model)`**: Distributed training အတွက် ပြင်ဆင်ထားသော model မှ base model ကို ပြန်လည်ရယူရန် 🤗 Accelerate method။
+*   **`unwrapped_model.save_pretrained(output_dir, save_function=accelerator.save)`**: model ကို output directory ထဲသို့ save လုပ်ရန် (🤗 Accelerate ရဲ့ save function ကို အသုံးပြုသည်)။
+*   **`accelerator.is_main_process`**: လက်ရှိ process က main process ဟုတ်မဟုတ်ကို စစ်ဆေးသော attribute။
+*   **`tokenizer.save_pretrained(output_dir)`**: tokenizer ကို output directory ထဲသို့ save လုပ်ရန် method။
+*   **`pipeline("question-answering", model=model_checkpoint)`**: Hugging Face Transformers library မှ question answering pipeline ကို model checkpoint သတ်မှတ်ပြီး ဖန်တီးခြင်း။
+*   **`Jax`**: Google မှ ဖန်တီးထားသော High-performance numerical computation library။
+*   **`PyTorch`**: Facebook (ယခု Meta) က ဖန်တီးထားတဲ့ open-source machine learning library တစ်ခုဖြစ်ပြီး deep learning မော်ဒယ်တွေ တည်ဆောက်ဖို့အတွက် အသုံးပြုပါတယ်။
+*   **`TensorFlow`**: Google က ဖန်တီးထားတဲ့ open-source machine learning library တစ်ခုဖြစ်ပြီး deep learning မော်ဒယ်တွေ တည်ဆောက်ဖို့အတွက် အသုံးပြုပါတယ်။
+*   **Seamless Integration**: ကိရိယာများ သို့မဟုတ် စနစ်များကြား ချောမွေ့စွာ ချိတ်ဆက် လုပ်ဆောင်နိုင်ခြင်း။

--- a/chapters/my/chapter7/8.mdx
+++ b/chapters/my/chapter7/8.mdx
@@ -1,0 +1,71 @@
+# LLM များကို ကျွမ်းကျင်ခြင်း[[mastering-llms]]
+
+<CourseFloatingBanner
+    chapter={7}
+    classNames="absolute z-10 right-0 top-0"
+/>
+
+ဒီသင်တန်းကို ဒီအထိ လေ့လာနိုင်ခဲ့ရင် ဂုဏ်ယူပါတယ်။ အခု သင်ဟာ 🤗 Transformers နဲ့ Hugging Face ecosystem ကို အသုံးပြုပြီး (နီးပါး) မည်သည့် language task ကိုမဆို ဖြေရှင်းဖို့ လိုအပ်တဲ့ ဗဟုသုတနဲ့ ကိရိယာတွေအားလုံးကို ရရှိထားပါပြီ။
+
+## NLP မှ LLM များဆီသို့
+
+ဒီသင်တန်းမှာ ကျွန်တော်တို့ traditional NLP tasks များစွာကို ဖော်ပြခဲ့ပေမယ့်၊ ဒီနယ်ပယ်ကို Large Language Models (LLMs) တွေက တော်လှန်ပြောင်းလဲခဲ့ပါတယ်။ ဒီ models တွေက language processing မှာ ဖြစ်နိုင်ခြေတွေကို သိသိသာသာ ချဲ့ထွင်ခဲ့ပါတယ်-
+
+- ၎င်းတို့ဟာ task-specific fine-tuning မလိုအပ်ဘဲ tasks များစွာကို ကိုင်တွယ်နိုင်ပါတယ်။
+- ၎င်းတို့ဟာ ညွှန်ကြားချက်တွေကို လိုက်နာရာမှာနဲ့ မတူညီတဲ့ အခြေအနေတွေနဲ့ လိုက်လျောညီထွေဖြစ်အောင် လုပ်ဆောင်ရာမှာ ထူးချွန်ပါတယ်။
+- ၎င်းတို့ဟာ မတူညီတဲ့ applications တွေအတွက် စနစ်တကျ၊ အခြေအနေနဲ့ကိုက်ညီတဲ့ text တွေကို ထုတ်လုပ်နိုင်ပါတယ်။
+- ၎င်းတို့ဟာ chain-of-thought prompting လို နည်းလမ်းတွေကနေ reasoning လုပ်ပြီး ရှုပ်ထွေးတဲ့ ပြဿနာတွေကို ဖြေရှင်းနိုင်ပါတယ်။
+
+သင်သင်ယူခဲ့တဲ့ အခြေခံ NLP skills တွေဟာ LLMs တွေနဲ့ ထိထိရောက်ရောက် အလုပ်လုပ်ဖို့အတွက် မရှိမဖြစ်လိုအပ်နေဆဲပါ။ tokenization၊ model architectures၊ fine-tuning approaches နဲ့ evaluation metrics တွေကို နားလည်ခြင်းက LLMs တွေကို အပြည့်အဝ အကျိုးယူနိုင်ဖို့ လိုအပ်တဲ့ ဗဟုသုတတွေကို ပံ့ပိုးပေးပါတယ်။
+
+ကျွန်တော်တို့ data collators အမျိုးမျိုးကို တွေ့ခဲ့ရပြီးပြီဖြစ်တဲ့အတွက်၊ task တစ်ခုစီအတွက် ဘယ်ဟာကို အသုံးပြုရမလဲဆိုတာ ရှာဖွေနိုင်ဖို့ ဒီဗီဒီယိုလေးကို ကျွန်တော်တို့ ပြုလုပ်ပေးထားပါတယ်။
+
+<Youtube id="-RPeakdlHYo"/>
+
+core language tasks တွေကို လျင်မြန်စွာ လေ့လာပြီးနောက်၊ သင်ဟာ အောက်ပါတို့ကို သိရှိသင့်ပါတယ်။
+
+*   Architecture အမျိုးအစား (encoder, decoder, ဒါမှမဟုတ် encoder-decoder) တွေထဲက ဘယ်ဟာက task တစ်ခုစီအတွက် အကောင်းဆုံးသင့်လျော်လဲ။
+*   language model ကို pretraining လုပ်တာနဲ့ fine-tuning လုပ်တာကြားက ကွာခြားချက်ကို နားလည်ပါ။
+*   သင်လိုက်နာခဲ့တဲ့ track ပေါ်မူတည်ပြီး `Trainer` API နဲ့ 🤗 Accelerate ရဲ့ distributed training features တွေ ဒါမှမဟုတ် TensorFlow နဲ့ Keras ကို အသုံးပြုပြီး Transformer models တွေကို ဘယ်လို train လုပ်ရမလဲ။
+*   text generation tasks တွေအတွက် ROUGE နဲ့ BLEU လို metrics တွေရဲ့ အဓိပ္ပာယ်နဲ့ ကန့်သတ်ချက်တွေကို နားလည်ပါ။
+*   Hub ပေါ်မှာရော 🤗 Transformers က `pipeline` ကို အသုံးပြုပြီးရော သင် fine-tune လုပ်ထားတဲ့ models တွေနဲ့ ဘယ်လို interact လုပ်ရမလဲ။
+*   LLMs တွေက traditional NLP techniques တွေကို ဘယ်လိုအခြေခံပြီး ချဲ့ထွင်ထားတယ်ဆိုတာကို တန်ဖိုးထား နားလည်ပါ။
+
+ဒီဗဟုသုတအားလုံး ရှိနေပေမယ့်လည်း၊ သင့် code မှာ ခက်ခဲတဲ့ bug တစ်ခုနဲ့ ကြုံတွေ့ရတာ ဒါမှမဟုတ် သီးခြား language processing problem တစ်ခုကို ဘယ်လိုဖြေရှင်းရမလဲဆိုတာ မေးခွန်းရှိလာတာမျိုး ဖြစ်လာနိုင်ပါတယ်။ ကံကောင်းစွာနဲ့ပဲ၊ Hugging Face community က သင့်ကို ကူညီဖို့ အသင့်ရှိပါတယ်။ သင်တန်းရဲ့ ဒီအပိုင်းရဲ့ နောက်ဆုံးအခန်းမှာ၊ သင့် Transformer models တွေကို ဘယ်လို debug လုပ်ရမလဲနဲ့ ထိထိရောက်ရောက် အကူအညီတောင်းရမလဲဆိုတာကို ကျွန်တော်တို့ လေ့လာသွားမှာပါ။
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **LLMs (Large Language Models)**: လူသားဘာသာစကားကို နားလည်ပြီး ထုတ်လုပ်ပေးနိုင်တဲ့ အလွန်ကြီးမားတဲ့ Artificial Intelligence (AI) မော်ဒယ်တွေ ဖြစ်ပါတယ်။ ၎င်းတို့ဟာ ဒေတာအမြောက်အမြားနဲ့ သင်ကြားလေ့ကျင့်ထားပြီး စာရေးတာ၊ မေးခွန်းဖြေတာ စတဲ့ ဘာသာစကားဆိုင်ရာ လုပ်ငန်းမျိုးစုံကို လုပ်ဆောင်နိုင်ပါတယ်။
+*   **🤗 Transformers Library**: Hugging Face က ထုတ်လုပ်ထားတဲ့ library တစ်ခုဖြစ်ပြီး Transformer မော်ဒယ်တွေကို အသုံးပြုပြီး Natural Language Processing (NLP), computer vision, audio processing စတဲ့ နယ်ပယ်တွေမှာ အဆင့်မြင့် AI မော်ဒယ်တွေကို တည်ဆောက်ပြီး အသုံးပြုနိုင်စေပါတယ်။
+*   **Hugging Face Ecosystem**: Hugging Face ကုမ္ပဏီမှ ဖန်တီးထားတဲ့ AI နဲ့ machine learning အတွက် ကိရိယာတွေ၊ library တွေ၊ မော်ဒယ်တွေနဲ့ platform တွေရဲ့ အစုအဝေးတစ်ခုပါ။
+*   **NLP (Natural Language Processing)**: ကွန်ပျူတာတွေ လူသားဘာသာစကားကို နားလည်၊ အဓိပ္ပာယ်ဖော်ပြီး၊ ဖန်တီးနိုင်အောင် လုပ်ဆောင်ပေးတဲ့ Artificial Intelligence (AI) ရဲ့ နယ်ပယ်ခွဲတစ်ခုပါ။
+*   **Traditional NLP Tasks**: Neural Networks များ မပေါ်မီက အသုံးပြုခဲ့သော Natural Language Processing (NLP) models များဖြင့် လုပ်ဆောင်ခဲ့သော လုပ်ငန်းများ (ဥပမာ- rule-based systems, statistical models)။
+*   **Task-specific Fine-tuning**: သီးခြား task တစ်ခုအတွက်သာ model ကို ထပ်မံလေ့ကျင့်ခြင်း။
+*   **Instructions**: LLM ကို လုပ်ဆောင်ရန် ညွှန်ကြားသော အမိန့်များ။
+*   **Contexts**: LLM ကို အသုံးပြုသည့် အခြေအနေများ သို့မဟုတ် ပတ်ဝန်းကျင်။
+*   **Generate Coherent Text**: ဆီလျော်မှုရှိပြီး နားလည်လွယ်သော စာသားကို ထုတ်လုပ်ခြင်း။
+*   **Contextually Appropriate Text**: ပေးထားသော အခြေအနေ သို့မဟုတ် ခေါင်းစဉ်နှင့် ကိုက်ညီသော စာသား။
+*   **Reasoning**: ဆင်ခြင်တုံတရားဖြင့် ပြဿနာများကို ဖြေရှင်းနိုင်စွမ်း။
+*   **Chain-of-thought Prompting**: LLM ကို ပြဿနာဖြေရှင်းရာတွင် အဆင့်ဆင့် တွေးခေါ်စေရန် လမ်းညွှန်သော prompting နည်းလမ်း။
+*   **Foundational NLP Skills**: NLP နယ်ပယ်တွင် မရှိမဖြစ်လိုအပ်သော အခြေခံကျွမ်းကျင်မှုများ။
+*   **Tokenization**: စာသား (သို့မဟုတ် အခြားဒေတာ) ကို AI မော်ဒယ်များ စီမံဆောင်ရွက်နိုင်ရန် tokens တွေအဖြစ် ပိုင်းခြားပေးသည့် လုပ်ငန်းစဉ်။
+*   **Model Architectures**: Model တစ်ခု၏ layers များနှင့် ၎င်းတို့ ချိတ်ဆက်ပုံကို ဖော်ပြသော ဒီဇိုင်းဖွဲ့စည်းပုံ။
+*   **Fine-tuning Approaches**: Pretrained model တစ်ခုကို သီးခြား task တစ်ခုအတွက် ထပ်မံလေ့ကျင့်ရန် နည်းလမ်းများ။
+*   **Evaluation Metrics**: Model ၏ စွမ်းဆောင်ရည်ကို တိုင်းတာရန် အသုံးပြုသော တန်ဖိုးများ (ဥပမာ- ROUGE, BLEU, F1 score)။
+*   **Data Collators**: Dataset မှ input samples များကို batch တစ်ခုအဖြစ် စုစည်းပေးသော function များ။
+*   **Core Language Tasks**: ဘာသာစကားနှင့် သက်ဆိုင်သော အဓိကလုပ်ငန်းများ (ဥပမာ- translation, summarization)။
+*   **Architecture (Encoder, Decoder, Encoder-Decoder)**: Transformer Model ၏ အမျိုးအစားများ (input ကို နားလည်ရန် Encoder၊ output ကို ထုတ်လုပ်ရန် Decoder၊ နှစ်ခုလုံးပါဝင်ရန် Encoder-Decoder)။
+*   **Pretraining**: Model တစ်ခုကို အကြီးစားဒေတာများဖြင့် အစောပိုင်းကတည်းက လေ့ကျင့်ထားခြင်း။
+*   **Fine-tuning**: ကြိုတင်လေ့ကျင့်ထားပြီးသား (pre-trained) မော်ဒယ်တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (specific task) အတွက် အနည်းငယ်သော ဒေတာနဲ့ ထပ်မံလေ့ကျင့်ပေးခြင်း။
+*   **Language Model**: လူသားဘာသာစကား၏ ဖြန့်ဝေမှုကို နားလည်ရန် လေ့ကျင့်ထားသော AI မော်ဒယ်တစ်ခု။
+*   **`Trainer` API**: Hugging Face Transformers library မှ model များကို ထိရောက်စွာ လေ့ကျင့်ရန်အတွက် ဒီဇိုင်းထုတ်ထားသော မြင့်မားသောအဆင့် API။
+*   **Distributed Training**: model တစ်ခုကို ကွန်ပျူတာ သို့မဟုတ် GPU များစွာဖြင့် တစ်ပြိုင်နက်တည်း လေ့ကျင့်ခြင်း။
+*   **🤗 Accelerate**: Hugging Face က ထုတ်လုပ်ထားတဲ့ library တစ်ခုဖြစ်ပြီး PyTorch code တွေကို မတူညီတဲ့ training environment (ဥပမာ - GPU အများအပြား၊ distributed training) တွေမှာ အလွယ်တကူ run နိုင်အောင် ကူညီပေးပါတယ်။
+*   **TensorFlow**: Google က ဖန်တီးထားတဲ့ open-source machine learning library တစ်ခုဖြစ်ပြီး deep learning မော်ဒယ်တွေ တည်ဆောက်ဖို့အတွက် အသုံးပြုပါတယ်။
+*   **Keras**: TensorFlow library တွင် ပါဝင်သော မြင့်မားသောအဆင့် (high-level) API တစ်ခုဖြစ်ပြီး deep learning models များကို လွယ်ကူလျင်မြန်စွာ တည်ဆောက်ရန် အသုံးပြုသည်။
+*   **ROUGE (Recall-Oriented Understudy for Gisting Evaluation)**: Summarization tasks များတွင် model ၏ output ကို အမှန်တကယ် summary (reference summary) များနှင့် နှိုင်းယှဉ်၍ အကဲဖြတ်သော metric။
+*   **BLEU (Bilingual Evaluation Understudy)**: Machine translation tasks များတွင် model ၏ output ကို reference translation များနှင့် နှိုင်းယှဉ်၍ အကဲဖြတ်သော metric။
+*   **Text Generation Tasks**: AI မော်ဒယ်များကို အသုံးပြု၍ လူသားကဲ့သို့သော စာသားအသစ်များ ဖန်တီးခြင်းနှင့် သက်ဆိုင်သော လုပ်ငန်းများ။
+*   **Interact**: model ၏ input ကို ပေးပြီး output ကို ရယူခြင်း။
+*   **`pipeline` Function**: Hugging Face Transformers library မှာ ပါဝင်တဲ့ လုပ်ဆောင်ချက်တစ်ခုဖြစ်ပြီး မော်ဒယ်တွေကို သီးခြားလုပ်ငန်းတာဝန်များ (ဥပမာ- စာသားခွဲခြားသတ်မှတ်ခြင်း၊ စာသားထုတ်လုပ်ခြင်း) အတွက် အသုံးပြုရလွယ်ကူအောင် ပြုလုပ်ပေးပါတယ်။
+*   **Debug**: code တွင်ရှိသော အမှားများ (bugs) ကို ရှာဖွေပြီး ပြင်ဆင်ခြင်း။

--- a/chapters/my/chapter7/9.mdx
+++ b/chapters/my/chapter7/9.mdx
@@ -1,0 +1,385 @@
+<FrameworkSwitchCourse {fw} />
+
+<!-- DISABLE-FRONTMATTER-SECTIONS -->
+
+# အခန်း (၇) ဆိုင်ရာ မေးခွန်းများ[[end-of-chapter-quiz]]
+
+<CourseFloatingBanner
+    chapter={7}
+    classNames="absolute z-10 right-0 top-0"
+/>
+
+ဒီအခန်းမှာ သင်ယူခဲ့တာတွေကို စစ်ဆေးကြည့်ရအောင်။
+
+### ၁။ အောက်ပါ tasks တွေထဲက ဘယ်ဟာတွေကို token classification problem အဖြစ် ပုံဖော်နိုင်သလဲ။
+
+<Question
+	choices={[
+		{
+			text: "စာကြောင်းတစ်ကြောင်းထဲက grammatical components တွေကို ရှာပါ။",
+			explain: "မှန်ပါတယ်။ အဲဒီအခါမှာ စကားလုံးတစ်လုံးစီကို noun, verb စသည်ဖြင့် label လုပ်နိုင်ပါတယ်။",
+			correct: true
+		},
+		{
+			text: "စာကြောင်းတစ်ကြောင်းဟာ grammatical အရ မှန်ကန်ခြင်း ရှိမရှိ ရှာပါ။",
+			explain: "မမှန်ပါဘူး၊ ဒါက sequence classification problem တစ်ခုပါ။"
+		},
+		{
+			text: "စာကြောင်းတစ်ကြောင်းမှာ ဖော်ပြထားတဲ့ လူပုဂ္ဂိုလ်တွေကို ရှာပါ။",
+			explain: "မှန်ပါတယ်။ စကားလုံးတစ်လုံးစီကို person ဒါမှမဟုတ် not person အဖြစ် label လုပ်နိုင်ပါတယ်။",
+            correct: true
+		},
+        {
+			text: "မေးခွန်းတစ်ခုရဲ့ အဖြေကို ပေးတဲ့ စာကြောင်းတစ်ကြောင်းထဲက words chunk ကို ရှာပါ။",
+			explain: "မမှန်ပါဘူး၊ ဒါက question answering problem တစ်ခု ဖြစ်ပါလိမ့်မယ်။"
+		}
+	]}
+/>
+
+### ၂။ token classification အတွက် preprocessing ရဲ့ ဘယ်အပိုင်းက အခြား preprocessing pipelines တွေနဲ့ ကွာခြားသလဲ။
+
+<Question
+	choices={[
+		{
+			text: "ဘာမှ လုပ်စရာ မလိုပါဘူး၊ texts တွေကို tokenize လုပ်ပြီးသားပါ။",
+			explain: "Texts တွေဟာ သီးခြား words တွေအဖြစ် ပေးထားတာ မှန်ပါတယ်၊ ဒါပေမယ့် subword tokenization model ကိုတော့ အသုံးပြုဖို့ လိုအပ်ပါသေးတယ်။"
+		},
+		{
+			text: "Texts တွေကို words တွေအဖြစ် ပေးထားတာကြောင့် subword tokenization ကိုပဲ အသုံးပြုဖို့ လိုပါတယ်။",
+			explain: "မှန်ပါတယ်။ ဒါက ပုံမှန် preprocessing နဲ့ ကွာခြားပါတယ်၊ ပုံမှန်မှာတော့ ကျွန်တော်တို့ full tokenization pipeline ကို အသုံးပြုဖို့ လိုပါတယ်။ တခြားကွာခြားချက်တစ်ခုကို စဉ်းစားနိုင်မလား။",
+			correct: true
+		},
+		{
+			text: "special tokens တွေကို label လုပ်ဖို့ <code>-100</code> ကို အသုံးပြုပါတယ်။",
+			explain: "ဒါက token classification အတွက် သီးခြားမဟုတ်ပါဘူး — ကျွန်တော်တို့ loss မှာ ignore လုပ်ချင်တဲ့ tokens တွေအတွက် label အဖြစ် <code>-100</code> ကို အမြဲတမ်း အသုံးပြုပါတယ်။"
+		},
+		{
+			text: "truncation/padding ကို အသုံးပြုတဲ့အခါ labels တွေကို inputs တွေနဲ့ တူညီတဲ့ size အထိ truncate ဒါမှမဟုတ် pad လုပ်ထားဖို့ သေချာစေရပါမယ်။",
+			explain: "ဟုတ်ပါတယ်။ ဒါပေမယ့် ဒါတစ်ခုတည်းသော ကွာခြားချက်တော့ မဟုတ်ပါဘူး။",
+			correct: true
+		}
+	]}
+/>
+
+### ၃။ token classification problem တစ်ခုမှာ words တွေကို tokenize လုပ်ပြီး tokens တွေကို label လုပ်ချင်တဲ့အခါ ဘယ်ပြဿနာ ဖြစ်ပေါ်လာသလဲ။
+
+<Question
+	choices={[
+		{
+			text: "tokenizer က special tokens တွေ ထည့်ပေးပြီး ၎င်းတို့အတွက် labels တွေ မရှိပါဘူး။",
+			explain: "ကျွန်တော်တို့ ၎င်းတို့ကို <code>-100</code> လို့ label လုပ်တာကြောင့် loss မှာ ignore လုပ်ပါတယ်။"
+		},
+		{
+			text: "word တစ်လုံးစီက tokens အများအပြားကို ထုတ်လုပ်နိုင်တာကြောင့် labels တွေထက် tokens တွေ ပိုများလာပါတယ်။",
+			explain: "ဒါက အဓိကပြဿနာဖြစ်ပြီး၊ ကျွန်တော်တို့ original labels တွေကို tokens တွေနဲ့ align လုပ်ဖို့ လိုအပ်ပါတယ်။",
+			correct: true
+		},
+		{
+			text: "ထည့်သွင်းထားတဲ့ tokens တွေမှာ labels တွေ မရှိတာကြောင့် ပြဿနာ မရှိပါဘူး။",
+			explain: "ဒါက မမှန်ပါဘူး၊ ကျွန်တော်တို့မှာ tokens အရေအတွက်အတိုင်း labels တွေ လိုအပ်ပါတယ်၊ မဟုတ်ရင် ကျွန်တော်တို့ models တွေ error ဖြစ်ပါလိမ့်မယ်။"
+		}
+	]}
+/>
+
+### ၄။ "Domain adaptation" ဆိုတာ ဘာကိုဆိုလိုသလဲ။
+
+<Question
+	choices={[
+		{
+			text: "dataset တစ်ခုပေါ်မှာ model တစ်ခုကို run ပြီး အဲဒီ dataset ထဲက sample တစ်ခုစီအတွက် predictions တွေ ရယူတာ။",
+			explain: "မမှန်ပါဘူး၊ ဒါက inference ကို run တာပါပဲ။"
+		},
+		{
+			text: "dataset တစ်ခုပေါ်မှာ model တစ်ခုကို train လုပ်တာ။",
+			explain: "မမှန်ပါဘူး၊ ဒါက model တစ်ခုကို training လုပ်တာပါ၊ ဒီနေရာမှာ adaptation မရှိပါဘူး။"
+		},
+		{
+			text: "pretrained model တစ်ခုကို dataset အသစ်တစ်ခုပေါ်မှာ fine-tune လုပ်ပြီး၊ အဲဒီ dataset အတွက် ပိုမိုသင့်လျော်တဲ့ predictions တွေ ပေးတာ။",
+			explain: "မှန်ပါတယ်။ model က သူ့ရဲ့ အသိပညာကို dataset အသစ်နဲ့ လိုက်လျောညီထွေဖြစ်အောင် လုပ်လိုက်တာပါ။",
+            correct: true
+		},
+        {
+			text: "model ကို ပိုမို robust ဖြစ်အောင်လုပ်ဖို့ dataset ထဲကို misclassified samples တွေ ထည့်သွင်းတာ။",
+			explain: "သင်က သင့် model ကို ပုံမှန် retrain လုပ်ရင် ဒါက သေချာပေါက် လုပ်သင့်တဲ့အရာပါ၊ ဒါပေမယ့် ဒါက domain adaptation မဟုတ်ပါဘူး။"
+		}
+	]}
+/>
+
+### ၅။ Masked language modeling problem မှာ labels တွေက ဘာတွေလဲ။
+
+<Question
+	choices={[
+		{
+			text: "input sentence ထဲက tokens အချို့ကို random အနေနဲ့ mask လုပ်ထားပြီး labels တွေက original input tokens တွေပါ။",
+			explain: "မှန်ပါပြီ။",
+            correct: true
+		},
+		{
+			text: "input sentence ထဲက tokens အချို့ကို random အနေနဲ့ mask လုပ်ထားပြီး labels တွေက original input tokens တွေဖြစ်ကာ၊ ဘယ်ဘက်ကို shifting လုပ်ထားပါတယ်။",
+			explain: "မမှန်ပါဘူး၊ labels တွေကို ဘယ်ဘက်ကို shifting လုပ်တာက နောက်ထပ် word ကို ခန့်မှန်းတာနဲ့ ကိုက်ညီပြီး၊ ဒါက causal language modeling ပါ။"
+		},
+		{
+			text: "input sentence ထဲက tokens အချို့ကို random အနေနဲ့ mask လုပ်ထားပြီး၊ label က sentence ဟာ positive ဖြစ်မဖြစ် ဒါမှမဟုတ် negative ဖြစ်မဖြစ်ပါ။",
+			explain: "ဒါက sequence classification problem တစ်ခုဖြစ်ပြီး data augmentation အချို့ပါဝင်ပါတယ်၊ masked language modeling မဟုတ်ပါဘူး။"
+		},
+        {
+			text: "input sentences နှစ်ခုထဲက tokens အချို့ကို random အနေနဲ့ mask လုပ်ထားပြီး၊ label က sentences နှစ်ခုဟာ ဆင်တူခြင်း ရှိမရှိပါ။",
+			explain: "ဒါက sequence classification problem တစ်ခုဖြစ်ပြီး data augmentation အချို့ပါဝင်ပါတယ်၊ masked language modeling မဟုတ်ပါဘူး။"
+		}
+	]}
+/>
+
+### ၆။ အောက်ပါ tasks တွေထဲက ဘယ်ဟာတွေကို sequence-to-sequence problem အဖြစ် မြင်နိုင်သလဲ။
+
+<Question
+	choices={[
+		{
+			text: "ရှည်လျားတဲ့ documents တွေရဲ့ အတိုချုပ် reviews တွေ ရေးသားတာ။",
+			explain: "ဟုတ်ပါတယ်၊ ဒါက summarization problem တစ်ခုပါ။ တခြားအဖြေတစ်ခု စမ်းကြည့်ပါ။",
+            correct: true
+		},
+		{
+			text: "document တစ်ခုနဲ့ပတ်သက်ပြီး မေးခွန်းတွေ ဖြေတာ။",
+			explain: "ဒါက sequence-to-sequence problem အဖြစ် ပုံဖော်နိုင်ပါတယ်။ ဒါပေမယ့် ဒါတစ်ခုတည်းသော အဖြေမှန်တော့ မဟုတ်ပါဘူး။",
+            correct: true
+		},
+		{
+			text: "Chinese text တစ်ခုကို English လို ဘာသာပြန်တာ။",
+			explain: "ဒါက သေချာပေါက် sequence-to-sequence problem တစ်ခုပါပဲ။ တခြားတစ်ခုကို တွေ့နိုင်မလား။",
+            correct: true
+		},
+        {
+			text: "ကျွန်ုပ်ရဲ့ တူလေး/သူငယ်ချင်း ပို့တဲ့ မက်ဆေ့ခ်ျတွေကို မှန်ကန်တဲ့ English ဖြစ်အောင် ပြင်ဆင်တာ။",
+			explain: "ဒါက ဘာသာပြန်ခြင်း ပြဿနာတစ်မျိုးဖြစ်တာကြောင့် သေချာပေါက် sequence-to-sequence task ပါ။ ဒါပေမယ့် ဒါတစ်ခုတည်းတော့ အဖြေမှန် မဟုတ်ပါဘူး!",
+			correct: true
+		}
+	]}
+/>
+
+### ၇။ sequence-to-sequence problem အတွက် data ကို မှန်ကန်စွာ preprocess လုပ်ဖို့ နည်းလမ်းက ဘာလဲ။
+
+<Question
+	choices={[
+		{
+			text: "inputs တွေနဲ့ targets တွေကို <code>inputs=...</code> နဲ့ <code>targets=...</code> နဲ့ tokenizer ကို အတူတူ ပေးပို့ရမယ်။",
+			explain: "ဒါက အနာဂတ်မှာ ကျွန်တော်တို့ ထည့်သွင်းမယ့် API တစ်ခု ဖြစ်နိုင်ပေမယ့်၊ အခုတော့ မရပါသေးဘူး။"
+		},
+		{
+			text: "inputs တွေနဲ့ targets တွေ နှစ်ခုလုံးကို tokenizer ကို သီးခြားစီ ခေါ်ဆိုမှုနှစ်ခုနဲ့ preprocess လုပ်ရမယ်။",
+			explain: "ဒါက မှန်ပေမယ့် မပြည့်စုံပါဘူး။ tokenizer က နှစ်ခုလုံးကို မှန်ကန်စွာ လုပ်ဆောင်နိုင်ဖို့ သင်လုပ်ရမယ့်အရာတစ်ခု ရှိပါတယ်။"
+		},
+		{
+			text: "ပုံမှန်အတိုင်း၊ inputs တွေကိုပဲ tokenize လုပ်ရပါမယ်။",
+			explain: "sequence classification problem မှာတော့ မဟုတ်ပါဘူး။ targets တွေကလည်း ကျွန်တော်တို့ numbers တွေအဖြစ် ပြောင်းလဲဖို့ လိုအပ်တဲ့ texts တွေပါပဲ!"
+		},
+        {
+			text: "inputs တွေကို tokenizer ကို ပေးပို့ရမယ်၊ targets တွေကိုလည်း ပေးပို့ရမယ်၊ ဒါပေမယ့် special context manager အောက်မှာ ပေးပို့ရမယ်။",
+			explain: "မှန်ပါတယ်။ tokenizer ကို အဲဒီ context manager က target mode ထဲကို ထည့်ဖို့ လိုအပ်ပါတယ်။",
+			correct: true
+		}
+	]}
+/>
+
+{#if fw === 'pt'}
+
+### ၈။ sequence-to-sequence problems တွေအတွက် <code>Trainer</code> ရဲ့ သီးခြား subclass တစ်ခု ဘာကြောင့် ရှိတာလဲ။
+
+<Question
+	choices={[
+		{
+			text: "sequence-to-sequence problems တွေက <code>-100</code> လို့ သတ်မှတ်ထားတဲ့ labels တွေကို ignore လုပ်ဖို့ custom loss တစ်ခု အသုံးပြုတာကြောင့်။",
+			explain: "ဒါက custom loss မဟုတ်ပါဘူး၊ loss ကို အမြဲတမ်း တွက်ချက်တဲ့ နည်းလမ်းပါပဲ။"
+		},
+		{
+			text: "sequence-to-sequence problems တွေက special evaluation loop တစ်ခု လိုအပ်တာကြောင့်။",
+			explain: "မှန်ပါတယ်။ Sequence-to-sequence models ရဲ့ predictions တွေကို <code>generate()</code> method ကို အသုံးပြုပြီး မကြာခဏ run ပါတယ်။",
+			correct: true
+		},
+		{
+			text: "sequence-to-sequence problems တွေမှာ targets တွေက texts တွေ ဖြစ်နေတာကြောင့်။",
+			explain: "<code>Trainer</code> က ဒါကို သိပ်ဂရုမစိုက်ပါဘူး၊ ဘာလို့လဲဆိုတော့ ၎င်းတို့ကို အရင်က preprocess လုပ်ပြီးသား ဖြစ်လို့ပါ။"
+		},
+        {
+			text: "sequence-to-sequence problems တွေမှာ models နှစ်ခုကို အသုံးပြုတာကြောင့်။",
+			explain: "ကျွန်တော်တို့ encoder နဲ့ decoder ဆိုပြီး models နှစ်ခုကို အသုံးပြုတာ မှန်ပါတယ်၊ ဒါပေမယ့် ၎င်းတို့ကို model တစ်ခုတည်းမှာ အတူတကွ ပေါင်းစည်းထားပါတယ်။"
+		}
+	]}
+/>
+
+{:else}
+
+### ၉။ Transformer model တစ်ခုပေါ်မှာ `compile()` ကို ခေါ်ဆိုတဲ့အခါ loss ကို သတ်မှတ်ဖို့ မလိုအပ်တာ ဘာကြောင့်လဲ။
+
+<Question
+	choices={[
+		{
+			text: "Transformer models တွေကို unsupervised learning နဲ့ train လုပ်ထားတာကြောင့်။",
+			explain: "မမှန်ပါဘူး -- unsupervised learning တောင်မှ loss function တစ်ခု လိုအပ်ပါသေးတယ်!"
+		},
+		{
+			text: "model ရဲ့ internal loss output ကို default အနေနဲ့ အသုံးပြုတာကြောင့်။",
+			explain: "မှန်ပါတယ်။",
+			correct: true
+		},
+		{
+			text: "training လုပ်ပြီးမှ metrics တွေကို တွက်ချက်တာကြောင့်။",
+			explain: "ကျွန်တော်တို့ အဲဒီလို လုပ်တာ မကြာခဏ မှန်ပါတယ်၊ ဒါပေမယ့် training မှာ ကျွန်တော်တို့ optimize လုပ်တဲ့ loss value ကို ဘယ်ကနေ ရသလဲဆိုတာ ရှင်းပြတာ မဟုတ်ပါဘူး။"
+		},
+        {
+			text: "<code>model.fit()</code> မှာ loss ကို သတ်မှတ်တာကြောင့်။",
+			explain: "မမှန်ပါဘူး၊ loss function ကို `model.compile()` run ပြီးတာနဲ့ အမြဲတမ်း fix လုပ်ထားတာဖြစ်ပြီး `model.fit()` မှာ ပြောင်းလဲလို့ မရပါဘူး။"
+		}
+	]}
+/>
+
+{/if}
+
+### ၁၀။ model အသစ်တစ်ခုကို ဘယ်အချိန်မှာ pretrain လုပ်သင့်လဲ။
+
+<Question
+	choices={[
+		{
+			text: "သင့်ရဲ့ သီးခြားဘာသာစကားအတွက် pretrained model မရနိုင်တဲ့အခါ။",
+			explain: "မှန်ပါတယ်။",
+			correct: true
+		},
+		{
+			text: "သင့်မှာ data အများကြီး ရနိုင်ပေမယ့်၊ အဲဒါနဲ့ အလုပ်လုပ်နိုင်မယ့် pretrained model တစ်ခု ရှိနေရင်တောင်။",
+			explain: "ဒီကိစ္စမှာတော့၊ ကြီးမားတဲ့ compute costs တွေကို ရှောင်ရှားဖို့အတွက် pretrained model ကို အသုံးပြုပြီး သင့် data ပေါ်မှာ fine-tune လုပ်သင့်ပါတယ်။"
+		},
+		{
+			text: "သင်အသုံးပြုနေတဲ့ pretrained model ရဲ့ ဘက်လိုက်မှုအပေါ် စိုးရိမ်ပူပန်မှုတွေ ရှိတဲ့အခါ။",
+			explain: "ဒါက မှန်ပါတယ်၊ ဒါပေမယ့် training အတွက် အသုံးပြုမယ့် data ဟာ တကယ်ကောင်းတယ်ဆိုတာ သေချာစေရပါမယ်။",
+			correct: true
+		},
+        {
+			text: "ရနိုင်တဲ့ pretrained models တွေက မလုံလောက်တဲ့အခါ။",
+			explain: "သင်ရဲ့ training ကို ကောင်းကောင်း debug လုပ်ခဲ့ပြီလားဆိုတာ သေချာရဲ့လား။"
+		}
+	]}
+/>
+
+### ၁၁။ language model တစ်ခုကို texts အများကြီးပေါ်မှာ pretrain လုပ်ဖို့ ဘာကြောင့် လွယ်ကူတာလဲ။
+
+<Question
+	choices={[
+		{
+			text: "အင်တာနက်ပေါ်မှာ texts တွေ အများကြီး ရရှိနိုင်တာကြောင့်။",
+			explain: "မှန်ပေမယ့်၊ ဒါက မေးခွန်းကို တကယ်ဖြေတာ မဟုတ်ပါဘူး။ ထပ်ကြိုးစားပါ။"
+		},
+		{
+			text: "pretraining objective က data ကို လူသားတွေက label လုပ်ဖို့ မလိုအပ်တာကြောင့်။",
+			explain: "မှန်ပါတယ်။ language modeling ဟာ self-supervised problem တစ်ခုပါ။",
+			correct: true
+		},
+		{
+			text: "🤗 Transformers library က training ကို စတင်ဖို့ code လိုင်းအနည်းငယ်ပဲ လိုအပ်တာကြောင့်။",
+			explain: "မှန်ပေမယ့်၊ ဒါက မေးထားတဲ့ မေးခွန်းကို တကယ်ဖြေတာ မဟုတ်ပါဘူး။ တခြားအဖြေတစ်ခု စမ်းကြည့်ပါ။"
+		}
+	]}
+/>
+
+### ၁၂။ question answering task အတွက် data ကို preprocess လုပ်တဲ့အခါ အဓိက စိန်ခေါ်မှုတွေက ဘာတွေလဲ။
+
+<Question
+	choices={[
+		{
+			text: "inputs တွေကို tokenize လုပ်ဖို့ လိုပါတယ်။",
+			explain: "မှန်ပါတယ်၊ ဒါပေမယ့် ဒါက တကယ် အဓိက စိန်ခေါ်မှုတစ်ခုလား။"
+		},
+		{
+			text: "အလွန်ရှည်လျားတဲ့ contexts တွေကို ကိုင်တွယ်ဖြေရှင်းဖို့ လိုပါတယ်။ ဒါတွေက training features အများအပြားကို ဖြစ်ပေါ်စေပြီး အဖြေပါဝင်နိုင်ချေ ရှိသလို မရှိဘဲလည်း ဖြစ်နိုင်ပါတယ်။",
+			explain: "ဒါက သေချာပေါက် စိန်ခေါ်မှုတွေထဲက တစ်ခုပါပဲ။",
+			correct: true
+		},
+		{
+			text: "မေးခွန်းရဲ့ အဖြေတွေကိုရော inputs တွေကိုပါ tokenize လုပ်ဖို့ လိုပါတယ်။",
+			explain: "မမှန်ပါဘူး၊ သင်ရဲ့ question answering problem ကို sequence-to-sequence task အဖြစ် ပုံဖော်ထားတာမဟုတ်ရင်ပေါ့။"
+		},
+       {
+			text: "text ထဲက answer span ကနေ၊ tokenized input ထဲက start နဲ့ end token ကို ရှာရပါမယ်။",
+			explain: "ဟုတ်ပါတယ်၊ ဒါက ခက်ခဲတဲ့ အပိုင်းတွေထဲက တစ်ခုပါပဲ။",
+			correct: true
+		}
+	]}
+/>
+
+### ၁၃။ question answering မှာ post-processing ကို ပုံမှန်အားဖြင့် ဘယ်လိုလုပ်ဆောင်သလဲ။
+
+<Question
+	choices={[
+		{
+			text: "model က အဖြေရဲ့ start နဲ့ end positions တွေကို ပေးပါတယ်၊ ပြီးတော့ သင်ဟာ သက်ဆိုင်ရာ tokens span ကို decode လုပ်ဖို့ပဲ လိုပါတယ်။",
+			explain: "ဒါက လုပ်ဆောင်နိုင်တဲ့ နည်းလမ်းတစ်ခု ဖြစ်နိုင်ပေမယ့်၊ နည်းနည်းရိုးရှင်းလွန်းပါတယ်။"
+		},
+		{
+			text: "model က example တစ်ခုကနေ ဖန်တီးထားတဲ့ feature တစ်ခုစီအတွက် အဖြေရဲ့ start နဲ့ end positions တွေကို ပေးပါတယ်၊ ပြီးတော့ သင်ဟာ အကောင်းဆုံး score ရှိတဲ့ အဲဒီ feature အတွက် context ထဲက သက်ဆိုင်ရာ tokens span ကို decode လုပ်ဖို့ပဲ လိုပါတယ်။",
+			explain: "ဒါက ကျွန်တော်တို့ လေ့လာခဲ့တဲ့ post-processing နဲ့ နီးစပ်ပေမယ့်၊ လုံးဝမှန်ကန်တာတော့ မဟုတ်ပါဘူး။"
+		},
+		{
+			text: "model က example တစ်ခုကနေ ဖန်တီးထားတဲ့ feature တစ်ခုစီအတွက် အဖြေရဲ့ start နဲ့ end positions တွေကို ပေးပါတယ်၊ ပြီးတော့ သင်ဟာ အကောင်းဆုံး score ရှိတဲ့ အဲဒီ feature အတွက် context ထဲက span ကို ကိုက်ညီအောင် လုပ်ဖို့ပဲ လိုပါတယ်။",
+			explain: "ဒါက အနှစ်ချုပ်ပါပဲ!",
+			correct: true
+		},
+        {
+			text: "model က အဖြေတစ်ခုကို generate လုပ်ပါတယ်၊ ပြီးတော့ သင်ဟာ အဲဒါကို decode လုပ်ဖို့ပဲ လိုပါတယ်။",
+			explain: "မမှန်ပါဘူး၊ သင်ရဲ့ question answering problem ကို sequence-to-sequence task အဖြစ် ပုံဖော်ထားတာမဟုတ်ရင်ပေါ့။"
+		}
+	]}
+/>
+
+## ဝေါဟာရ ရှင်းလင်းချက် (Glossary)
+
+*   **Token Classification Problem**: စာသား sequence တစ်ခုအတွင်းရှိ token တစ်ခုစီကို အမျိုးအစားခွဲခြားသတ်မှတ်ခြင်း လုပ်ငန်း (ဥပမာ- Named Entity Recognition)။
+*   **Grammatical Components**: စာကြောင်းတစ်ကြောင်းအတွင်းရှိ သဒ္ဒါဆိုင်ရာ အစိတ်အပိုင်းများ (ဥပမာ- noun, verb, adjective)။
+*   **Sequence Classification Problem**: စာသား sequence တစ်ခုလုံးကို သတ်မှတ်ထားသော အမျိုးအစားတစ်ခုသို့ ခွဲခြားသတ်မှတ်ခြင်း လုပ်ငန်း။
+*   **Named Entity Recognition (NER)**: စာသားထဲက လူအမည်၊ နေရာအမည်၊ အဖွဲ့အစည်းအမည် စတဲ့ သီးခြားအမည်တွေကို ရှာဖွေဖော်ထုတ်ခြင်း။
+*   **Preprocessing Pipelines**: AI မော်ဒယ်များအတွက် ဒေတာများကို ပြင်ဆင်ရန် အဆင့်ဆင့်လုပ်ဆောင်ရသော လုပ်ငန်းစဉ်များ။
+*   **Tokenize**: စာသား (သို့မဟုတ် အခြားဒေတာ) ကို AI မော်ဒယ်များ စီမံဆောင်ရွက်နိုင်ရန် tokens တွေအဖြစ် ပိုင်းခြားပေးသည့် လုပ်ငန်းစဉ်။
+*   **Subword Tokenization Model**: စကားလုံးများကို သေးငယ်သော subword units (ဥပမာ- word pieces, byte-pair encodings) များအဖြစ် ပိုင်းခြားသော model။
+*   **Full Tokenization Pipeline**: စာသားကို tokens များအဖြစ် ပြောင်းလဲရန် လိုအပ်သော အဆင့်များအားလုံး (ဥပမာ- splitting, subword tokenization, special token addition)။
+*   **Special Tokens**: Model များအတွက် အထူးအဓိပ္ပာယ်ရှိသော tokens များ (ဥပမာ- `[CLS]`, `[SEP]`, `[PAD]`)။
+*   **`-100` (Label)**: Loss တွက်ချက်မှုတွင် လျစ်လျူရှုရန် သတ်မှတ်ထားသော label တန်ဖိုး။
+*   **Truncate**: input sequence ကို အရှည်သတ်မှတ်ချက်တစ်ခုအထိ ဖြတ်တောက်ခြင်း။
+*   **Pad**: input sequence များကို သတ်မှတ်ထားသော အရှည်အထိ တူညီအောင် အပို tokens များထည့်သွင်းခြင်း။
+*   **Labels**: AI မော်ဒယ်ကို လေ့ကျင့်ရာတွင် အသုံးပြုသော မှန်ကန်သည့် output တန်ဖိုးများ။
+*   **Original Labels**: preprocessing မလုပ်မီက ဒေတာနှင့် တွဲလျက်ပါရှိသော မူရင်း labels များ။
+*   **Align Labels**: original labels များကို tokenization ပြုလုပ်ပြီးနောက် ရရှိလာသော tokens များနှင့် ကိုက်ညီအောင် ချိန်ညှိခြင်း။
+*   **Domain Adaptation**: မော်ဒယ်တစ်ခုကို မူလလေ့ကျင့်ထားသော domain မှ ကွဲပြားခြားနားသော domain အသစ်တစ်ခုတွင် ပိုမိုကောင်းမွန်စွာ လုပ်ဆောင်နိုင်စေရန် ချိန်ညှိခြင်း။
+*   **Inference**: လေ့ကျင့်ပြီးသား Artificial Intelligence (AI) မော်ဒယ်တစ်ခုကို အသုံးပြုပြီး input data ကနေ ခန့်မှန်းချက်တွေ ဒါမှမဟုတ် output တွေကို ထုတ်လုပ်တဲ့ လုပ်ငန်းစဉ်။
+*   **Fine-tune**: ကြိုတင်လေ့ကျင့်ထားပြီးသား (pre-trained) မော်ဒယ်တစ်ခုကို သီးခြားလုပ်ငန်းတစ်ခု (specific task) အတွက် အနည်းငယ်သော ဒေတာနဲ့ ထပ်မံလေ့ကျင့်ပေးခြင်းကို ဆိုလိုပါတယ်။
+*   **Robust**: မတူညီသော input များ သို့မဟုတ် အခြေအနေများအောက်တွင် ကောင်းစွာလုပ်ဆောင်နိုင်ခြင်း။
+*   **Masked Language Modeling (MLM)**: စာကြောင်းတစ်ခုထဲမှ စကားလုံးအချို့ကို ဝှက်ထားပြီး ၎င်းတို့ကို ခန့်မှန်းစေခြင်းဖြင့် model ကို လေ့ကျင့်သော task (BERT ကဲ့သို့)။
+*   **Input Sentence**: model သို့ ပေးပို့သော စာကြောင်း။
+*   **Randomly Masked**: ကျပန်းရွေးချယ်ထားသော စကားလုံးများကို ဖုံးကွယ်ထားခြင်း။
+*   **Original Input Tokens**: mask မလုပ်မီက မူရင်း input sequence ရှိ tokens များ။
+*   **Causal Language Modeling**: စာကြောင်းတစ်ခု၏ နောက်ဆက်တွဲ token (စကားလုံး) ကို ခန့်မှန်းခြင်းဖြင့် model ကို လေ့ကျင့်သော task (GPT-2 ကဲ့သို့)။
+*   **Data Augmentation**: Training data ကို အမျိုးမျိုးသော နည်းလမ်းများဖြင့် တိုးချဲ့ခြင်း။
+*   **Sequence-to-sequence Problem**: input sequence တစ်ခုမှ output sequence တစ်ခုသို့ ပြောင်းလဲခြင်း လုပ်ငန်း (ဥပမာ- translation, summarization)။
+*   **Summarization**: ရှည်လျားသော စာသားတစ်ခု၏ အနှစ်ချုပ်ကို ထုတ်လုပ်ခြင်း။
+*   **Question Answering Problem**: ပေးထားသော စာသားတစ်ခုမှ မေးခွန်းတစ်ခု၏ အဖြေကို ရှာဖွေခြင်း။
+*   **Translation Problem**: ဘာသာစကားတစ်ခုမှ အခြားဘာသာစကားတစ်ခုသို့ စာသားများကို ဘာသာပြန်ခြင်း။
+*   **Inputs**: model သို့ ပေးပို့သော ဒေတာ။
+*   **Targets**: model ၏ လိုချင်သော output များ (labels)။
+*   **Context Manager (Python)**: `with` statement ကို အသုံးပြု၍ အရင်းအမြစ်များကို စီမံခန့်ခွဲရန် ကူညီပေးသော Python အင်္ဂါရပ်။
+*   **`Trainer`**: Hugging Face Transformers library မှ model များကို လေ့ကျင့်ရန်အတွက် မြင့်မားသောအဆင့် (high-level) API။
+*   **Custom Loss**: ပုံမှန် loss function မဟုတ်ဘဲ သီးခြားလိုအပ်ချက်များအတွက် ဖန်တီးထားသော loss function။
+*   **Evaluation Loop**: model ၏ စွမ်းဆောင်ရည်ကို အကဲဖြတ်ရန် လုပ်ဆောင်သော လုပ်ငန်းစဉ်။
+*   **`generate()` Method**: Sequence-to-sequence models များတွင် text ကို generate (ထုတ်လုပ်) ရန် အသုံးပြုသော method။
+*   **Encoder**: Transformer Architecture ၏ အစိတ်အပိုင်းတစ်ခုဖြစ်ပြီး input data (ဥပမာ- စာသား) ကို နားလည်ပြီး ကိုယ်စားပြုတဲ့ အချက်အလက် (representation) အဖြစ် ပြောင်းလဲပေးပါတယ်။
+*   **Decoder**: Transformer Architecture ၏ အစိတ်အပိုင်းတစ်ခုဖြစ်ပြီး encoder ကနေ ရရှိတဲ့ အချက်အလက် (representation) ကို အသုံးပြုပြီး output data (ဥပမာ- ဘာသာပြန်ထားတဲ့ စာသား) ကို ထုတ်ပေးပါတယ်။
+*   **`compile()` Method**: Keras API တွင် model ကို training အတွက် ပြင်ဆင်ရန် အသုံးပြုသော method။ ၎င်းသည် optimizer, loss function နှင့် metrics များကို သတ်မှတ်သည်။
+*   **Unsupervised Learning**: Labels မပါဝင်သော data များကို အသုံးပြု၍ model ကို လေ့ကျင့်ခြင်း။
+*   **Loss Function**: Model ၏ ခန့်မှန်းချက်များနှင့် အမှန်တကယ် labels များကြား ကွာခြားမှုကို တိုင်းတာသော function။
+*   **`model.internal_loss_output`**: model ၏အတွင်းပိုင်းမှ ထုတ်လုပ်သော loss တန်ဖိုး။
+*   **`model.fit()`**: Keras API တွင် model ကို training data ဖြင့် လေ့ကျင့်ရန် အသုံးပြုသော method။
+*   **Pretrain a New Model**: မည်သည့် ကြိုတင်လေ့ကျင့်မှုမျှ မရှိဘဲ လုံးဝအသစ်ကနေ model တစ်ခုကို လေ့ကျင့်ခြင်း။
+*   **Compute Costs**: AI model များ လေ့ကျင့်ရန်အတွက် လိုအပ်သော ကွန်ပျူတာ အရင်းအမြစ်များ (CPU, GPU) ၏ ကုန်ကျစရိတ်။
+*   **Self-supervised Problem**: Input data ကိုယ်တိုင်ကနေ labels တွေကို ဖန်တီးယူပြီး model ကို လေ့ကျင့်တဲ့ ပြဿနာ (ဥပမာ- language modeling)။
+*   **Contexts (QA)**: မေးခွန်းရဲ့ အဖြေပါဝင်နိုင်တဲ့ ရှည်လျားသော စာသား။
+*   **Training Features**: training အတွက် ပြင်ဆင်ထားသော input data ၏ အစိတ်အပိုင်းများ။
+*   **Answer Span**: မေးခွန်းရဲ့ အဖြေပါဝင်တဲ့ text ထဲက အပိုင်း။
+*   **Start/End Token**: answer span ရဲ့ စတင်တဲ့ token နဲ့ ဆုံးဖြတ်တဲ့ token ရဲ့ အနေအထား။
+*   **Post-processing**: Model ၏ output များကို နောက်ဆုံးအသုံးပြုမှုအတွက် ပြင်ဆင်ခြင်း လုပ်ငန်းစဉ်။
+*   **Decode**: token IDs များကို မူရင်းစာသား (သို့မဟုတ် အခြားပုံစံ) အဖြစ် ပြန်လည်ပြောင်းလဲခြင်း။
+*   **Score**: Model က ခန့်မှန်းချက်တစ်ခုအတွက် ပေးသော ယုံကြည်စိတ်ချရမှု တန်ဖိုး။


### PR DESCRIPTION
This PR adds the Myanmar translation for ``Chapter 7: Classical NLP Tasks``.

The translation includes per-chapter glossaries for technical terms, aiming for clarity and accessibility. Specialized English terms are retained in the main text to align with technical standards, with their explanations provided in the glossaries.

@lewtun, @stevhliu, and @sittyatenyo - please review this translation.

Closes #1042