### PR TITLE
# 将 grouped_entities=True 替换为 aggregation_strategy="simple"

### DIFF
--- a/chapters/zh-CN/chapter1/3.mdx
+++ b/chapters/zh-CN/chapter1/3.mdx
@@ -193,7 +193,7 @@ unmasker("This course will teach you all about <mask> models.", top_k=2)
 ```python
 from transformers import pipeline
 
-ner = pipeline("ner", grouped_entities=True)
+ner = pipeline("ner", aggregation_strategy="simple")
 ner("My name is Sylvain and I work at Hugging Face in Brooklyn.")
 ```
 ```python out
@@ -205,7 +205,7 @@ ner("My name is Sylvain and I work at Hugging Face in Brooklyn.")
 
 在这里，模型正确地识别出 Sylvain 是一个人 （PER），Hugging Face 是一个组织 （ORG），而布鲁克林是一个位置 （LOC）。
 
-我们在创建 pipeline 的函数中传递的 `grouped_entities=True` 参数告诉 pipeline 将与同一实体对应的句子部分重新分组：这里模型正确地将“Hugging”和“Face”分组为一个组织，即使名称由多个词组成。事实上，正如我们即将在下一章看到的，预处理甚至会将一些单词分成更小的部分。例如， `Sylvain` 分割为了四部分： `S、##yl、##va` 和 `##in` 。在后处理步骤中，pipeline 成功地重新组合了这些部分。
+我们在创建 pipeline 的函数中传递的 `aggregation_strategy="simple"` 参数告诉 pipeline 将与同一实体对应的句子部分重新分组：这里模型正确地将“Hugging”和“Face”分组为一个组织，即使名称由多个词组成。事实上，正如我们即将在下一章看到的，预处理甚至会将一些单词分成更小的部分。例如， `Sylvain` 分割为了四部分： `S、##yl、##va` 和 `##in` 。在后处理步骤中，pipeline 成功地重新组合了这些部分。
 
 > [!TIP]
 > ✏️**快来试试吧！**在模型中心（hub）搜索能够用英语进行词性标注（通常缩写为 POS）的模型。对于上面示例中的句子，这个词性标注的模型预测了什么？


### PR DESCRIPTION
在较新的版本中，pipeline 的参数名称发生了变化。具体来说，grouped_entities 这个参数已经被废弃，并被重命名为 aggregation_strategy。