### PR TITLE
fix(ch6. unigram): probability calculations in Unigram tokenization chapter

### DIFF
--- a/chapters/en/chapter6/7.mdx
+++ b/chapters/en/chapter6/7.mdx
@@ -60,20 +60,20 @@ So, the sum of all frequencies is 210, and the probability of the subword `"ug"`
 
 Now, to tokenize a given word, we look at all the possible segmentations into tokens and compute the probability of each according to the Unigram model. Since all tokens are considered independent, this probability is just the product of the probability of each token. For instance, the tokenization `["p", "u", "g"]` of `"pug"` has the probability:
 
-$$P([``p", ``u", ``g"]) = P(``p") \times P(``u") \times P(``g") = \frac{5}{210} \times \frac{36}{210} \times \frac{20}{210} = 0.000389$$
+$$P([``p", ``u", ``g"]) = P(``p") \times P(``u") \times P(``g") = \frac{17}{210} \times \frac{36}{210} \times \frac{20}{210} = 0.001322$$
 
 Comparatively, the tokenization `["pu", "g"]` has the probability:
 
-$$P([``pu", ``g"]) = P(``pu") \times P(``g") = \frac{5}{210} \times \frac{20}{210} = 0.0022676$$
+$$P([``pu", ``g"]) = P(``pu") \times P(``g") = \frac{17}{210} \times \frac{20}{210} = 0.007710$$
 
 so that one is way more likely. In general, tokenizations with the least tokens possible will have the highest probability (because of that division by 210 repeated for each token), which corresponds to what we want intuitively: to split a word into the least number of tokens possible.
 
 The tokenization of a word with the Unigram model is then the tokenization with the highest probability. In the example of `"pug"`, here are the probabilities we would get for each possible segmentation:
 
 ```
-["p", "u", "g"] : 0.000389
-["p", "ug"] : 0.0022676
-["pu", "g"] : 0.0022676
+["p", "u", "g"] : 0.001322
+["p", "ug"] : 0.007710
+["pu", "g"] : 0.007710
 ```
 
 So, `"pug"` would be tokenized as `["p", "ug"]` or `["pu", "g"]`, depending on which of those segmentations is encountered first (note that in a larger corpus, equality cases like this will be rare).


### PR DESCRIPTION
Corrected three related errors in the probability calculations for the word "pug":
1. Fixed P(["p","u","g"]) to use correct frequency 17/210 instead of 5/210
2. Fixed P(["pu","g"]) to use correct frequency 17/210 instead of 5/210
3. Updated tokenization probabilities table with correct values

The errors stemmed from using frequency 5 (for tokens like "s", "gs", "ugs") instead of the correct frequency 17 for "p" and "pu" as shown in the frequency table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)