### PR TITLE
Fix max_length/max_new_tokens conflict in Chapter 1.3

### DIFF
--- a/chapters/en/chapter1/3.mdx
+++ b/chapters/en/chapter1/3.mdx
@@ -146,10 +146,10 @@ generator("In this course, we will teach you how to")
                     'HTTP'}]
 ```
 
-You can control how many different sequences are generated with the argument `num_return_sequences` and the total length of the output text with the argument `max_length`.
+You can control how many different sequences are generated with the argument `num_return_sequences` and the total length of the output text with the argument `max_new_tokens`.
 
 > [!TIP]
-> ✏️ **Try it out!** Use the `num_return_sequences` and `max_length` arguments to generate two sentences of 15 words each.
+> ✏️ **Try it out!** Use the `num_return_sequences` and `max_new_tokens` arguments to generate two sentences of 15 words each.
 
 ## Using any model from the Hub in a pipeline[[using-any-model-from-the-hub-in-a-pipeline]]
 
@@ -163,7 +163,7 @@ from transformers import pipeline
 generator = pipeline("text-generation", model="HuggingFaceTB/SmolLM2-360M")
 generator(
     "In this course, we will teach you how to",
-    max_length=30,
+    max_new_tokens=30,
     num_return_sequences=2,
 )
 ```

--- a/chapters/en/chapter1/3.mdx
+++ b/chapters/en/chapter1/3.mdx
@@ -146,10 +146,10 @@ generator("In this course, we will teach you how to")
                     'HTTP'}]
 ```
 
-You can control how many different sequences are generated with the argument `num_return_sequences` and the total length of the output text with the argument `max_new_tokens`.
+You can control how many different sequences are generated with the argument `num_return_sequences` and the maximum number of newly generated tokens with the argument `max_new_tokens`.
 
 > [!TIP]
-> ✏️ **Try it out!** Use the `num_return_sequences` and `max_new_tokens` arguments to generate two sentences of 15 words each.
+> ✏️ **Try it out!** Use the `num_return_sequences` and `max_new_tokens` arguments to generate two sequences with at most 15 new tokens each.
 
 ## Using any model from the Hub in a pipeline[[using-any-model-from-the-hub-in-a-pipeline]]
 


### PR DESCRIPTION
## Summary

Fix the text-generation example in Chapter 1.3 by replacing `max_length` with `max_new_tokens`.

In recent versions of `transformers`, the text-generation pipeline may already define `max_new_tokens`, which causes a conflict when the course example explicitly passes `max_length`. Since `max_new_tokens` takes precedence, the example may not control the generated output length as intended.

## Changes

* Replace `max_length=30` with `max_new_tokens=30`
* Update the surrounding explanation to use `max_new_tokens`
* Clarify that generation length is measured in tokens, not words

This PR intentionally updates only the English source. Localized versions can be synchronized separately through the translation workflow.

Fixes #1285