### PR TITLE
Fix tokenizer argument that align with the actual output

### DIFF
--- a/chapters/en/chapter2/3.mdx
+++ b/chapters/en/chapter2/3.mdx
@@ -135,7 +135,7 @@ You'll notice that the tokenizer has added special tokens — `[CLS]` and `[SEP]
 You can encode multiple sentences at once, either by batching them together (we'll discuss this soon) or by passing a list:
 
 ```py
-encoded_input = tokenizer("How are you?", "I'm fine, thank you!")
+encoded_input = tokenizer(["How are you?", "I'm fine, thank you!"])
 print(encoded_input)
 ```
 


### PR DESCRIPTION
To put two sentences into tokenizer, it should be a list.
The sample code below of returning tensor is also not correct but I have no idea how to address without padding to get the exact output as the doc.