### PR TITLE
Add Spanish translation of chapter 2 introduction

### DIFF
--- a/chapters/es/_toctree.yml
+++ b/chapters/es/_toctree.yml
@@ -29,6 +29,8 @@
 
 - title: 2. Usando Transformers 🤗
   sections:
+  - local: chapter2/1
+    title: Introducción
   - local: chapter2/4
     title: Tokenizadores
   - local: chapter2/5

--- a/chapters/es/chapter2/1.mdx
+++ b/chapters/es/chapter2/1.mdx
@@ -1,0 +1,23 @@
+# Introducción[[introduction]]
+
+<CourseFloatingBanner
+    chapter={2}
+    classNames="absolute z-10 right-0 top-0"
+/>
+
+Como viste en el [Capítulo 1](/course/chapter1), los modelos Transformer suelen ser muy grandes. Con millones y hasta decenas de *miles de millones* de parámetros, entrenar y desplegar estos modelos es una tarea complicada. Además, con nuevos modelos publicándose casi a diario y teniendo cada uno su propia implementación, probarlos todos no es tarea fácil.
+
+La biblioteca 🤗 Transformers se creó para resolver este problema. Su objetivo es proporcionar una única API a través de la cual se pueda cargar, entrenar y guardar cualquier modelo Transformer. Las características principales de la biblioteca son:
+
+- **Facilidad de uso**: Descargar, cargar y usar un modelo de PLN de última generación para inferencia se puede hacer en solo dos líneas de código.
+- **Flexibilidad**: En el fondo, todos los modelos son simples clases `nn.Module` de PyTorch y se pueden manejar como cualquier otro modelo en sus respectivos frameworks de aprendizaje automático (ML).
+- **Simplicidad**: Apenas se hacen abstracciones a lo largo de la biblioteca. El "Todo en un archivo" es un concepto central: la pasada hacia delante de un modelo se define por completo en un único archivo, de modo que el propio código sea comprensible y modificable.
+
+Esta última característica hace que 🤗 Transformers sea bastante diferente de otras bibliotecas de ML. Los modelos no se construyen sobre módulos que se comparten entre archivos; en su lugar, cada modelo tiene sus propias capas. Además de hacer que los modelos sean más accesibles y comprensibles, esto te permite experimentar fácilmente con un modelo sin afectar a los demás.
+
+Este capítulo comenzará con un ejemplo de principio a fin en el que usamos juntos un modelo y un tokenizador para replicar la función `pipeline()` presentada en el [Capítulo 1](/course/chapter1). A continuación, hablaremos de la API de modelos: profundizaremos en las clases de modelo y de configuración, y te mostraremos cómo cargar un modelo y cómo procesa entradas numéricas para producir predicciones.
+
+Después veremos la API del tokenizador, que es el otro componente principal de la función `pipeline()`. Los tokenizadores se encargan del primer y del último paso de procesamiento, gestionando la conversión de texto a entradas numéricas para la red neuronal, y la conversión de vuelta a texto cuando es necesario. Por último, te mostraremos cómo gestionar el envío de varias frases a un modelo en un lote preparado, y lo cerraremos todo con una mirada más detallada a la función de alto nivel `tokenizer()`.
+
+> [!TIP]
+> ⚠️ Para beneficiarte de todas las funcionalidades disponibles con el Model Hub y 🤗 Transformers, te recomendamos <a href="https://huggingface.co/join">crear una cuenta</a>.


### PR DESCRIPTION
This PR adds the Spanish (es) translation of the Chapter 2 introduction (`chapter2/1`) and lists it in the Spanish table of contents.

I am a native Spanish speaker. I kept the MDX components, the heading anchor, code references and links unchanged, translating only the prose.