### PR TITLE
docs(zh-TW): fix tokenizer input type in chapter3/2.mdx

### DIFF
--- a/chapters/zh-TW/chapter3/2.mdx
+++ b/chapters/zh-TW/chapter3/2.mdx
@@ -164,8 +164,8 @@ from transformers import AutoTokenizer
 
 checkpoint = "bert-base-uncased"
 tokenizer = AutoTokenizer.from_pretrained(checkpoint)
-tokenized_sentences_1 = tokenizer(raw_datasets["train"]["sentence1"])
-tokenized_sentences_2 = tokenizer(raw_datasets["train"]["sentence2"])
+tokenized_sentences_1 = tokenizer(list(raw_datasets["train"]["sentence1"]))
+tokenized_sentences_2 = tokenizer(list(raw_datasets["train"]["sentence2"]))
 ```
 
 然而，在兩句話傳遞給模型，預測這兩句話是否是同義之前。我們需要這兩句話依次進行適當的預處理。幸運的是，標記器不僅僅可以輸入單個句子還可以輸入一組句子，並按照我們的BERT模型所期望的輸入進行處理：

--- a/chapters/zh-TW/chapter3/2.mdx
+++ b/chapters/zh-TW/chapter3/2.mdx
@@ -164,8 +164,8 @@ from transformers import AutoTokenizer
 
 checkpoint = "bert-base-uncased"
 tokenizer = AutoTokenizer.from_pretrained(checkpoint)
-tokenized_sentences_1 = tokenizer(raw_datasets["train"]["sentence1"])
-tokenized_sentences_2 = tokenizer(raw_datasets["train"]["sentence2"])
+tokenized_sentences_1 = tokenizer(list(raw_datasets["train"]["sentence1"]))
+tokenized_sentences_2 = tokenizer(list(raw_datasets["train"]["sentence2"]))
 ```
 
 然而，在兩句話傳遞給模型，預測這兩句話是否是同義之前。我們需要這兩句話依次進行適當的預處理。幸運的是，標記器不僅僅可以輸入單個句子還可以輸入一組句子，並按照我們的BERT模型所期望的輸入進行處理：
@@ -221,8 +221,8 @@ tokenizer.convert_ids_to_tokens(inputs["input_ids"])
 
 ```py
 tokenized_dataset = tokenizer(
-    raw_datasets["train"]["sentence1"],
-    raw_datasets["train"]["sentence2"],
+    raw_datasets["train"]["sentence1"].to_pylist(),
+    raw_datasets["train"]["sentence2"].to_pylist(),
     padding=True,
     truncation=True,
 )


### PR DESCRIPTION
### Description

Fix tokenizer input in the MRPC preprocessing example.
In recent versions, `raw_datasets["train"]["sentence1"]` and `["sentence2"]` are `datasets.arrow_dataset.Column` objects, which must be converted to Python lists before tokenization.

---

### Change

```python
# Before
tokenized_dataset = tokenizer(
    raw_datasets["train"]["sentence1"],
    raw_datasets["train"]["sentence2"],
    padding=True,
    truncation=True,
)

# After
tokenized_dataset = tokenizer(
    list(raw_datasets["train"]["sentence1"]),
    list(raw_datasets["train"]["sentence2"]),
    padding=True,
    truncation=True,
)
# or
tokenized_dataset = tokenizer(
    raw_datasets["train"].data["sentence1"].to_pylist(),
    raw_datasets["train"].data["sentence2"].to_pylist(),
    padding=True,
    truncation=True,
)


```

---

### Impact

Prevents

```
ValueError: text input must be of type `str`, `list[str]`, or `list[list[str]]`
```

and ensures compatibility with **transformers ≥4.56** and **datasets ≥3.0**.
