### PR TITLE
Fix erratic learning-rate example

### DIFF
--- a/chapters/en/chapter3/5.mdx
+++ b/chapters/en/chapter3/5.mdx
@@ -260,8 +260,8 @@ from transformers import TrainingArguments
 
 training_args = TrainingArguments(
     output_dir="./results",
-    -learning_rate=1e-5,
-    +learning_rate=1e-4,
+    -learning_rate=1e-4,
+    +learning_rate=1e-5,
     -per_device_train_batch_size=16,
     +per_device_train_batch_size=32,
 )
@@ -405,4 +405,3 @@ Test your understanding of learning curves and training analysis:
 		}
 	]}
 />
-

--- a/chapters/ko/chapter3/5.mdx
+++ b/chapters/ko/chapter3/5.mdx
@@ -260,8 +260,8 @@ from transformers import TrainingArguments
 
 training_args = TrainingArguments(
     output_dir="./results",
-    -learning_rate=1e-5,
-    +learning_rate=1e-4,
+    -learning_rate=1e-4,
+    +learning_rate=1e-5,
     -per_device_train_batch_size=16,
     +per_device_train_batch_size=32,
 )

--- a/chapters/my/chapter3/5.mdx
+++ b/chapters/my/chapter3/5.mdx
@@ -262,8 +262,8 @@ from transformers import TrainingArguments
 
 training_args = TrainingArguments(
     output_dir="./results",
-    -learning_rate=1e-5,
-    +learning_rate=1e-4,
+    -learning_rate=1e-4,
+    +learning_rate=1e-5,
     -per_device_train_batch_size=16,
     +per_device_train_batch_size=32,
 )


### PR DESCRIPTION
Summary:
- Correct the erratic learning curves example so the diff lowers the learning rate from 1e-4 to 1e-5.
- Apply the same numeric fix to the English, Korean, and Burmese chapter files that contain the same example.

Verification:
- git diff --check
- rg -n --multiline "-learning_rate=1e-5,\n\s*\+learning_rate=1e-4" chapters/en/chapter3/5.mdx chapters/my/chapter3/5.mdx chapters/ko/chapter3/5.mdx

Fixes #1240