### PR TITLE
docs(zh-CN): fix eature-extraction typo to feature-extraction

### DIFF
--- a/chapters/zh-CN/chapter1/3.mdx
+++ b/chapters/zh-CN/chapter1/3.mdx
@@ -65,7 +65,7 @@ classifier(
 
 目前 [可用的一些pipeline](https://huggingface.co/transformers/main_classes/pipelines) 有：
 
-* `eature-extraction` （获取文本的向量表示）
+* `feature-extraction` （获取文本的向量表示）
 * `fill-mask` （完形填空）
 * `ner` （命名实体识别）
 * `question-answering` （问答）


### PR DESCRIPTION
Fixes #1238

## What changed

The zh-CN translation of chapter1/3.mdx was missing the leading `f` on `feature-extraction`:

```
* `eature-extraction` （获取文本的向量表示）
```

All other translations (vi, ja, it, te, ru, ro, pt, zh-TW, my, pt, ...) already spell it correctly. This aligns the zh-CN file with the rest.

One-character fix.
