### PR TITLE
fix(fr): Remove extra 'de' before 'plusieurs séquences' in chapter 2

### DIFF
--- a/chapters/fr/chapter2/5.mdx
+++ b/chapters/fr/chapter2/5.mdx
@@ -34,8 +34,8 @@
 
 Dans la section précédente, nous avons exploré le cas d'utilisation le plus simple : faire une inférence sur une seule séquence de petite longueur. Cependant, certaines questions émergent déjà :
 
-- comment gérer de plusieurs séquences ?
-- comment gérer de plusieurs séquences *de longueurs différentes* ?
+- comment gérer plusieurs séquences ?
+- comment gérer plusieurs séquences *de longueurs différentes* ?
 - les indices du vocabulaire sont-ils les seules entrées qui permettent à un modèle de bien fonctionner ?
 - existe-t-il une séquence trop longue ?
 


### PR DESCRIPTION
Small typo fixes

@lbourdois , @ChainYo @melaniedrevet, @abdouaziz 
