### PR TITLE
Convert Arrow Column objects to Python lists to prevent ValueError in…

### DIFF
--- a/chapters/en/chapter3/2.mdx
+++ b/chapters/en/chapter3/2.mdx
@@ -120,8 +120,8 @@ from transformers import AutoTokenizer
 
 checkpoint = "bert-base-uncased"
 tokenizer = AutoTokenizer.from_pretrained(checkpoint)
-tokenized_sentences_1 = tokenizer(raw_datasets["train"]["sentence1"])
-tokenized_sentences_2 = tokenizer(raw_datasets["train"]["sentence2"])
+tokenized_sentences_1 = tokenizer(list(raw_datasets["train"]["sentence1"]))
+tokenized_sentences_2 = tokenizer(list(raw_datasets["train"]["sentence2"]))
 ```
 
 > [!TIP]
@@ -180,8 +180,8 @@ Now that we have seen how our tokenizer can deal with one pair of sentences, we 
 
 ```py
 tokenized_dataset = tokenizer(
-    raw_datasets["train"]["sentence1"],
-    raw_datasets["train"]["sentence2"],
+    list(raw_datasets["train"]["sentence1"]),
+    list(raw_datasets["train"]["sentence2"]),
     padding=True,
     truncation=True,
 )


### PR DESCRIPTION
…  tokenizer. Matches the fix implemented in the zh-TW version.

This PR fixes a ValueError that occurs when passing dataset columns  directly to the tokenizer.

In current versions of the `datasets` library, indexing a column returns  an Arrow `Column` object instead of a standard Python list. The  tokenizer requires a list to function correctly.

History/Context:
- This issue was previously identified and addressed in the zh-TW  translation of the course.
- This PR applies the same logic to the English version to maintain  consistency and fix the broken example.

Changes:
- Wrapped `raw_datasets["train"]["sentence1"]` and `["sentence2"]`  with `list()` to ensure compatibility.