### PR TITLE
Fix broken LoRA image link and remove leftover TODO comment

### DIFF
--- a/chapters/en/chapter11/4.mdx
+++ b/chapters/en/chapter11/4.mdx
@@ -43,7 +43,7 @@ model = AutoModelForCausalLM.from_pretrained(config.base_model_name_or_path)
 lora_model = PeftModel.from_pretrained(model, "ybelkada/opt-350m-lora")
 ```
 
-![lora_load_adapter](https://github.com/huggingface/smol-course/raw/main/3_parameter_efficient_finetuning/images/lora_adapter.png)
+![lora_load_adapter](https://github.com/huggingface/smol-course/raw/main/v1/3_parameter_efficient_finetuning/images/lora_adapter.png)
 
 ## Fine-tune LLM using `trl` and the `SFTTrainer` with LoRA
 
@@ -77,7 +77,6 @@ PEFT methods can be combined with TRL for fine-tuning to reduce memory requireme
 ```python
 from peft import LoraConfig
 
-# TODO: Configure LoRA parameters
 # r: rank dimension for LoRA update matrices (smaller = more compression)
 rank_dimension = 6
 # lora_alpha: scaling factor for LoRA layers (higher = stronger adaptation)


### PR DESCRIPTION
## What does this PR do?

This fixes two small issues in the LoRA section of Chapter 11:

- updates the LoRA adapter image link so the image loads correctly
- removes a leftover `TODO` comment from the LoRA configuration example

Both changes are small docs cleanups, but they improve the reading experience and make the section feel more polished, and they were quite noticeable when I went through the course myself.