### PR TITLE
fix(zh-CN): replace incorrect term in chapter 5 section 3

### DIFF
--- a/chapters/zh-CN/chapter5/3.mdx
+++ b/chapters/zh-CN/chapter5/3.mdx
@@ -152,7 +152,7 @@ lambda x : x * x
 drug_dataset = drug_dataset.filter(lambda x: x["condition"] is not None)
 ``` 
 
-含有`None`的积累删除之后,我们可以规范我们的 `condition` 列:
+含有`None`的记录删除之后,我们可以规范我们的 `condition` 列:
 
 ```py
 drug_dataset = drug_dataset.map(lowercase_condition)


### PR DESCRIPTION
This corrects an incorrect term in the Simplified Chinese translation of Chapter 5, Section 3 (`积累` → `记录`) so the sentence refers to dataset records.

Checks:
- targeted content assertion
- `python utils/code_formatter.py --check_only`
- `make quality`
- `git diff --check`

Fixes #1288