### PR TITLE
fix(ro): remove latex from headings in chapter12/3a

### DIFF
--- a/chapters/ro/chapter12/3a.mdx
+++ b/chapters/ro/chapter12/3a.mdx
@@ -110,7 +110,7 @@ $\text{clip}\left( \frac{\pi_{\theta}(o_i|q)}{\pi_{\theta_{old}}(o_i|q)}, 1 - \e
 
 Limitează raportul discutat mai sus să fie în intervalul $[1 - \epsilon, 1 + \epsilon]$ pentru a evita/controla schimbări drastice sau actualizări nebunești și să nu pășească prea departe de politica veche. Cu alte cuvinte, limitează cât de mult poate crește raportul de probabilitate pentru a ajuta la menținerea stabilității prin evitarea actualizărilor care împing modelul nou prea departe de cel vechi.
 
-#### Exemplu $\space \text{să presupunem}(\epsilon = 0.2)$
+#### Exemplu (să presupunem ε = 0.2)
 Să ne uităm la două scenarii diferite pentru a înțelege mai bine această funcție de tăiere:
 
 - **Cazul 1**: dacă noua politică are o probabilitate de 0.9 pentru un răspuns specific și vechea politică are o probabilitate de 0.5, înseamnă că acest răspuns este întărit de noua politică să aibă o probabilitate mai mare, dar într-o limită controlată care este tăierea pentru a-și strânge mâinile să nu devină drastică 
@@ -144,7 +144,7 @@ Să ne amintim că distanța KL este definită după cum urmează:
 $$D_{KL}(P || Q) = \sum_{x \in X} P(x) \log \frac{P(x)}{Q(x)}$$
 În RLHF, cele două distribuții de interes sunt adesea distribuția versiunii noului model, P(x), și o distribuție a politicii de referință, Q(x).
 
-#### Rolul Parametrului $\beta$
+#### Rolul Parametrului β
 
 Coeficientul $\beta$ controlează cât de puternic impunem constrângerea divergenței KL:
 


### PR DESCRIPTION
## What does this PR do?

Fixes the build failure in Romanian translation caused by LaTeX expressions in Markdown headings.

Closes #1121 

## Why these changes?

The MDX processor converts LaTeX in headings to HTML with `{@html}` tags, which Svelte doesn't allow in component attribute values. This was causing build failures for all PRs, not just Romanian translation PRs.

## Testing

- [x] Local build passes
- [x] Documentation renders correctly
- [x] Unicode characters (ε, β) display properly in headings
- [x] LaTeX in body text still renders correctly

## Additional Context

This issue was discovered while working on Korean translation PR #1095. The build was failing due to this pre-existing issue in the Romanian files, affecting all PRs that trigger documentation builds.

@stevhliu May you please review this PR? 🤗