### PR TITLE
Fix incorrect learning rate in erratic curves example

### DIFF
--- a/chapters/en/chapter3/5.mdx
+++ b/chapters/en/chapter3/5.mdx
@@ -260,8 +260,8 @@ from transformers import TrainingArguments
 
 training_args = TrainingArguments(
     output_dir="./results",
-    -learning_rate=1e-5,
-    +learning_rate=1e-4,
+    -learning_rate=1e-4,
+    +learning_rate=1e-5,
     -per_device_train_batch_size=16,
     +per_device_train_batch_size=32,
 )


### PR DESCRIPTION
## Fix incorrect learning rate in erratic curves example

### Bug
Section 3.7 **Erratic** Learning Curves** states the example "**lowers the learning rate**" but the code actually **increases** it from 1e-5 to 1e-4 (10x higher).

### Fix
Swapped the values to correctly decrease learning rate from 1e-4 to 1e-5.

### Changes
- `chapters/en/chapter3/section7.mdx`: Fixed learning rate diff to show actual decrease