### PR TITLE
max_seq_length is no longer a valid param in SFTTrainer

### DIFF
--- a/chapters/en/chapter11/4.mdx
+++ b/chapters/en/chapter11/4.mdx
@@ -106,7 +106,6 @@ trainer = SFTTrainer(
     args=args,
     train_dataset=dataset["train"],
     peft_config=peft_config,  # LoRA configuration
-    max_seq_length=max_seq_length,  # Maximum sequence length
     processing_class=tokenizer,
 )
 ```


### PR DESCRIPTION
- max_seq_length is no longer a valid param in SFTTrainer, instead we use max_length in SFTConfig
- since this param is not important in this chapter, I delete the outdated line to avoid confusion
- Link: https://huggingface.co/docs/trl/main/en/sft_trainer