### PR TITLE
Clarify tensor conversion example by padding sequences to equal length

### DIFF
--- a/chapters/en/chapter2/3.mdx
+++ b/chapters/en/chapter2/3.mdx
@@ -273,11 +273,11 @@ encoded_sequences = [
         1012,
         102,
     ],
-    [101, 1045, 5223, 2023, 2061, 2172, 999, 102],
+    [101, 1045, 5223, 2023, 2061, 2172, 999, 102, 0, 0, 0, 0, 0, 0, 0, 0],
 ]
 ```
 
-This is a list of encoded sequences: a list of lists. Tensors only accept rectangular shapes (think matrices). This "array" is already of rectangular shape, so converting it to a tensor is easy:
+This is a list of encoded sequences: a list of lists. Tensors only accept rectangular shapes (think matrices). After padding, the sequences have equal length (rectangular shape), so converting them to a tensor is straightforward:
 
 ```py
 import torch


### PR DESCRIPTION
The original example showed sequences of different lengths, which cannot be directly converted to a tensor. This update adds padding to ensure the sequences are rectangular before tensor conversion.