### PR TITLE
Fix Chinese translation and list formatting issues in chapter2/2.mdx

### DIFF
--- a/chapters/zh-CN/chapter2/2.mdx
+++ b/chapters/zh-CN/chapter2/2.mdx
@@ -61,16 +61,16 @@ classifier(
 
 让我们先简单了解一下这三个步骤。
 
-## 使用 tokenizer（ tokenizer ）进行预处理 [[使用 tokenizer（ tokenizer ）进行预处理]]
+## 使用 tokenizer（ 分词器 ）进行预处理 [[使用 tokenizer（ 分词器 ）进行预处理]]
 
-与其他神经网络一样，Transformer 模型无法直接处理原始文本，因此我们管道的第一步是将文本输入转换为模型能够理解的数字。为此，我们使用 tokenizer（ tokenizer ），它将负责：
+与其他神经网络一样，Transformer 模型无法直接处理原始文本，因此我们管道的第一步是将文本输入转换为模型能够理解的数字。为此，我们使用 tokenizer（ 分词器 ），它将负责：
 
 - 将输入拆分为单词、子单词或符号（如标点符号），称为 **token**（标记）
-- 将每个标记（token）映射到一个数字，称为 **input ID**（inputs ID）
+- 将每个token（标记）映射到一个数字，称为 **input ID**（输入 ID）
 - 添加模型需要的其他输入，例如特殊标记（如 `[CLS]` 和 `[SEP]` ）
-- - 位置编码：指示每个标记在句子中的位置。
-- - 段落标记：区分不同段落的文本。
-- - 特殊标记：例如 [CLS] 和 [SEP] 标记，用于标识句子的开头和结尾。
+  - 位置编码：指示每个标记在句子中的位置。
+  - 段落标记：区分不同段落的文本。
+  - 特殊标记：例如 `[CLS]` 和 `[SEP]` 标记，用于标识句子的开头和结尾。
 
 在使用模型时所有这些预处理都需要与模型预训练时的方式完全相同，因此我们首先需要从 [Model Hub](https://huggingface.co/models) 中下载这些信息。为此，我们使用 `AutoTokenizer` 类和它的 `from_pretrained()` 方法，并输入我们模型 checkpoint 的名称，它将自动获取与模型的 tokenizer 相关联的数据，并对其进行缓存（因此只有在你第一次运行下面的代码时才会下载）。
 
@@ -83,7 +83,7 @@ checkpoint = "distilbert-base-uncased-finetuned-sst-2-english"
 tokenizer = AutoTokenizer.from_pretrained(checkpoint)
 ```
 
-当我们有了 tokenizer，我们就可以直接将我们的句子传递给它，我们就会得到一个 `input ID（inputs ID）` 的列表！剩下要做的唯一一件事就是将 input ID 列表转换为 tensor（张量）。
+当我们有了 tokenizer，我们就可以直接将我们的句子传递给它，我们就会得到一个 `input ID（输入 ID）` 的列表！剩下要做的唯一一件事就是将 input ID 列表转换为 tensor（张量）。
 
 你在使用🤗 Transformers 时，您无需担心它背后的机器学习框架；它可能是 PyTorch 或 TensorFlow，或 Flax。但是，Transformers 模型只接受 `tensor（张量）` 作为输入。如果这是你第一次听说 tensor，你可以把它们想象成 NumPy 数组。NumPy 数组可以是标量（0D）、向量（1D）、矩阵（2D）或具有更多维度。这些都可以称为 tensor；其他 ML 框架的 tensor 使用方法也类似，通常与 NumPy 数组一样容易创建。
 


### PR DESCRIPTION
This PR fixes several issues in the Chinese translation of `chapter2/2.mdx`.

Changes include:
- Corrected incorrect title phrasing (e.g., duplicated “tokenizer（tokenizer）”)
- Fixed Markdown list formatting (replaced invalid "- -" with proper indented sub-lists)
- Ensured proper formatting of special tokens `[CLS]` and `[SEP]`

These changes improve readability, accuracy, and MDX rendering consistency.
