### PR TITLE
Replace iframe with external link to Hugging Face model page

### DIFF
--- a/chapters/en/chapter1/6.mdx
+++ b/chapters/en/chapter1/6.mdx
@@ -78,12 +78,10 @@ Modern decoder-based LLMs have demonstrated impressive capabilities:
 
 You can experiment with decoder-based LLMs directly in your browser via model repo pages on the Hub. Here's an example with the classic [GPT-2](https://huggingface.co/openai-community/gpt2) (OpenAI's finest open source model!):
 
-<iframe
-	src="https://huggingface.co/openai-community/gpt2"
-	frameborder="0"
-	width="100%"
-	height="450"
-></iframe>
+<a 
+  href="https://huggingface.co/openai-community/gpt2" target="_blank">
+  View GPT-2 model on Hugging Face
+</a>
 
 ## Sequence-to-sequence models[[sequence-to-sequence-models]]
 


### PR DESCRIPTION
Embedding the GPT-2 model page from Hugging Face using an <iframe> was not working because the site sends security headers (X-Frame-Options: DENY / SAMEORIGIN) that prevent the page from being displayed inside external frames.

As a result, the iframe rendered as a blank frame and produced a browser console error:

Refused to display 'https://huggingface.co/' in a frame because it set 'X-Frame-Options' to 'deny'.

This change removes the iframe and replaces it with a direct external link to the model page:

https://huggingface.co/openai-community/gpt2

This ensures users can still access the model page without encountering embedding errors.