### PR TITLE
Change aggregation strategy in NER pipeline example

### DIFF
--- a/chapters/en/chapter1/3.mdx
+++ b/chapters/en/chapter1/3.mdx
@@ -223,7 +223,7 @@ Named entity recognition (NER) is a task where the model has to find which parts
 ```python
 from transformers import pipeline
 
-ner = pipeline("ner", grouped_entities=True)
+ner = pipeline("ner", aggregation_strategy="simple")
 ner("My name is Sylvain and I work at Hugging Face in Brooklyn.")
 ```
 


### PR DESCRIPTION
Issue: TypeError: TokenClassificationPipeline._sanitize_parameters() got an unexpected keyword argument 'grouped_entities'

This error occurred because grouped_entities=True was incorrectly passed either to the ner() call or during pipeline initialization. For the transformers library's NER pipeline, entity grouping is configured at initialization using the aggregation_strategy parameter.

Solution: The fix involves initializing the NER pipeline with aggregation_strategy="simple".
