### PR TITLE
Fix Chapter 1.3: migrate removed question-answering/summarization/translation pipelines to text-generation (Transformers v5)

### DIFF
--- a/chapters/en/chapter1/3.mdx
+++ b/chapters/en/chapter1/3.mdx
@@ -99,6 +99,9 @@ Here's an overview of what's available:
 
 - `image-text-to-text`: Respond to an image based on a text prompt
 
+> [!TIP]
+> Some text tasks that used to have their own pipeline — notably summarization, translation, and question answering — no longer do as of 🤗 Transformers v5. Modern instruction-tuned (chat) models handle these directly through the `text-generation` pipeline, simply by describing the task in a prompt. We'll use that approach in the corresponding sections below.
+
 Let's explore some of these pipelines in more detail!
 
 ## Zero-shot classification[[zero-shot-classification]]
@@ -243,34 +246,44 @@ We pass the option `aggregation_strategy="simple"` in the pipeline creation func
 
 ## Question answering[[question-answering]]
 
-The `question-answering` pipeline answers questions using information from a given context:
+Question answering answers a question using information from a given context. Earlier versions of 🤗 Transformers had a dedicated `question-answering` pipeline, but it was removed in v5. Instead, we pass an instruction-tuned model to the `text-generation` pipeline and describe the task in the prompt:
 
 ```python
 from transformers import pipeline
 
-question_answerer = pipeline("question-answering")
-question_answerer(
-    question="Where do I work?",
-    context="My name is Sylvain and I work at Hugging Face in Brooklyn",
+question_answerer = pipeline(
+    "text-generation", model="HuggingFaceTB/SmolLM2-360M-Instruct"
 )
+output = question_answerer(
+    [
+        {
+            "role": "user",
+            "content": "Answer the question in one short sentence, using only the context below.\n\n"
+            "Context: My name is Sylvain and I work at Hugging Face in Brooklyn.\n"
+            "Question: Where do I work?",
+        }
+    ],
+    max_new_tokens=50,
+)
+print(output[0]["generated_text"][-1]["content"])
 ```
 
 ```python out
-{'score': 0.6385916471481323, 'start': 33, 'end': 45, 'answer': 'Hugging Face'}
+You work at Hugging Face in Brooklyn.
 ```
 
-Note that this pipeline works by extracting information from the provided context; it does not generate the answer.
+Unlike the older extractive pipeline, which copied a span straight out of the context, the model now *generates* the answer. Because text generation involves randomness, your exact wording may differ from the output above.
 
 ## Summarization[[summarization]]
 
-Summarization is the task of reducing a text into a shorter text while keeping all (or most) of the important aspects referenced in the text. Here's an example:
+Summarization reduces a text into a shorter version while keeping all (or most) of the important aspects referenced in the text. As with question answering, the standalone `summarization` pipeline was removed in v5, so we prompt an instruction-tuned model through the `text-generation` pipeline:
 
 ```python
 from transformers import pipeline
 
-summarizer = pipeline("summarization")
-summarizer(
-    """
+summarizer = pipeline("text-generation", model="HuggingFaceTB/SmolLM2-360M-Instruct")
+
+text = """
     America has changed dramatically during recent years. Not only has the number of 
     graduates in traditional engineering disciplines such as mechanical, civil, 
     electrical, chemical, and aeronautical engineering declined, but in most of 
@@ -290,41 +303,57 @@ summarizer(
     suffers an increasingly serious decline in the number of engineering graduates 
     and a lack of well-educated engineers.
 """
+
+output = summarizer(
+    [{"role": "user", "content": f"Summarize the following text:\n\n{text}"}],
+    max_new_tokens=150,
 )
+print(output[0]["generated_text"][-1]["content"])
 ```
 
 ```python out
-[{'summary_text': ' America has changed dramatically during recent years . The '
-                  'number of engineering graduates in the U.S. has declined in '
-                  'traditional engineering disciplines such as mechanical, civil '
-                  ', electrical, chemical, and aeronautical engineering . Rapidly '
-                  'developing economies such as China and India, as well as other '
-                  'industrial countries in Europe and Asia, continue to encourage '
-                  'and advance engineering .'}]
+The passage discusses significant changes in the U.S. engineering landscape. It reports that
+the number of traditional engineering graduates has decreased, while the number of
+science-related engineering subjects has increased. This shift has led to a decline in the
+number of engineering graduates, with America's premier universities focusing on
+science-related fields. The decline has been particularly pronounced for infrastructure,
+environmental, and related fields and has led to a greater emphasis on high technology.
+However, these developments do not come at the expense of traditional engineering but rather
+are part of a broader effort to promote more complex scientific developments.
 ```
 
-Like with text generation, you can specify a `max_length` or a `min_length` for the result.
+You can steer the length and style of the summary through your prompt (for example, "in one sentence" or "as bullet points") or by adjusting `max_new_tokens`.
 
 
 ## Translation[[translation]]
 
-For translation, you can use a default model if you provide a language pair in the task name (such as `"translation_en_to_fr"`), but the easiest way is to pick the model you want to use on the [Model Hub](https://huggingface.co/models). Here we'll try translating from French to English:
+Translation converts text from one language to another. The dedicated `translation` pipeline was also removed in v5, so once again we prompt an instruction-tuned model through the `text-generation` pipeline. Here we'll try translating from French to English:
 
 ```python
 from transformers import pipeline
 
-translator = pipeline("translation", model="Helsinki-NLP/opus-mt-fr-en")
-translator("Ce cours est produit par Hugging Face.")
+translator = pipeline("text-generation", model="HuggingFaceTB/SmolLM2-360M-Instruct")
+output = translator(
+    [
+        {
+            "role": "user",
+            "content": "Translate the following sentence from French to English: "
+            "Ce cours est produit par Hugging Face.",
+        }
+    ],
+    max_new_tokens=40,
+)
+print(output[0]["generated_text"][-1]["content"])
 ```
 
 ```python out
-[{'translation_text': 'This course is produced by Hugging Face.'}]
+This course is created by Hugging Face.
 ```
 
-Like with text generation and summarization, you can specify a `max_length` or a `min_length` for the result.
+You can translate into any language the model supports simply by changing the prompt.
 
 > [!TIP]
-> ✏️ **Try it out!** Search for translation models in other languages and try to translate the previous sentence into a few different languages.
+> ✏️ **Try it out!** Change the target language in the prompt and translate the sentence into a few different languages.
 
 ## Image and audio pipelines
 


### PR DESCRIPTION
## What does this PR do?

The `question-answering`, `summarization`, and `translation` pipelines were removed in Transformers v5.3. As a result, three code samples in Chapter 1 §3 ("Transformers, what can they do?") now fail on current Transformers with:

```
KeyError: "Unknown task question-answering, available tasks are [...]"
```

(and the equivalent for `summarization` and `translation`). This affects both the course page and its auto-generated [Colab notebook](https://colab.research.google.com/github/huggingface/notebooks/blob/master/course/en/chapter1/section3.ipynb).

### Fix

Following the [official v5 migration guide](https://github.com/huggingface/transformers/blob/main/MIGRATION_GUIDE_V5.md) — which recommends replacing these task pipelines with the `text-generation` pipeline and a chat model — this PR rewrites all three sections to prompt an instruction-tuned model:

- **Question answering** → now *generative* (via `text-generation`) instead of extractive; the surrounding prose is updated to reflect this.
- **Summarization** → `text-generation` with a summarize prompt.
- **Translation** → `text-generation` with a translate prompt.
- Added a short note in the pipelines overview explaining that these tasks no longer have dedicated pipelines as of v5.

All example outputs were captured from a real run on `transformers==5.13`.

### Notes / decision points for reviewers

- **Model choice:** I used `HuggingFaceTB/SmolLM2-360M-Instruct` to stay consistent with the `SmolLM2-360M` model already used earlier in this chapter and to keep it light enough for free Colab. The migration guide's own example uses `Qwen/Qwen3-4B-Instruct-2507`, which produces higher-quality output at a heavier download/compute cost — happy to switch if you'd prefer that.
- **Extractive vs. generative QA:** I moved QA to the generative approach for consistency with the other two tasks and with the migration guide. If you'd rather keep it extractive, it can instead use `AutoTokenizer` + `AutoModelForQuestionAnswering` (the approach taken in huggingface/transformers#44787).
- **Scope:** only the English source `chapters/en/chapter1/3.mdx` is changed; the localized copies are left to the course's translation workflow.

Refs #1197, #1211
