### PR TITLE
[fix] Update Google Colab borken link in  "Fine-tune a model with GRPO" chapter of LLM Course

### DIFF
--- a/chapters/en/chapter12/5.mdx
+++ b/chapters/en/chapter12/5.mdx
@@ -1,7 +1,7 @@
 <CourseFloatingBanner chapter={2}
   classNames="absolute z-10 right-0 top-0"
   notebooks={[
-    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/course/en/chapter12/grpo_finetune.ipynb"},
+    {label: "Google Colab", value: "https://colab.research.google.com/github/huggingface/notebooks/blob/main/course/en/chapter13/grpo_finetune.ipynb"},
 ]} />
 
 # Practical Exercise: Fine-tune a model with GRPO


### PR DESCRIPTION
## Current State

The link to the google colab is broken and is pointing to wrong github location. 

The current link throws 404 :

```
{
  "message": "Not Found",
  "documentation_url": "https://docs.github.com/rest/repos/contents#get-repository-content",
  "status": "404"
}
```
## Fix 

Updating the link to `https://colab.research.google.com/github/huggingface/notebooks/blob/main/course/en/chapter13/grpo_finetune.ipynb`, fixes the issue.