### PR TITLE
docs: fix ragged list example in model intro to ensure rectangular shape

### DIFF
--- a/chapters/en/chapter2/3.mdx
+++ b/chapters/en/chapter2/3.mdx
@@ -251,7 +251,7 @@ sequences = [
 ]
 ```
 
-Once tokenized, we have:
+Once tokenized with ```padding=True```, we have:
 
 ```python
 encoded_sequences = [
@@ -273,7 +273,7 @@ encoded_sequences = [
         1012,
         102,
     ],
-    [101, 1045, 5223, 2023, 2061, 2172, 999, 102],
+    [101, 1045, 5223, 2023, 2061, 2172, 999, 102, 0, 0, 0, 0, 0, 0, 0, 0],
 ]
 ```
 


### PR DESCRIPTION
In the "Models" section of the documentation, the example regarding tensor conversion  contained a logical error. It presented a list of two sequences with unequal  lengths (16 and 8 tokens) while stating the structure was "already of rectangular  shape." 

This would cause a ValueError when passed to torch.tensor().

This PR:
- Updates the encoded_sequences example to include padding zeros for the second sequence.
- Clarifies that the tokenization step assumes `padding=True` to achieve this shape.
- Ensures the code snippets are functionally accurate for users copying them into  a PyTorch environment.