### PR TITLE
Add missing anchor links and unify terminology

### DIFF
--- a/chapters/ko/chapter0/1.mdx
+++ b/chapters/ko/chapter0/1.mdx
@@ -1,4 +1,4 @@
-# 강의 소개
+# 강의 소개[[강의-소개]]
 
 Hugging Face 강의에 오신 여러분들 환영합니다! 이번 강의 소개에서는 작업 환경 설정에 대해 안내드리겠습니다. 방금 막 이번 과정을 시작하셨다면 먼저 [Chapter 1](/course/chapter1) 내용을 살펴보고 돌아오신 뒤, 환경을 설정하여 코드를 직접 실행해보시길 추천드립니다.
 
@@ -10,7 +10,7 @@ Hugging Face 강의에 오신 여러분들 환영합니다! 이번 강의 소개
 
 대부분의 강의는 여러분이 Hugging Face 계정이 있다는 것을 전제로 하기 때문에 지금 바로 계정을 생성하시길 추천드립니다: [계정 생성하기](https://huggingface.co/join)
 
-## Google Colab 노트북 사용하기
+## Google Colab 노트북 사용하기[[google-colab-노트북-사용하기]]
 
 Colab 노트북은 가장 쉬운 설정 방식입니다. 브라우저에 Colab 노트북을 켜고 바로 코딩을 시작하시면 됩니다!
 
@@ -38,7 +38,7 @@ import transformers
 <img src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter0/install.gif" alt="A gif showing the result of the two commands above: installation and import" width="80%"/>
 </div>
 
-위의 방식으로는 아주 가벼운 버전의 🤗 Transformers가 설치되고, 이는 PyTorch나 TensorFlow와 같은 특정 기계학습 프레임워크를 포함하지 않습니다. 하지만 본 강의에서는 이 라이브러리의 아주 다양한 기능들을 사용할 예정이므로, 아래의 명령어를 통해 대부분의 예제에 필요한 종속성(dependency)을 제공하는 개발 버전을 설치하시길 바랍니다:
+위의 방식으로는 아주 가벼운 버전의 🤗 Transformers가 설치되고, 이는 PyTorch나 TensorFlow와 같은 특정 기계학습 프레임워크를 포함하지 않습니다. 하지만 본 강의에서는 이 라이브러리의 아주 다양한 기능들을 사용할 예정이므로, 아래의 명령어를 통해 대부분의 예제에 필요한 의존성을 제공하는 개발 버전을 설치하시길 바랍니다:
 
 ```
 !pip install transformers[sentencepiece]
@@ -46,7 +46,7 @@ import transformers
 
 설치에 시간이 조금 걸리지만 곧 강의를 위한 준비가 모두 끝납니다!
 
-## 파이썬 가상 환경 사용하기
+## 파이썬 가상 환경 사용하기[[파이썬-가상-환경-사용하기]]
 
 파이썬 가상 환경 사용을 원하신다면 먼저 파이썬을 설치해야 합니다. 이 [가이드](https://realpython.com/installing-python/)를 따라 설치를 진행하실 수 있습니다.
 
@@ -99,7 +99,7 @@ which python
 /home/<user>/transformers-course/.env/bin/python
 ```
 
-### 의존성(dependencies) 설치하기
+### 의존성 설치하기[[의존성-설치하기]]
 
 Google Colab 사용법에서와 마찬가지로 다음 단계로 넘어가기 위해 패키지를 설치해야 합니다. 여기서도, `pip` 패키지 관리자를 통해  🤗 Transformers 개발 버전을 설치할 수 있습니다:
 


### PR DESCRIPTION
# To 0-1
- Added missing internal links (anchors) to headers.
- Unified the translation of 'dependency' to '의존성' for consistency.