### PR TITLE
Clarify "labels" question in ch1 quiz to specify human-annotated

### DIFF
--- a/chapters/en/chapter1/7.mdx
+++ b/chapters/en/chapter1/7.mdx
@@ -137,7 +137,7 @@ result = classifier("This is a course about the Transformers library")
 	]}
 />
 
-### 6. True or false? A language model usually does not need labels for its pretraining.
+### 6. True or false? A language model usually does not need human-annotated labels for its pretraining.
 
 <Question
 	choices={[


### PR DESCRIPTION
The question asks if a model needs "labels" for pretraining, with True marked correct. But self-supervised pretraining still uses labels — next-token or masked-token targets are labels, just not human-annotated ones. The question as is implies that there are no labels at all which isn't accurate.