### PR TITLE
docs: fix LaTeX spacing rendering in documentation

### DIFF
--- a/chapters/en/chapter1/6.mdx
+++ b/chapters/en/chapter1/6.mdx
@@ -163,11 +163,7 @@ use a sparse version of the attention matrix to speed up training.
 
 ### LSH attention
 
-[Reformer](https://huggingface.co/docs/transformers/model_doc/reformer) uses LSH attention. In the softmax(QK^t), only the biggest elements (in the softmax dimension) of the matrix QK^t are going to give useful contributions. So for each query q in Q, we can consider only
-the keys k in K that are close to q. A hash function is used to determine if q and k are close. The attention mask is
-modified to mask the current token (except at the first position), because it will give a query and a key equal (so
-very similar to each other). Since the hash can be a bit random, several hash functions are used in practice
-(determined by a n_rounds parameter) and then are averaged together.
+[Reformer](https://huggingface.co/docs/transformers/model_doc/reformer) uses LSH attention. In the&nbsp;\\(\text{softmax}(QK^t)\\), only the biggest elements (in the softmax dimension) of the matrix&nbsp;\\(QK^t\\)&nbsp;are going to give useful contributions. So for each query&nbsp;\\(q\\)&nbsp;in&nbsp;\\(Q\\), we can consider only the keys&nbsp;\\(k\\)&nbsp;in&nbsp;\\(K\\)&nbsp;that are close to&nbsp;\\(q\\). A hash function is used to determine if&nbsp;\\(q\\)&nbsp;and&nbsp;\\(k\\)&nbsp;are close. The attention mask is modified to mask the current token (except at the first position), because it will give a query and a key equal (so very similar to each other). Since the hash can be a bit random, several hash functions are used in practice (determined by a `n_rounds` parameter) and then are averaged together.
 
 ### Local attention
 
@@ -188,14 +184,7 @@ length.
 
 ### Axial positional encodings
 
-[Reformer](https://huggingface.co/docs/transformers/model_doc/reformer) uses axial positional encodings: in traditional transformer models, the positional encoding
-E is a matrix of size \\(l\\) by \\(d\\), \\(l\\) being the sequence length and \\(d\\) the dimension of the
-hidden state. If you have very long texts, this matrix can be huge and take way too much space on the GPU. To alleviate
-that, axial positional encodings consist of factorizing that big matrix E in two smaller matrices E1 and E2, with
-dimensions \\(l_{1} \times d_{1}\\) and \\(l_{2} \times d_{2}\\), such that \\(l_{1} \times l_{2} = l\\) and
-\\(d_{1} + d_{2} = d\\) (with the product for the lengths, this ends up being way smaller). The embedding for time
-step \\(j\\) in E is obtained by concatenating the embeddings for timestep \\(j \% l1\\) in E1 and \\(j // l1\\)
-in E2.
+[Reformer](https://huggingface.co/docs/transformers/model_doc/reformer) uses axial positional encodings: in traditional transformer models, the positional encoding E is a matrix of size&nbsp;\\(l\\)&nbsp;by&nbsp;\\(d\\),&nbsp;\\(l\\)&nbsp;being the sequence length and&nbsp;\\(d\\)&nbsp;the dimension of the hidden state. If you have very long texts, this matrix can be huge and take way too much space on the GPU. To alleviate that, axial positional encodings consist of factorizing that big matrix E in two smaller matrices E1 and E2, with dimensions&nbsp;\\(l_{1} \times d_{1}\\)&nbsp;and&nbsp;\\(l_{2} \times d_{2}\\), such that&nbsp;\\(l_{1} \times l_{2} = l\\)&nbsp;and&nbsp;\\(d_{1} + d_{2} = d\\)&nbsp;(with the product for the lengths, this ends up being way smaller). The embedding for time step&nbsp;\\(j\\)&nbsp;in E is obtained by concatenating the embeddings for timestep&nbsp;\\(j \% l_{1}\\)&nbsp;in E1 and&nbsp;\\(j // l_{1}\\)&nbsp;in E2.
 
 ## Conclusion[[conclusion]]
 


### PR DESCRIPTION
- Wrapped plain-text variables in standard Hugging Face MathJax delimiters `\\( ... \\)`.
- Added `&nbsp;` where necessary to force the markdown parser to respect whitespace between text and Katex spans.
- Fixed specific rendering issues such as `sizel`, `byd`, and unformatted `softmax(QK^t)`.