### PR TITLE
docs(my): Query status of Myanmar translation official release

### DIFF
--- a/chapters/my/chapter0/1.mdx
+++ b/chapters/my/chapter0/1.mdx
@@ -101,7 +101,7 @@ which python
 
 ### Dependencies တွေကို Install လုပ်ခြင်း[[installing-dependencies]]
 
-Google Colab instances တွေကို အသုံးပြုခြင်းနဲ့ ပတ်သက်တဲ့ ယခင်အပိုင်းမှာလိုပဲ၊ ဆက်လက်လုပ်ဆောင်ဖို့ လိုအပ်တဲ့ packages တွေကို အခု သင် install လုပ်ဖို့ လိုအပ်ပါလိမ့်မယ်။ ထပ်မံပြီးတော့ `pip` package manager ကို အသုံးပြုပြီး 🤗 Transformers ရဲ့ development version ကို install လုပ်နိုင်ပါတယ်-
+Google Colab instances တွေကို အသုံးပြုခြင်းနဲ့ ပတ်သက်တဲ့ ယခင်အပိုင်းမှာလိုပဲ၊ ဆက်လက်လုပ်ဆောင်ဖို့ လိုအပ်တဲ့ packages တွေကို အခု သင် install လုပ်ဖို့ လိုအပ်ပါလိမ့်မယ်။ ထပ်မံပြီးတော့ `pip` package manager ကို အသုံးပြုပြီး 🤗 Transformers ရဲ့ development version ကို install လုပ်နိုင်ပါတယ်။
 
 ```
 pip install "transformers[sentencepiece]"


### PR DESCRIPTION
**Hello** @stevhliu and @lewtun,

Following up on the completed Myanmar translation for `all chapters (0-12) and Course Events`, we've noticed that the Burmese language option is not yet available on the official Hugging Face Course website or in the language list.

Could you please clarify if there are any remaining steps or actions required from our side to facilitate its official release? We want to ensure everything is complete for the Myanmar translation to be fully integrated.

Thank you for your guidance!

Best regards,
@kalixlouiis (and the Myanmar translation team)