### PR TITLE
Change build process from Make to CMake

### DIFF
--- a/chapters/en/chapter2/8.mdx
+++ b/chapters/en/chapter2/8.mdx
@@ -162,8 +162,9 @@ First, install and build llama.cpp:
 git clone https://github.com/ggerganov/llama.cpp
 cd llama.cpp
 
-# Build the project
-make
+# Build the project 
+cmake -B build
+cmake --build build --config Release
 
 # Download the SmolLM2-1.7B-Instruct-GGUF model
 curl -L -O https://huggingface.co/HuggingFaceTB/SmolLM2-1.7B-Instruct-GGUF/resolve/main/smollm2-1.7b-instruct.Q4_K_M.gguf


### PR DESCRIPTION
Updated build instructions to use CMake instead of Make. Since LLama cpp now uses CMAKE instead