### PR TITLE
Fix typo: eature-extraction in zh-CN chapter 1

### DIFF
--- a/chapters/zh-CN/chapter1/3.mdx
+++ b/chapters/zh-CN/chapter1/3.mdx
@@ -65,7 +65,7 @@ classifier(
 
 目前 [可用的一些pipeline](https://huggingface.co/transformers/main_classes/pipelines) 有：
 
-* `eature-extraction` （获取文本的向量表示）
+* `feature-extraction` （获取文本的向量表示）
 * `fill-mask` （完形填空）
 * `ner` （命名实体识别）
 * `question-answering` （问答）


### PR DESCRIPTION
## Summary
- Fixes a missing leading `f` in the zh-CN chapter 1 pipeline task list (`eature-extraction` -> `feature-extraction`)
- Matches the real Transformers pipeline task name used in the English source

Fixes #1238

## Test plan
- [ ] Confirm `chapters/zh-CN/chapter1/3.mdx` shows `` `feature-extraction` ``
- [ ] Spot-check the rendered zh-CN chapter 1 section 3 pipeline list