### PR TITLE
Fix deprecated AdamW imports in Romanian course chapters

### DIFF
--- a/chapters/ro/chapter3/2.mdx
+++ b/chapters/ro/chapter3/2.mdx
@@ -27,7 +27,8 @@ Continuând cu exemplul din [capitolul anterior](/course/chapter2), iată cum am
 
 ```python
 import torch
-from transformers import AdamW, AutoTokenizer, AutoModelForSequenceClassification
+from transformers import AutoTokenizer, AutoModelForSequenceClassification
+from torch.optim import AdamW
 
 # La fel ca înainte
 checkpoint = "bert-base-uncased"

--- a/chapters/ro/chapter3/4.mdx
+++ b/chapters/ro/chapter3/4.mdx
@@ -105,7 +105,7 @@ Toate modelele 🤗 Transformers vor returna pierderea (loss) când `labels` sun
 Suntem aproape gata să scriem bucla de antrenament! Ne mai lipsesc două lucruri: un optimizer și un scheduler pentru rata de învățare. Pentru că încercăm să reproducem ceea ce făcea `Trainer`, vom folosi aceleași valori implicite. Optimizer-ul folosit de `Trainer` este `AdamW`, care este același cu Adam, dar cu o abordare particulară pentru regularizarea weight decay (vedeți lucrarea ["Decoupled Weight Decay Regularization"](https://arxiv.org/abs/1711.05101) de Ilya Loshchilov și Frank Hutter):
 
 ```py
-from transformers import AdamW
+from torch.optim import AdamW
 
 optimizer = AdamW(model.parameters(), lr=5e-5)
 ```
@@ -207,7 +207,8 @@ Din nou, rezultatele voastre vor fi ușor diferite din cauza aleatorietății î
 Bucla de antrenament pe care am definit-o anterior funcționează bine pe un singur CPU sau GPU. Dar, folosind biblioteca [🤗 Accelerate](https://github.com/huggingface/accelerate), cu doar câteva ajustări putem activa antrenarea distribuită pe mai multe GPU-uri sau TPU-uri. Pornind de la crearea dataloader-urilor de antrenament și validare, iată cum arată bucla noastră manuală de antrenament:
 
 ```py
-from transformers import AdamW, AutoModelForSequenceClassification, get_scheduler
+from transformers import AutoModelForSequenceClassification, get_scheduler
+from torch.optim import AdamW
 
 model = AutoModelForSequenceClassification.from_pretrained(checkpoint, num_labels=2)
 optimizer = AdamW(model.parameters(), lr=3e-5)
@@ -244,7 +245,8 @@ Iar aici sunt modificările:
 
 ```diff
 + from accelerate import Accelerator
-  from transformers import AdamW, AutoModelForSequenceClassification, get_scheduler
+  from transformers import AutoModelForSequenceClassification, get_scheduler
+  from torch.optim import AdamW
 
 + accelerator = Accelerator()
 
@@ -295,7 +297,8 @@ Dacă vreți să copiați și să lipiți pentru a vă juca, iată cum arată bu
 
 ```py
 from accelerate import Accelerator
-from transformers import AdamW, AutoModelForSequenceClassification, get_scheduler
+from transformers import AutoModelForSequenceClassification, get_scheduler
+from torch.optim import AdamW
 
 accelerator = Accelerator()
 

--- a/chapters/ro/chapter7/4.mdx
+++ b/chapters/ro/chapter7/4.mdx
@@ -796,7 +796,7 @@ model = AutoModelForSeq2SeqLM.from_pretrained(model_checkpoint)
 Pe urmă vom avea nevoie de un optimizator:
 
 ```py
-from transformers import AdamW
+from torch.optim import AdamW
 
 optimizer = AdamW(model.parameters(), lr=2e-5)
 ```


### PR DESCRIPTION
Replaces deprecated `AdamW` imports from `transformers` with `torch.optim.AdamW` in Romanian course chapter files.

Updated files:

* chapters/ro/chapter3/2.mdx
* chapters/ro/chapter3/4.mdx
* chapters/ro/chapter7/4.mdx

Related to #975
