### PR TITLE
Fix local preview guidance for course chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,17 +90,31 @@ Once you have translated the `_toctree.yml` file, you can start translating the 
 
 Once you're happy with your changes, you can preview how they'll look by first installing the [`doc-builder`](https://github.com/huggingface/doc-builder) tool that we use for building all documentation at Hugging Face:
 
-```
-pip install hf-doc-builder
+```bash
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install --upgrade pip
+python -m pip install "git+https://github.com/huggingface/doc-builder.git"
 ```
 
-```
-doc-builder preview course ../course/chapters/LANG-ID --not_python_module
+```bash
+doc-builder preview course ./chapters/LANG-ID --not_python_module
 ```
 
-**`preview` command does not work with Windows.
+If `LANG-ID` content is partial, make sure `_toctree.yml` only references files that exist in `chapters/LANG-ID`.
 
-This will build and render the course on [http://localhost:3000/](http://localhost:3000/). Although the content looks much nicer on the Hugging Face website, this step will still allow you to check that everything is formatted correctly.
+If preview starts but all routes return `404`, this might be a local `doc-builder` version mismatch between the Python package and the SvelteKit template:
+
+```bash
+python -m pip uninstall -y hf-doc-builder
+python -m pip install "git+https://github.com/huggingface/doc-builder.git"
+```
+
+Then restart `doc-builder preview`.
+
+> `preview` command does not work with Windows.
+
+This will build and render the course on [http://localhost:5173/](http://localhost:5173/). Although the content looks much nicer on the Hugging Face website, this step will still allow you to check that everything is formatted correctly.
 
 **🚀 Submit a pull request**
 


### PR DESCRIPTION
## Background

When contributors preview translated course content locally, `doc-builder preview` may start successfully but still return runtime `404` for valid routes.

## Root Cause

The issue came from a dependency/version skew in the local tooling:

- Python package: `hf-doc-builder` installed from PyPI (v0.5.0) which generates `.mdx` file for preview.
- Frontend template: cached `doc-builder` kit from a newer revision which requires `+page.svelte` file per path.

Because of this mismatch, route generation behavior was inconsistent and local preview could boot while serving unresolved routes as `404`.

## What Changed

1. Updated contributor instructions in `README.md` to:
   - use a clean virtual environment;
   - install `hf-doc-builder` from the current GitHub source;
   - run preview with explicit `--language LANG-ID`.
2. Added a troubleshooting section for preview-time `404` that clearly points to re-installing `hf-doc-builder` and restarting preview.

## Why This Helps

Contributors now get deterministic setup steps that keep the Python CLI and SvelteKit template in sync, which prevents route-generation mismatch and avoids false-negative `404` previews.
<img width="1624" height="978" alt="image" src="https://github.com/user-attachments/assets/00688bba-a05e-4be5-864b-706455fee2d4" />

## Verification Notes

- Confirmed translated routes render after aligning `doc-builder` dependency source.
- Confirmed chapter routes behavior is stable when preview is started with explicit language flag.

## Things To Note

- Currently, the root path isn't configured properly due to the absence of root path document file. 

## References

- [huggingface/course#1098](https://github.com/huggingface/course/issues/1098)
- [huggingface/doc-builder#448](https://github.com/huggingface/doc-builder/issues/448)
