### PR TITLE
[FR] Fix literal <i> and <code> tags showing up in French headings

### DIFF
--- a/chapters/fr/chapter0/1.mdx
+++ b/chapters/fr/chapter0/1.mdx
@@ -10,7 +10,7 @@ Notez que nous ne couvrirons pas le système Windows. Si vous travaillez sous Wi
 
 La plupart du cours repose sur le fait que vous ayez un compte Hugging Face. Si vous n'en disposez pas d'un, nous vous recommandons d'en créer un dès maintenant : [créer un compte](https://huggingface.co/join).
 
-## Utilisation d'un <i>notebook</i> Google Colab
+## Utilisation d'un notebook Google Colab
 
 L'utilisation d'un *notebook* Google Colab est la configuration la plus simple possible. Démarrez un *notebook* dans votre navigateur et passez directement au codage !
 

--- a/chapters/fr/chapter1/2.mdx
+++ b/chapters/fr/chapter1/2.mdx
@@ -1,4 +1,4 @@
-# Traitement du langage naturel (NLP pour <i>Natural Language Processing</i>)
+# Traitement du langage naturel (NLP pour Natural Language Processing)
 
 <CourseFloatingBanner
     chapter={1}

--- a/chapters/fr/chapter1/3.mdx
+++ b/chapters/fr/chapter1/3.mdx
@@ -1,4 +1,4 @@
-# Que peuvent faire les <i>transformers</i> ?
+# Que peuvent faire les transformers ?
 
 <CourseFloatingBanner chapter={1}
   classNames="absolute z-10 right-0 top-0"
@@ -16,7 +16,7 @@ Dans cette section, nous allons voir ce que peuvent faire les *transformers* et 
 >
 > Si vous souhaitez exécuter les codes en local, nous vous recommandons de jeter un œil au chapitre <a href="/course/fr/chapter0">configuration</a>.
 
-## Les <i>transformers</i> sont partout !
+## Les transformers sont partout !
 
 Les *transformers* sont utilisés pour résoudre toute sorte de tâches de NLP comme celles mentionnées dans la section précédente. Voici quelques-unes des entreprises et organisations qui utilisent Hugging Face, les *transformers* et qui contribuent aussi à la communauté en partageant leurs modèles :
 
@@ -87,7 +87,7 @@ Voici une liste non-exhaustive des [pipelines disponibles](https://huggingface.c
 
 Regardons de plus près certains d'entre eux !
 
-## <i>Zero-shot classification</i>
+## Zero-shot classification
 
 Nous allons commencer par nous attaquer à une tâche plus difficile où nous devons classer des textes qui n'ont pas été annotés. C'est un scénario très répandu dans les projets réels car l'annotation de textes est généralement longue et nécessite parfois une expertise dans un domaine. Pour ce cas d'usage, le pipeline `zero-shot-classification` est très puissant : il vous permet de spécifier les labels à utiliser pour la classification, de sorte que vous n'ayez pas à vous soucier des labels du modèle pré-entraîné. Nous avons déjà vu comment le modèle peut classer un texte comme positif ou négatif en utilisant ces deux labels mais il peut également classer le texte en utilisant n'importe quel autre ensemble de labels que vous souhaitez.
 
@@ -147,7 +147,7 @@ Il est possible de contrôler le nombre de séquences générées avec l'argumen
 > ✏️ **Essayez !** Utilisez les arguments `num_return_sequences` et `max_length` pour générer deux phrases de 15 mots chacune.
 
 
-## Utiliser n'importe quel modèle du <i>Hub</i> dans un pipeline
+## Utiliser n'importe quel modèle du Hub dans un pipeline
 
 Les exemples précédents utilisaient le modèle par défaut pour la tâche en question mais vous pouvez aussi choisir un modèle particulier du *Hub* et l'utiliser dans un pipeline pour une tâche spécifique comme par exemple la génération de texte. Rendez-vous sur le [*Hub*](https://huggingface.co/models) et cliquez sur le *filtre* correspondant sur la gauche pour afficher seulement les modèles supportés pour cette tâche. Vous devriez arriver sur une page comme [celle-ci](https://huggingface.co/models?pipeline_tag=text-generation).
 

--- a/chapters/fr/chapter1/4.mdx
+++ b/chapters/fr/chapter1/4.mdx
@@ -1,4 +1,4 @@
-# Comment fonctionnent les <i>transformers</i> ?
+# Comment fonctionnent les transformers ?
 
 <CourseFloatingBanner
     chapter={1}
@@ -7,7 +7,7 @@
 
 Dans cette partie, nous allons jeter un coup d'œil à l'architecture des *transformers*.
 
-## Court historique des <i>transformers</i>
+## Court historique des transformers
 
 Voici quelques dates clefs dans la courte histoire des *transformers* :
 
@@ -38,7 +38,7 @@ Cette liste est loin d'être exhaustive et met en lumière certains *transformer
 
 Nous verrons plus en profondeur ces familles de modèles plus tard.
 
-## Les <i>transformers</i> sont des modèles de langage
+## Les transformers sont des modèles de langage
 
 Tous les *transformers* mentionnés ci-dessus (GPT, BERT, BART, T5, etc.) ont été entraînés comme des *modèles de langage*. Cela signifie qu'ils ont été entraînés sur une large quantité de textes bruts de manière autosupervisée. L'apprentissage autosupervisé est un type d'entraînement dans lequel l'objectif est automatiquement calculé à partir des entrées du modèle. Cela signifie que les humains ne sont pas nécessaires pour étiqueter les données !
 
@@ -57,7 +57,7 @@ Un autre exemple est la *modélisation du langage masqué*, dans laquelle le mod
 <img class="hidden dark:block" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter1/masked_modeling-dark.svg" alt="Example of masked language modeling in which a masked word from a sentence is predicted.">
 </div>
 
-## Les <i>transformers</i> sont énormes
+## Les transformers sont énormes
 
 En dehors de quelques exceptions (comme DistilBERT), la stratégie générale pour obtenir de meilleure performance consiste à augmenter la taille des modèles ainsi que la quantité de données utilisées pour l'entraînement de ces derniers.
 
@@ -166,7 +166,7 @@ Notez que la première couche d'attention dans un bloc décodeur prête attentio
 
 Le *masque d'attention* peut également être utilisé dans l'encodeur/décodeur pour empêcher le modèle de prêter attention à certains mots spéciaux. Par exemple, le mot de remplissage spécial (le *padding*) utilisé pour que toutes les entrées aient la même longueur lors du regroupement de phrases.
 
-## Architectures contre <i>checkpoints</i>
+## Architectures contre checkpoints
  
 En approfondissant l'étude des <i>transformers</i> dans ce cours, vous verrez des mentions d'<i>architectures</i> et de <i>checkpoints</i> ainsi que de <i>modèles</i>. Ces termes ont tous des significations légèrement différentes :
 

--- a/chapters/fr/chapter2/2.mdx
+++ b/chapters/fr/chapter2/2.mdx
@@ -66,7 +66,7 @@ Comme nous l'avons vu dans le [chapitre 1](/course/fr/chapter1), ce pipeline reg
 
 Passons rapidement en revue chacun de ces éléments.
 
-## Prétraitement avec un <i>tokenizer</i>
+## Prétraitement avec un tokenizer
 
 Comme d'autres réseaux de neurones, les *transformers* ne peuvent pas traiter directement le texte brut, donc la première étape de notre pipeline est de convertir les entrées textuelles en nombres afin que le modèle puisse les comprendre. Pour ce faire, nous utilisons un *tokenizer*, qui sera responsable de :
 - diviser l'entrée en mots, sous-mots, ou symboles (comme la ponctuation) qui sont appelés *tokens*,

--- a/chapters/fr/chapter2/3.mdx
+++ b/chapters/fr/chapter2/3.mdx
@@ -46,7 +46,7 @@ La classe `TFAutoModel` et toutes les classes apparentées sont en fait de simpl
 
 Cependant, si vous connaissez le type de modèle que vous voulez utiliser, vous pouvez utiliser directement la classe qui définit son architecture. Voyons comment cela fonctionne avec un modèle BERT.
 
-## Création d’un <i>transformer</i>
+## Création d’un transformer
 
 La première chose que nous devons faire pour initialiser un modèle BERT est de charger un objet configuration :
 
@@ -184,7 +184,7 @@ Le fichier *tf_model.h5* est connu comme le *dictionnaire d'état*. Il contient 
 
 {/if}
 
-### Utilisation d'un <i>transformer</i> pour l'inférence
+### Utilisation d'un transformer pour l'inférence
 
 Maintenant que vous savez comment charger et sauvegarder un modèle, essayons de l'utiliser pour faire quelques prédictions. Les *transformers* ne peuvent traiter que des nombres. Des nombres que le *tokenizer* génère. Mais avant de parler des *tokenizers*, explorons les entrées que le modèle accepte.
 

--- a/chapters/fr/chapter2/4.mdx
+++ b/chapters/fr/chapter2/4.mdx
@@ -1,6 +1,6 @@
 <FrameworkSwitchCourse {fw} />
 
-# Les <i>tokenizers</i>
+# Les tokenizers
 
 {#if fw === 'pt'}
 
@@ -41,7 +41,7 @@ Les modèles ne pouvant traiter que des nombres, nous devons trouver un moyen de
 
 Voyons quelques exemples d'algorithmes de tokénisation et essayons de répondre à certaines des questions que vous pouvez vous poser à ce sujet.
 
-## <i>Tokenizer</i> basé sur les mots
+## Tokenizer basé sur les mots
 
 
 <Youtube id="nhJxYji1aho"/>
@@ -75,7 +75,7 @@ Enfin, nous avons besoin d'un *token* personnalisé pour représenter les mots q
 Une façon de réduire la quantité de *tokens* inconnus est d'aller un niveau plus profond, en utilisant un *tokenizer* basé sur les caractères.
 
 
-## <i>Tokenizer</i>  basé sur les caractères
+## Tokenizer  basé sur les caractères
 
 <Youtube id="ssLq_EK2jLE"/>
 
@@ -215,7 +215,7 @@ La sortie de cette méthode est une liste de chaînes de caractères ou de *toke
 
 Ce *tokenizer* est un *tokenizer* de sous-mots : il découpe les mots jusqu'à obtenir des *tokens* qui peuvent être représentés par son vocabulaire. C'est le cas ici avec `transformer` qui est divisé en deux *tokens* : `transform` et `##er`.
 
-### De <i>tokens</i> aux identifiants d'entrée
+### De tokens aux identifiants d'entrée
 
 La conversion en identifiants d'entrée est gérée par la méthode `convert_tokens_to_ids()` du *tokenizer* :
 

--- a/chapters/fr/chapter2/5.mdx
+++ b/chapters/fr/chapter2/5.mdx
@@ -197,7 +197,7 @@ Il s'agit d'un batch de deux séquences identiques !
 
 Utiliser des *batchs* permet au modèle de fonctionner lorsque vous lui donnez plusieurs séquences. Utiliser plusieurs séquences est aussi simple que de construire un batch avec une seule séquence. Il y a cependant un deuxième problème. Lorsque vous essayez de regrouper deux phrases (ou plus), elles peuvent être de longueurs différentes. Si vous avez déjà travaillé avec des tenseurs, vous savez qu'ils doivent être de forme rectangulaire. Vous ne pourrez donc pas convertir directement la liste des identifiants d'entrée en un tenseur. Pour contourner ce problème, nous avons l'habitude de *rembourrer*/*remplir* (le *padding* en anglais) les entrées.
 
-## <i>Padding</i> des entrées
+## Padding des entrées
 
 La liste de listes suivante ne peut pas être convertie en un tenseur :
 

--- a/chapters/fr/chapter2/6.mdx
+++ b/chapters/fr/chapter2/6.mdx
@@ -151,7 +151,7 @@ print(tokenizer.decode(ids))
 
 Le *tokenizer* a ajouté le mot spécial `[CLS]` au début et le mot spécial `[SEP]` à la fin. C'est parce que le modèle a été pré-entraîné avec ces mots, donc pour obtenir les mêmes résultats pour l'inférence, nous devons également les ajouter. Notez que certains modèles n'ajoutent pas de mots spéciaux, ou en ajoutent des différents. Les modèles peuvent aussi ajouter ces mots spéciaux seulement au début, ou seulement à la fin. Dans tous les cas, le *tokenizer* sait lesquels sont attendus et s'en occupe pour vous.
 
-## Conclusion : du <i>tokenizer</i> au modèle
+## Conclusion : du tokenizer au modèle
 
 Maintenant que nous avons vu toutes les étapes individuelles que l'objet `tokenizer` utilise lorsqu'il est appliqué sur des textes, voyons une dernière fois comment il peut gérer plusieurs séquences (*padding*), de très longues séquences (*troncation*) et plusieurs types de tenseurs avec son API principale :
 

--- a/chapters/fr/chapter2/8.mdx
+++ b/chapters/fr/chapter2/8.mdx
@@ -28,7 +28,7 @@
 	]}
 />
 
-### 2. Combien de dimensions le tenseur produit par le <i>transformer</i> de base possède-t-il et quelles sont-elles ?
+### 2. Combien de dimensions le tenseur produit par le transformer de base possède-t-il et quelles sont-elles ?
 
 
 <Question
@@ -195,7 +195,7 @@
 	]}
 />
 
-### 8. Autour de quelle méthode s'articule la majeure partie de l'API <i>tokenizer</i> ?
+### 8. Autour de quelle méthode s'articule la majeure partie de l'API tokenizer ?
 
 <Question
 	choices={[

--- a/chapters/fr/chapter3/2.mdx
+++ b/chapters/fr/chapter3/2.mdx
@@ -85,7 +85,7 @@ Evidemment, entraîner un modèle avec seulement deux phrases ne va pas donner d
 
 Dans cette section, nous allons utiliser comme exemple le jeu de données MRPC (*Microsoft Research Paraphrase Corpus*) présenté dans un [papier](https://www.aclweb.org/anthology/I05-5002.pdf) par William B. Dolan et Chris Brockett. Ce jeu de données contient 5801 paires de phrases avec un label indiquant si ces paires sont des paraphrases ou non (i.e. si elles ont la même signification). Nous l'avons choisi pour ce chapitre parce que c'est un petit jeu de données et cela rend donc simples les expériences d'entraînement sur ce jeu de données. 
 
-### Charger un jeu de données depuis le <i>Hub</i>
+### Charger un jeu de données depuis le Hub
 
 {#if fw === 'pt'}
 <Youtube id="_BZearw7f0w"/>
@@ -288,7 +288,7 @@ Notre `tokenize_function` retourne un dictionnaire avec les clés `input_ids`, `
 
 La dernière chose que nous devrons faire est de remplir tous les exemples à la longueur de l'élément le plus long lorsque nous regroupons les éléments, une technique que nous appelons le *padding dynamique*.
 
-### <i>Padding</i> dynamique
+### Padding dynamique
 
 <Youtube id="7q5NyFT8REg"/>
 

--- a/chapters/fr/chapter3/3.mdx
+++ b/chapters/fr/chapter3/3.mdx
@@ -1,6 +1,6 @@
 <FrameworkSwitchCourse {fw} />
 
-# <i>Finetuner</i> un modèle avec l'API Trainer
+# Finetuner un modèle avec l'API Trainer
 
 <CourseFloatingBanner chapter={3}
   classNames="absolute z-10 right-0 top-0"

--- a/chapters/fr/chapter3/3_tf.mdx
+++ b/chapters/fr/chapter3/3_tf.mdx
@@ -1,6 +1,6 @@
 <FrameworkSwitchCourse {fw} />
 
-# <i>Finetuner</i> un modèle avec Keras
+# Finetuner un modèle avec Keras
 
 <CourseFloatingBanner chapter={3}
   classNames="absolute z-10 right-0 top-0"

--- a/chapters/fr/chapter3/4.mdx
+++ b/chapters/fr/chapter3/4.mdx
@@ -202,7 +202,7 @@ Une fois encore, vos résultats seront légèrement différents en raison du car
 > [!TIP]
 > ✏️ **Essayez** Modifiez la boucle d'entraînement précédente pour *finetuner* votre modèle sur le jeu de données SST-2.
 
-### Optimisez votre boucle d'entraînement avec 🤗 <i>Accelerate</i>
+### Optimisez votre boucle d'entraînement avec 🤗 Accelerate
 
 <Youtube id="s7dy8QRgjJ0" />
 

--- a/chapters/fr/chapter3/5.mdx
+++ b/chapters/fr/chapter3/5.mdx
@@ -1,6 +1,6 @@
 <FrameworkSwitchCourse {fw} />
 
-# <i>Finetuning</i>, coché !
+# Finetuning, coché !
 
 <CourseFloatingBanner
     chapter={3}

--- a/chapters/fr/chapter4/1.mdx
+++ b/chapters/fr/chapter4/1.mdx
@@ -1,4 +1,4 @@
-# Le <i>Hub</i> d'Hugging Face
+# Le Hub d'Hugging Face
 
 <CourseFloatingBanner
     chapter={4}

--- a/chapters/fr/chapter5/2.mdx
+++ b/chapters/fr/chapter5/2.mdx
@@ -1,4 +1,4 @@
-# Que faire si mon jeu de données n'est pas sur le <i>Hub</i> ?
+# Que faire si mon jeu de données n'est pas sur le Hub ?
 
 <CourseFloatingBanner chapter={5}
   classNames="absolute z-10 right-0 top-0"

--- a/chapters/fr/chapter5/4.mdx
+++ b/chapters/fr/chapter5/4.mdx
@@ -1,4 +1,4 @@
-# Données massives ? 🤗 <i>Datasets</i> à la rescousse !
+# Données massives ? 🤗 Datasets à la rescousse !
 
 
 <CourseFloatingBanner chapter={5}
@@ -18,7 +18,7 @@ Heureusement, 🤗 *Datasets* a été conçu pour surmonter ces limitations. Il 
 
 Dans cette section, nous allons explorer ces fonctionnalités de 🤗 *Datasets* avec un énorme corpus de 825 Go connu sous le nom de [*The Pile*](https://pile.eleuther.ai). Commençons !
 
-## Qu'est-ce que <i>The Pile</i> ?
+## Qu'est-ce que The Pile ?
 
 *The Pile* est un corpus de texte en anglais créé par [EleutherAI](https://www.eleuther.ai) pour entraîner des modèles de langage à grande échelle. Il comprend une gamme variée de jeux de données, couvrant des articles scientifiques, des référentiels de code GitHub et du texte Web filtré. Le corpus d’entraînement est disponible en [morceaux de 14 Go](https://the-eye.eu/public/AI/pile/) et vous pouvez aussi télécharger plusieurs des [composants individuels]( https://the-eye.eu/public/AI/pile_preliminary_components/). Commençons par jeter un coup d'œil au jeu de données *PubMed Abstracts*, qui est un corpus de résumés de 15 millions de publications biomédicales sur [PubMed](https://pubmed.ncbi.nlm.nih.gov/). Le jeu de données est au [format JSON Lines](https://jsonlines.org) et est compressé à l'aide de la bibliothèque `zstandard`. Nous devons donc d'abord installer cette bibliothèque :
 
@@ -64,7 +64,7 @@ pubmed_dataset[0]
 
 Cela ressemble au résumé d'un article médical. Voyons maintenant combien de RAM nous avons utilisé pour charger le jeu de données !
 
-## La magie du <i>memory mapping</i>
+## La magie du memory mapping
 
 Un moyen simple de mesurer l'utilisation de la mémoire dans Python consiste à utiliser la bibliothèque [`psutil`](https://psutil.readthedocs.io/en/latest/) qui peut être installée avec `pip` comme suit :
 

--- a/chapters/fr/chapter5/5.mdx
+++ b/chapters/fr/chapter5/5.mdx
@@ -321,7 +321,7 @@ La dernière étape consiste à enregistrer le jeu de données augmentées avec 
 issues_with_comments_dataset.to_json("issues-datasets-with-comments.jsonl")
 ```
 
-## Téléchargement du jeu de données sur le <i>Hub</i>
+## Téléchargement du jeu de données sur le Hub
 
 <Youtube id="HaN6qCr_Afc"/>
 

--- a/chapters/fr/chapter5/7.mdx
+++ b/chapters/fr/chapter5/7.mdx
@@ -1,4 +1,4 @@
-# 🤗 <i>Datasets</i>, coché !
+# 🤗 Datasets, coché !
 
 <CourseFloatingBanner
     chapter={5}

--- a/chapters/fr/chapter6/10.mdx
+++ b/chapters/fr/chapter6/10.mdx
@@ -33,7 +33,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 2. Quel est l'avantage d'utiliser un générateur de listes par rapport à une liste de listes lors de l'utilisation de <code>train_new_from_iterator()</code> ?
+### 2. Quel est l'avantage d'utiliser un générateur de listes par rapport à une liste de listes lors de l'utilisation de `train_new_from_iterator()` ?
 
 <Question
 	choices={[

--- a/chapters/fr/chapter6/10.mdx
+++ b/chapters/fr/chapter6/10.mdx
@@ -9,7 +9,7 @@
 
 Testons ce que vous avez appris dans ce chapitre !
 
-### 1. Quand devez-vous entraîner un nouveau <i>tokenizer</i> ?
+### 1. Quand devez-vous entraîner un nouveau tokenizer ?
 
 <Question
 	choices={[
@@ -57,7 +57,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 3. Quels sont les avantages d'utiliser un <i>tokenizer</i> « rapide » ?
+### 3. Quels sont les avantages d'utiliser un tokenizer « rapide » ?
 
 <Question
 	choices={[
@@ -82,7 +82,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 4. Comment le pipeline `token-classification` gère-t-il les entités qui s'étendent sur plusieurs <i>tokens</i> ?
+### 4. Comment le pipeline `token-classification` gère-t-il les entités qui s'étendent sur plusieurs tokens ?
 
 <Question
 	choices={[
@@ -156,7 +156,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 7. Qu'est-ce que la pré-tokénisation pour un <i>tokenizer</i> en sous-mots ?
+### 7. Qu'est-ce que la pré-tokénisation pour un tokenizer en sous-mots ?
 
 <Question
 	choices={[
@@ -180,7 +180,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 8. Sélectionnez les phrases qui s'appliquent au <i>tokenizer</i> BPE.
+### 8. Sélectionnez les phrases qui s'appliquent au tokenizer BPE.
 
 <Question
 	choices={[
@@ -214,7 +214,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 9. Sélectionnez les phrases qui s'appliquent au <i>tokenizer</i> WordPiece.
+### 9. Sélectionnez les phrases qui s'appliquent au tokenizer WordPiece.
 
 <Question
 	choices={[
@@ -248,7 +248,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 10. Sélectionnez les phrases qui s'appliquent au <i>tokenizer</i> Unigram.
+### 10. Sélectionnez les phrases qui s'appliquent au tokenizer Unigram.
 
 <Question
 	choices={[

--- a/chapters/fr/chapter6/2.mdx
+++ b/chapters/fr/chapter6/2.mdx
@@ -1,4 +1,4 @@
-# Entraîner un nouveau <i>tokenizer</i> à partir d'un ancien
+# Entraîner un nouveau tokenizer à partir d'un ancien
 
 <CourseFloatingBanner chapter={6}
   classNames="absolute z-10 right-0 top-0"
@@ -131,7 +131,7 @@ def get_training_corpus():
 qui produit exactement le même générateur que précédemment mais  permet d'utiliser une logique plus complexe que celle que vous pouvez utiliser dans une compréhension de liste.
 
 
-## Entraînement d'un nouveau <i>tokenizer</i>
+## Entraînement d'un nouveau tokenizer
 
 Maintenant que nous avons notre corpus sous la forme d'un itérateur de batchs de textes, nous sommes prêts à entraîner un nouveau *tokenizer*. Pour ce faire, nous devons d'abord charger le *tokenizer* que nous voulons coupler avec notre modèle (ici, le GPT-2) :
 
@@ -224,7 +224,7 @@ tokenizer.tokenize(example)
 
 En plus du *token* correspondant à une indentation, on peut également voir ici un *token* pour une double indentation : `ĊĠĠĠĠĠĠĠĠĠ`. Les mots spéciaux de Python comme `class`, `init`, `call`, `self`, et `return` sont tous tokenizés comme un seul *token*. Nous pouvons voir qu'en plus de séparer sur `_` et `.` le tokenizer sépare correctement même les noms en minuscules. Par exemple `LinearLayer` est tokenisé comme `["ĠLinear", "Layer"]`.
 
-## Sauvegarde du <i>tokenizer</i>
+## Sauvegarde du tokenizer
 
 Pour être sûr de pouvoir l'utiliser plus tard, nous devons sauvegarder notre nouveau *tokenizer*. Comme pour les modèles, ceci est fait avec la méthode `save_pretrained()` :
 

--- a/chapters/fr/chapter6/3.mdx
+++ b/chapters/fr/chapter6/3.mdx
@@ -1,6 +1,6 @@
 <FrameworkSwitchCourse {fw} />
 
-# Pouvoirs spéciaux des <i>tokenizers</i> rapides
+# Pouvoirs spéciaux des tokenizers rapides
 
 {#if fw === 'pt'}
 
@@ -40,7 +40,7 @@ Dans la discussion qui suit, nous ferons souvent la distinction entre les *token
 > [!WARNING]
 > ⚠️ Lors de la tokenisation d'une seule phrase, vous ne verrez pas toujours une différence de vitesse entre les versions lente et rapide d'un même *tokenizer*. En fait, la version rapide peut même être plus lente ! Ce n'est que lorsque vous tokenisez beaucoup de textes en parallèle et en même temps que vous pourrez clairement voir la différence.
 
-## L'objet <i>BatchEncoding</i>
+## L'objet BatchEncoding
 
 <Youtube id="3umI3tm27Vw"/>
 

--- a/chapters/fr/chapter6/3b.mdx
+++ b/chapters/fr/chapter6/3b.mdx
@@ -1,6 +1,6 @@
 <FrameworkSwitchCourse {fw} />
 
-# <i>Tokenizer</i> rapide dans le pipeline de QA
+# Tokenizer rapide dans le pipeline de QA
 
 {#if fw === 'pt'}
 

--- a/chapters/fr/chapter6/5.mdx
+++ b/chapters/fr/chapter6/5.mdx
@@ -1,4 +1,4 @@
-# Tokénisation <i>Byte-Pair Encoding</i>
+# Tokénisation Byte-Pair Encoding
 
 <CourseFloatingBanner chapter={6}
   classNames="absolute z-10 right-0 top-0"

--- a/chapters/fr/chapter6/6.mdx
+++ b/chapters/fr/chapter6/6.mdx
@@ -1,4 +1,4 @@
-# Tokénisation <i>WordPiece</i>
+# Tokénisation WordPiece
 
 <CourseFloatingBanner chapter={6}
   classNames="absolute z-10 right-0 top-0"
@@ -88,7 +88,7 @@ Lorsque la tokenisation arrive à un stade où il n'est pas possible de trouver 
 > [!TIP]
 > ✏️ **A votre tour !** Comment le mot `"pugs"` sera-t-il tokenisé ?
 
-## Implémentation de <i>WordPiece</i>
+## Implémentation de WordPiece
 
 Voyons maintenant une implémentation de l'algorithme *WordPiece*. Comme pour le BPE, il s'agit d'un exemple pédagogique et vous ne pourrez pas l'utiliser sur un grand corpus.
 

--- a/chapters/fr/chapter6/7.mdx
+++ b/chapters/fr/chapter6/7.mdx
@@ -1,4 +1,4 @@
-# Tokenisation <i>Unigram</i>
+# Tokenisation Unigram
 
 <CourseFloatingBanner chapter={6}
   classNames="absolute z-10 right-0 top-0"
@@ -142,7 +142,7 @@ Ces changements entraîneront une augmentation de la perte de :
 
 Par conséquent, le token `"pu"` sera probablement retiré du vocabulaire, mais pas `"hug"`.
 
-## Implémentation d'<i>Unigram</i>
+## Implémentation d'Unigram
 
 Maintenant, implémentons tout ce que nous avons vu jusqu'à présent dans le code. Comme pour le BPE et *WordPiece*, ce n'est pas une implémentation efficace de l'algorithme *Unigram* (bien au contraire), mais elle devrait vous aider à le comprendre un peu mieux.
 

--- a/chapters/fr/chapter6/8.mdx
+++ b/chapters/fr/chapter6/8.mdx
@@ -1,4 +1,4 @@
-# Construction d'un <i>tokenizer</i>, bloc par bloc
+# Construction d'un tokenizer, bloc par bloc
 
 
 <CourseFloatingBanner chapter={6}
@@ -67,7 +67,7 @@ with open("wikitext-2.txt", "w", encoding="utf-8") as f:
 
 Ensuite, nous vous montrerons comment construire vos propres *tokenizers* pour BERT, GPT-2 et XLNet, bloc par bloc. Cela vous donnera un exemple de chacun des trois principaux algorithmes de tokenisation : *WordPiece*, BPE et *Unigram*. Commençons par BERT !
 
-## Construire un <i>tokenizer WordPiece</i> à partir de zéro
+## Construire un tokenizer WordPiece à partir de zéro
 
 Pour construire un *tokenizer* avec la bibliothèque 🤗 *Tokenizers*, nous commençons par instancier un objet `Tokenizer` avec un `model`. Puis nous définissons ses attributs `normalizer`, `pre_tokenizer`, `post_processor` et `decoder` aux valeurs que nous voulons.
 
@@ -310,7 +310,7 @@ Vous pouvez ensuite utiliser ce *tokenizer* comme n'importe quel autre *tokenize
 
 Maintenant que nous avons vu comment construire un *tokenizer WordPiece*, faisons de même pour un *tokenizer* BPE. Nous irons un peu plus vite puisque vous connaissez toutes les étapes. Nous ne soulignerons que les différences.
 
-## Construire un <i>tokenizer</i> BPE à partir de zéro
+## Construire un tokenizer BPE à partir de zéro
 
 Construisons maintenant un *tokenizer* BPE. Comme pour le *tokenizer* BERT, nous commençons par initialiser un `Tokenizer` avec un modèle BPE :
 
@@ -421,7 +421,7 @@ wrapped_tokenizer = GPT2TokenizerFast(tokenizer_object=tokenizer)
 
 Comme dernier exemple, nous allons vous montrer comment construire un *tokenizer* *Unigram* à partir de zéro.
 
-## Construire un <i>tokenizer Unigram</i> à partir de zéro
+## Construire un tokenizer Unigram à partir de zéro
 
 Construisons maintenant un *tokenizer* XLNet. Comme pour les *tokenizers* précédents, nous commençons par initialiser un `Tokenizer` avec un modèle *Unigram* :
 

--- a/chapters/fr/chapter6/9.mdx
+++ b/chapters/fr/chapter6/9.mdx
@@ -1,4 +1,4 @@
-# <i>Tokenizer</i>, coché !
+# Tokenizer, coché !
 
 <CourseFloatingBanner
     chapter={6}

--- a/chapters/fr/chapter7/2.mdx
+++ b/chapters/fr/chapter7/2.mdx
@@ -1,6 +1,6 @@
 <FrameworkSwitchCourse {fw} />
 
-# Classification de <i>tokens</i>
+# Classification de tokens
 
 {#if fw === 'pt'}
 <CourseFloatingBanner chapter={7}
@@ -297,13 +297,13 @@ Nous avons fait la partie la plus difficile ! Maintenant que les données ont é
 
 {#if fw === 'pt'}
 
-## <i>Finetuning</i> du modèle avec l'API `Trainer`
+## Finetuning du modèle avec l'API `Trainer`
 
 Le code utilisant `Trainer` sera le même que précédemment. Les seuls changements sont la façon dont les données sont rassemblées dans un batch ainsi que la fonction de calcul de la métrique.
 
 {:else}
 
-## <i>Finetuning</i> du modèle avec Keras
+## Finetuning du modèle avec Keras
 
 Le code utilisant Keras sera très similaire au précédent. Les seuls changements sont la façon dont les données sont rassemblées dans un batch ainsi que la fonction de calcul de la métrique.
 
@@ -427,7 +427,7 @@ model.config.num_labels
 > [!WARNING]
 > ⚠️ Si vous avez un modèle avec le mauvais nombre d'étiquettes, vous obtiendrez plus tard une erreur obscure lors de l'appel de `model.fit()`. Cela peut être ennuyeux à déboguer donc assurez-vous de faire cette vérification pour confirmer que vous avez le nombre d'étiquettes attendu.
 
-### <i>Finetuning</i> du modèle
+### Finetuning du modèle
 
 Nous sommes maintenant prêts à entraîner notre modèle ! Mais nous devons d'abord faire un peu de ménage : nous devons nous connecter à Hugging Face et définir nos hyperparamètres d'entraînement. Si vous travaillez dans un *notebook*, il y a une fonction pratique pour vous aider à le faire :
 
@@ -671,7 +671,7 @@ model.config.num_labels
 > [!WARNING]
 > ⚠️ Si vous avez un modèle avec le mauvais nombre d'étiquettes, vous obtiendrez une erreur obscure lors de l'appel de la méthode `Trainer.train()` (quelque chose comme "CUDA error : device-side assert triggered"). C'est la première cause de bogues signalés par les utilisateurs pour de telles erreurs, donc assurez-vous de faire cette vérification pour confirmer que vous avez le nombre d'étiquettes attendu.
 
-### <i>Finetuning</i> du modèle
+### Finetuning du modèle
 
 Nous sommes maintenant prêts à entraîner notre modèle ! Nous devons juste faire deux dernières choses avant de définir notre `Trainer` : se connecter à Hugging Face et définir nos arguments d'entraînement. Si vous travaillez dans un *notebook*, il y a une fonction pratique pour vous aider à le faire :
 
@@ -937,7 +937,7 @@ Une fois ceci fait, vous devriez avoir un modèle qui produit des résultats ass
 
 {/if}
 
-### Utilisation du modèle <i>finetuné</i>
+### Utilisation du modèle finetuné
 
 Nous vous avons déjà montré comment vous pouvez utiliser le modèle *finetuné* sur le *Hub* avec le *widget* d'inférence. Pour l'utiliser localement dans un `pipeline`, vous devez juste spécifier l'identifiant de modèle approprié :
 

--- a/chapters/fr/chapter7/3.mdx
+++ b/chapters/fr/chapter7/3.mdx
@@ -1,6 +1,6 @@
 <FrameworkSwitchCourse {fw} />
 
-# <i>Finetuner</i> un modèle de langage masqué
+# Finetuner un modèle de langage masqué
 
 {#if fw === 'pt'}
 <CourseFloatingBanner chapter={7}
@@ -436,7 +436,7 @@ tokenizer.decode(lm_datasets["train"][1]["labels"])
 
 Comme prévu par notre fonction `group_texts()` ci-dessus, cela semble identique aux `input_ids` décodés. Mais alors comment notre modèle peut-il apprendre quoi que ce soit ? Il nous manque une étape clé : insérer des *tokens* à des positions aléatoires dans les entrées ! Voyons comment nous pouvons le faire à la volée pendant le *finetuning* en utilisant un assembleur de données spécial.
 
-## <i>Finetuning</i> de DistilBERT avec l'API `Trainer`
+## Finetuning de DistilBERT avec l'API `Trainer`
 
 Le *finetuning* d'un modèle de langage masqué est presque identique au *finetuning* d'un modèle de classification de séquences, comme nous l'avons fait dans le [chapitre 3](/course/fr/chapter3). La seule différence est que nous avons besoin d'un collecteur de données spécial qui peut masquer de manière aléatoire certains des *tokens* dans chaque batch de textes. Heureusement, 🤗 *Transformers* est livré préparé avec un `DataCollatorForLanguageModeling` dédié à cette tâche. Nous devons juste lui passer le *tokenizer* et un argument `mlm_probability` qui spécifie quelle fraction des *tokens* à masquer. Nous choisirons 15%, qui est la quantité utilisée pour BERT et un choix commun dans la littérature :
 
@@ -809,7 +809,7 @@ trainer.push_to_hub()
 
 Dans notre cas d'utilisation, nous n'avons pas eu besoin de faire quelque chose de spécial avec la boucle d'entraînement, mais dans certains cas, vous pourriez avoir besoin de mettre en œuvre une logique personnalisée. Pour ces applications, vous pouvez utiliser 🤗 *Accelerate*. Jetons un coup d'œil !
 
-## <i>Finetuning</i> de DistilBERT avec 🤗 <i>Accelerate</i>
+## Finetuning de DistilBERT avec 🤗 Accelerate
 
 Comme nous l'avons vu, avec `Trainer` le *finetuning* d'un modèle de langage masqué est très similaire à l'exemple de classification de texte du [chapitre 3](/course/fr/chapter3). En fait, la seule subtilité est l'utilisation d'un assembleur de données spécial, et nous l'avons déjà couvert plus tôt dans cette section ! 
 
@@ -986,7 +986,7 @@ Cool, nous avons été en mesure d'évaluer la perplexité à chaque époque et 
 
 {/if}
 
-### Utilisation de notre modèle <i>finetuné</i>
+### Utilisation de notre modèle finetuné
 
 Vous pouvez interagir avec votre modèle *finetuné* soit en utilisant son *widget* sur le *Hub*, soit localement avec le `pipeline` de 🤗 *Transformers*. Utilisons ce dernier pour télécharger notre modèle en utilisant le pipeline `fill-mask` :
 

--- a/chapters/fr/chapter7/4.mdx
+++ b/chapters/fr/chapter7/4.mdx
@@ -263,7 +263,7 @@ Maintenant que les données ont été prétraitées, nous sommes prêts à *fine
 
 {#if fw === 'pt'}
 
-## <i>Finetuner</i> le modèle avec l'API `Trainer`
+## Finetuner le modèle avec l'API `Trainer`
 
 Le code actuel utilisant `Trainer` sera le même que précédemment, avec juste un petit changement : nous utilisons ici [`Seq2SeqTrainer`](https://huggingface.co/transformers/main_classes/trainer.html#seq2seqtrainer) qui est une sous-classe de `Trainer` qui nous permet de traiter correctement l'évaluation, en utilisant la méthode `generate()` pour prédire les sorties à partir des entrées. Nous y reviendrons plus en détail lorsque nous parlerons du calcul de la métrique.
 
@@ -277,7 +277,7 @@ model = AutoModelForSeq2SeqLM.from_pretrained(model_checkpoint)
 
 {:else}
 
-## <i>Finetuner</i> du modèle avec Keras
+## Finetuner du modèle avec Keras
 
 Tout d'abord, nous avons besoin d'un modèle à *finetuner*. Nous allons utiliser l'API habituelle `AutoModel` :
 
@@ -575,7 +575,7 @@ def compute_metrics(eval_preds):
 Maintenant que c'est fait, nous sommes prêts à *finetuner* notre modèle !
 
 
-### <i>Finetuner</i> le modèle
+### Finetuner le modèle
 
 La première étape consiste à se connecter à Hugging Face, afin de pouvoir télécharger vos résultats sur le *Hub*. Il y a une fonction pratique pour vous aider à le faire dans un *notebook* :
 
@@ -958,7 +958,7 @@ Une fois que c'est fait, vous devriez avoir un modèle qui a des résultats asse
 
 {/if}
 
-### Utilisation du modèle <i>finetuné</i>
+### Utilisation du modèle finetuné
 
 Nous vous avons déjà montré comment vous pouvez utiliser le modèle que nous avons *finetuné* sur le *Hub* avec le *widget* d'inférence. Pour l'utiliser localement dans un `pipeline`, nous devons juste spécifier l'identifiant de modèle approprié :
 

--- a/chapters/fr/chapter7/5.mdx
+++ b/chapters/fr/chapter7/5.mdx
@@ -464,7 +464,7 @@ Nous pouvons voir que le score de `rouge2` est significativement plus bas que le
 
 {#if fw === 'pt'}
 
-## <i>Finetuning</i> de mT5 avec l'API `Trainer`
+## Finetuning de mT5 avec l'API `Trainer`
 
 Le *finetuning* d'un modèle pour le résumé est très similaire aux autres tâches que nous avons couvertes dans ce chapitre. La première chose à faire est de charger le modèle pré-entraîné à partir du *checkpoint* `mt5-small`. Puisque la compression est une tâche de séquence à séquence, nous pouvons charger le modèle avec la classe `AutoModelForSeq2SeqLM`, qui téléchargera automatiquement et mettra en cache les poids :
 
@@ -476,7 +476,7 @@ model = AutoModelForSeq2SeqLM.from_pretrained(model_checkpoint)
 
 {:else}
 
-## <i>Finetuning</i> de mT5 avec Keras
+## Finetuning de mT5 avec Keras
 
 Le *finetuning* d'un modèle pour le résumé est très similaire aux autres tâches que nous avons couvertes dans ce chapitre. La première chose à faire est de charger le modèle pré-entraîné à partir du *checkpoint* `mt5-small`. Puisque la compression est une tâche de séquence à séquence, nous pouvons charger le modèle avec la classe `TFAutoModelForSeq2SeqLM`, qui téléchargera automatiquement et mettra en cache les poids :
 
@@ -796,7 +796,7 @@ result = {key: value.mid.fmeasure * 100 for key, value in result.items()}
 
 {#if fw === 'pt'}
 
-## <i>Finetuning</i> de mT5 avec 🤗 <i>Accelerate</i>
+## Finetuning de mT5 avec 🤗 Accelerate
 
 Le *finetuning* de notre modèle avec 🤗 *Accelerate* est très similaire à l'exemple de classification de texte que nous avons rencontré dans le [chapitre 3](/course/fr/chapter3). Les principales différences seront la nécessité de générer explicitement nos résumés pendant l'entraînement et de définir comment nous calculons les scores ROUGE (rappelons que le `Seq2SeqTrainer` s'est occupé de la génération pour nous). Voyons comment nous pouvons mettre en œuvre ces deux exigences dans 🤗 *Accelerate* !
 
@@ -1020,7 +1020,7 @@ Et c'est tout ! Une fois que vous l'aurez exécuté, vous aurez un modèle et de
 
 {/if}
 
-## Utilisation de votre modèle <i>finetuné</i>
+## Utilisation de votre modèle finetuné
 
 Une fois que vous avez poussé le modèle vers le *Hub*, vous pouvez jouer avec lui soit via le *widget* d'inférence, soit avec un objet `pipeline`, comme suit :
 

--- a/chapters/fr/chapter7/6.mdx
+++ b/chapters/fr/chapter7/6.mdx
@@ -635,7 +635,7 @@ Au vu de ces quelques exemples, il semble que le modèle ait appris une partie d
 
 {#if fw === 'pt'}
 
-## Entraîner avec 🤗 <i>Accelerate</i>
+## Entraîner avec 🤗 Accelerate
 
 Nous avons vu comment entraîner un modèle avec le `Trainer`, qui permet une certaine personnalisation. Cependant, parfois nous voulons un contrôle total sur la boucle d'entraînement ou nous souhaitons faire quelques changements exotiques. Dans ce cas, 🤗 *Accelerate* est un excellent choix, et dans cette section, nous allons suivre les étapes pour l'utiliser pour entraîner notre modèle. Pour rendre les choses plus intéressantes, nous allons également ajouter une touche à la boucle d'entraînement.
 

--- a/chapters/fr/chapter7/7.mdx
+++ b/chapters/fr/chapter7/7.mdx
@@ -520,13 +520,13 @@ Maintenant que nous avons prétraité toutes les données, nous pouvons passer �
 
 {#if fw === 'pt'}
 
-## <i>Finetuner</i> le modèle avec l'API `Trainer`
+## Finetuner le modèle avec l'API `Trainer`
 
 Le code d'entraînement pour cet exemple ressemblera beaucoup au code des sections précédentes mais le calcul de la métrique avec la fonction `compute_metrics()` sera un défi unique. Puisque nous avons rembourré tous les échantillons à la longueur maximale que nous avons définie, il n'y a pas d'assembleur de données à définir. Ainsi le calcul de la métrique est vraiment la seule chose dont nous devons nous soucier. La partie la plus difficile sera de post-traiter les prédictions du modèle en étendues de texte dans les exemples originaux. Une fois que nous aurons fait cela, la métrique de la bibliothèque 🤗 *Datasets* fera le gros du travail pour nous.
 
 {:else}
 
-## <i>Finetuner</i> fin du modèle avec Keras
+## Finetuner fin du modèle avec Keras
 
 Le code d'entraînement de cet exemple ressemblera beaucoup au code des sections précédentes, mais le calcul de la métrique sera un défi unique. Puisque nous avons rembourré tous les échantillons à la longueur maximale que nous avons définie, il n'y a pas d'assembleur de données à définir. Ainsi le calcul de la métrique est vraiment la seule chose dont nous devons nous soucier. La partie la plus difficile sera de post-traiter les prédictions du modèle en étendues de texte dans les exemples originaux. Une fois que nous aurons fait cela, la métrique de la bibliothèque 🤗 *Datasets* fera le gros du travail pour nous.
 
@@ -803,7 +803,7 @@ compute_metrics(start_logits, end_logits, eval_set, small_eval_set)
 
 C'est bien ! Maintenant, utilisons ceci pour *finetuner* notre modèle.
 
-### <i>Finetuning</i> du modèle
+### Finetuning du modèle
 
 {#if fw === 'pt'}
 
@@ -1183,7 +1183,7 @@ Une fois ceci fait, vous devriez avoir un modèle qui produit des résultats ass
 
 {/if}
 
-### Utilisation du modèle <i>finetuné</i>
+### Utilisation du modèle finetuné
 
 Nous vous avons déjà montré comment vous pouvez utiliser le modèle que nous avons *finetuné* sur le *Hub* avec le *widget* d'inférence. Pour l'utiliser localement dans un `pipeline`, il suffit de spécifier l'identifiant du modèle :
 

--- a/chapters/fr/chapter7/8.mdx
+++ b/chapters/fr/chapter7/8.mdx
@@ -1,4 +1,4 @@
-# Maîtriser le <i>NLP</i>
+# Maîtriser le NLP
 
 <CourseFloatingBanner
     chapter={7}

--- a/chapters/fr/chapter7/9.mdx
+++ b/chapters/fr/chapter7/9.mdx
@@ -182,7 +182,7 @@ Testons ce que vous avez appris dans ce chapitre !
 
 {#if fw === 'pt'}
 
-### 8. Pourquoi existe-t-il une sous-classe spécifique de <code>Trainer</code> pour les problèmes de séquence à séquence ?
+### 8. Pourquoi existe-t-il une sous-classe spécifique de `Trainer` pour les problèmes de séquence à séquence ?
 
 <Question
 	choices={[
@@ -208,7 +208,7 @@ Testons ce que vous avez appris dans ce chapitre !
 
 {:else}
 
-### 9. Pourquoi est-il souvent inutile de spécifier une perte quand on appelle <code>compile()</code> sur un transformer ?
+### 9. Pourquoi est-il souvent inutile de spécifier une perte quand on appelle `compile()` sur un transformer ?
 
 <Question
 	choices={[

--- a/chapters/fr/chapter7/9.mdx
+++ b/chapters/fr/chapter7/9.mdx
@@ -11,7 +11,7 @@
 
 Testons ce que vous avez appris dans ce chapitre !
 
-### 1. Laquelle des tâches suivantes peut être considérée comme un problème de classification de <i>tokens</i> ?
+### 1. Laquelle des tâches suivantes peut être considérée comme un problème de classification de tokens ?
 
 <Question
 	choices={[
@@ -36,7 +36,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 2. Quelle partie du prétraitement pour la classification de <i>tokens</i> diffère des autres pipelines de prétraitement ?
+### 2. Quelle partie du prétraitement pour la classification de tokens diffère des autres pipelines de prétraitement ?
 
 <Question
 	choices={[
@@ -61,7 +61,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 3. Quel problème se pose lorsque nous tokenisons les mots dans un problème de classification de <i>tokens</i> et que nous voulons étiqueter les <i>tokens</i> ?
+### 3. Quel problème se pose lorsque nous tokenisons les mots dans un problème de classification de tokens et que nous voulons étiqueter les tokens ?
 
 <Question
 	choices={[
@@ -208,7 +208,7 @@ Testons ce que vous avez appris dans ce chapitre !
 
 {:else}
 
-### 9. Pourquoi est-il souvent inutile de spécifier une perte quand on appelle <code>compile()</code> sur un <i>transformer</i> ?
+### 9. Pourquoi est-il souvent inutile de spécifier une perte quand on appelle <code>compile()</code> sur un transformer ?
 
 <Question
 	choices={[

--- a/chapters/fr/chapter8/2.mdx
+++ b/chapters/fr/chapter8/2.mdx
@@ -54,7 +54,7 @@ def copy_repository_template():
 
 Maintenant, lorsque vous appelez `copy_repository_template()`, cela va créer une copie du gabarit du dépôt sous votre compte.
 
-## Déboguer le pipeline à partir de 🤗 <i>Transformers</i>
+## Déboguer le pipeline à partir de 🤗 Transformers
 
 Pour donner le coup d'envoi de notre voyage dans le monde merveilleux du débogage de *transformers*, considérez le scénario suivant : vous travaillez avec un collègue sur un projet de réponse à des questions pour aider les clients d'un site de commerce en ligne à trouver des réponses à des produits. Votre collègue vous envoie un message du genre :
 

--- a/chapters/fr/chapter8/3.mdx
+++ b/chapters/fr/chapter8/3.mdx
@@ -186,7 +186,7 @@ La lecture du code source est déjà difficile dans un IDE, mais c'est encore pl
 
 Comme vous pouvez le voir dans la capture d'écran, le fait d'entourer les blocs de code de *backticks* convertit le texte brut en code formaté, avec un style de couleur ! Notez également que des *backticks* simples peuvent être utilisés pour formater des variables en ligne comme nous l'avons fait pour `distilbert-base-uncased`. Ce sujet a l'air bien meilleur, et avec un peu de chance, nous pourrions trouver quelqu'un dans la communauté qui pourrait deviner à quoi correspond l'erreur. Cependant, au lieu de compter sur la chance, rendons la vie plus facile en incluant le *traceback* dans ses moindres détails !
 
-### Inclure le <i>traceback</i> complet
+### Inclure le traceback complet
 
 Puisque la dernière ligne de le *traceback* est souvent suffisante pour déboguer votre propre code, il peut être tentant de ne fournir que cela dans votre sujet pour "gagner de la place". Bien que bien intentionné, cela rend en fait le débogage du problème _plus difficile_ pour les autres, car les informations situées plus haut dans le *traceback* peuvent également être très utiles. Une bonne pratique consiste donc à copier et coller le *traceback* _entier_, en veillant à ce qu'elle soit bien formatée. Comme ces tracebacks peuvent être assez longs, certaines personnes préfèrent les montrer après avoir expliqué le code source. C'est ce que nous allons faire. Maintenant, notre sujet de forum ressemble à ce qui suit :
 

--- a/chapters/fr/chapter8/4.mdx
+++ b/chapters/fr/chapter8/4.mdx
@@ -516,7 +516,7 @@ trainer.optimizer.step()
 
 Encore une fois, si vous utilisez l'optimiseur par défaut dans le `Trainer`, vous ne devriez pas avoir d'erreur à ce stade, mais si vous avez un optimiseur personnalisé, il pourrait y avoir quelques problèmes à déboguer ici. N'oubliez pas de revenir au CPU si vous obtenez une erreur CUDA bizarre à ce stade. En parlant d'erreurs CUDA, nous avons mentionné précédemment un cas particulier. Voyons cela maintenant.
 
-### Gérer les erreurs <i>CUDA out of memory</i>
+### Gérer les erreurs CUDA out of memory
 
 Chaque fois que vous obtenez un message d'erreur qui commence par `RuntimeError : CUDA out of memory`, cela indique que vous êtes à court de mémoire GPU. Cela n'est pas directement lié à votre code et peut arriver avec un script qui fonctionne parfaitement bien. Cette erreur signifie que vous avez essayé de mettre trop de choses dans la mémoire interne de votre GPU et que cela a entraîné une erreur. Comme pour d'autres erreurs CUDA, vous devrez redémarrer votre noyau pour être en mesure d'exécuter à nouveau votre entraînement.
 

--- a/chapters/fr/chapter8/5.mdx
+++ b/chapters/fr/chapter8/5.mdx
@@ -1,4 +1,4 @@
-# Comment rédiger une bonne <i>issue</i>
+# Comment rédiger une bonne issue
 
 <CourseFloatingBanner chapter={8}
   classNames="absolute z-10 right-0 top-0"

--- a/chapters/fr/chapter8/7.mdx
+++ b/chapters/fr/chapter8/7.mdx
@@ -9,7 +9,7 @@
 
 Testons ce que vous avez appris dans ce chapitre !
 
-### 1. Dans quel ordre devez-vous lire un <i>traceback</i> Python ?
+### 1. Dans quel ordre devez-vous lire un traceback Python ?
 
 <Question
 	choices={[

--- a/chapters/fr/chapter9/1.mdx
+++ b/chapters/fr/chapter9/1.mdx
@@ -1,4 +1,4 @@
-# Introduction à <i>Gradio</i>
+# Introduction à Gradio
 
 <CourseFloatingBanner
     chapter={9}

--- a/chapters/fr/chapter9/3.mdx
+++ b/chapters/fr/chapter9/3.mdx
@@ -1,4 +1,4 @@
-# Comprendre la classe <i>Interface</i>
+# Comprendre la classe Interface
 
 <CourseFloatingBanner chapter={9}
   classNames="absolute z-10 right-0 top-0"

--- a/chapters/fr/chapter9/4.mdx
+++ b/chapters/fr/chapter9/4.mdx
@@ -13,7 +13,7 @@ Maintenant que vous avez construit une démo, vous voudrez probablement la parta
 
 Nous aborderons ces deux approches sous peu. Mais avant de partager votre démo, vous voudrez peut-être la peaufiner 💅.
 
-### Polir votre démo <i>Gradio</i>
+### Polir votre démo Gradio
 
 <div class="flex justify-center">
 <img class="block dark:hidden" src="https://huggingface.co/datasets/huggingface-course/documentation-images/resolve/main/en/chapter9/gradio-demo-overview.png" alt="Overview of a gradio interface">
@@ -69,7 +69,7 @@ Cela génère un lien public et partageable que vous pouvez envoyer à n'importe
 
 Gardez cependant à l'esprit que ces liens sont accessibles au public, ce qui signifie que n'importe qui peut utiliser votre modèle pour la prédiction ! Par conséquent, assurez-vous de ne pas exposer d'informations sensibles à travers les fonctions que vous écrivez, ou de permettre que des changements critiques se produisent sur votre appareil. Si vous définissez `share=False` (la valeur par défaut), seul un lien local est créé.
 
-### Hébergement de votre démo sur <i>Hugging Face Spaces</i>
+### Hébergement de votre démo sur Hugging Face Spaces
 
 Un lien de partage que vous pouvez passer à vos collègues est cool, mais comment pouvez-vous héberger de façon permanente votre démo et la faire exister dans son propre « espace » sur internet ?
 

--- a/chapters/fr/chapter9/5.mdx
+++ b/chapters/fr/chapter9/5.mdx
@@ -1,4 +1,4 @@
-# Intégrations avec le <i>Hub d'Hugging Face</i>
+# Intégrations avec le Hub d'Hugging Face
 
 <CourseFloatingBanner chapter={9}
   classNames="absolute z-10 right-0 top-0"
@@ -12,7 +12,7 @@
 Pour vous rendre la vie encore plus facile, *Gradio* s'intègre directement avec *Hub* et *Spaces*.
 Vous pouvez charger des démos depuis le *Hub* et les *Spaces* avec seulement *une ligne de code*.
 
-### Chargement de modèles depuis le <i>Hub d'Hugging Face</i>
+### Chargement de modèles depuis le Hub d'Hugging Face
 
 Pour commencer, choisissez un des milliers de modèles qu'*Hugging Face* offre à travers le *Hub*, comme décrit dans le [chapitre 4](/course/fr/chapter4/2).
 
@@ -52,7 +52,7 @@ Le code ci-dessus produira l'interface ci-dessous :
 
 Le chargement d'un modèle de cette manière utilise l'[API d'Inference](https://huggingface.co/inference-api) de *Hugging Face* au lieu de charger le modèle en mémoire. C'est idéal pour les modèles énormes comme GPT-J ou T0pp qui nécessitent beaucoup de RAM.
 
-### Chargement depuis <i>Hugging Face Spaces</i>
+### Chargement depuis Hugging Face Spaces
 
 Pour charger n'importe quel *Space* depuis le *Hub* et le recréer localement, vous pouvez passer `spaces/` à l'`Interface`, suivi du nom du *Space*.
 

--- a/chapters/fr/chapter9/7.mdx
+++ b/chapters/fr/chapter9/7.mdx
@@ -1,4 +1,4 @@
-# Introduction à la classe <i>Blocks</i>
+# Introduction à la classe Blocks
 
 <CourseFloatingBanner chapter={9}
   classNames="absolute z-10 right-0 top-0"
@@ -18,7 +18,7 @@ Quelle est la différence entre `Interface` et `Blocks` ?
 - 🧱 `Blocks` : une API de bas niveau qui vous permet d'avoir un contrôle total sur les flux de données et la disposition de votre application. Vous pouvez construire des applications très complexes, en plusieurs étapes, en utilisant `Blocks`.
 
 
-### Pourquoi <i>Blocks</i> 🧱 ?
+### Pourquoi Blocks 🧱 ?
 
 Comme nous l'avons vu dans les sections précédentes, la classe `Interface` vous permet de créer facilement des démos d'apprentissage automatique à part entière avec seulement quelques lignes de code. L'API `Interface` est extrêmement facile à utiliser, mais elle n'a pas la flexibilité qu'offre l'API `Blocks`. Par exemple, vous pourriez vouloir :
 
@@ -29,7 +29,7 @@ Comme nous l'avons vu dans les sections précédentes, la classe `Interface` vou
 
 Nous allons explorer tous ces concepts ci-dessous.
 
-### Création d'une démo simple en utilisant <i>Blocks</i>
+### Création d'une démo simple en utilisant Blocks
 
 Après avoir installé *Gradio*, exécutez le code ci-dessous sous forme de script Python, de *notebook* Jupyter ou de *notebook* Colab.
 

--- a/chapters/fr/chapter9/8.mdx
+++ b/chapters/fr/chapter9/8.mdx
@@ -1,4 +1,4 @@
-# <i>Gradio</i>, coché !
+# Gradio, coché !
 
 <CourseFloatingBanner
     chapter={9}

--- a/chapters/fr/chapter9/9.mdx
+++ b/chapters/fr/chapter9/9.mdx
@@ -221,7 +221,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 10. Vous pouvez partager un lien public vers une démo <code>Blocks</code> et accueillir une démo <code>Blocks</code> sur Space
+### 10. Vous pouvez partager un lien public vers une démo `Blocks` et accueillir une démo `Blocks` sur Space
 
 <Question
 	choices={[

--- a/chapters/fr/chapter9/9.mdx
+++ b/chapters/fr/chapter9/9.mdx
@@ -9,7 +9,7 @@
 
 Testons ce que vous avez appris dans ce chapitre !
 
-### 1. Que pouvez-vous faire avec <i>Gradio</i> ?
+### 1. Que pouvez-vous faire avec Gradio ?
 
 <Question
 	choices={[
@@ -35,7 +35,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 2. <i>Gradio</i> fonctionne UNIQUEMENT avec les modèles en PyTorch
+### 2. Gradio fonctionne UNIQUEMENT avec les modèles en PyTorch
 
 <Question
 	choices={[
@@ -51,7 +51,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 3. D'où pouvez-vous lancer une démo <i>Gradio</i> ?
+### 3. D'où pouvez-vous lancer une démo Gradio ?
 
 <Question
 	choices={[
@@ -73,7 +73,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 4. <i>Gradio</i> est conçu principalement pour les modèles de NLP
+### 4. Gradio est conçu principalement pour les modèles de NLP
 
 <Question
 	choices={[
@@ -89,7 +89,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 5. Parmi les fonctionnalités suivantes, lesquelles sont prises en charge par <i>Gradio</i> ?
+### 5. Parmi les fonctionnalités suivantes, lesquelles sont prises en charge par Gradio ?
 
 <Question
 	choices={[
@@ -120,7 +120,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 6. Lesquelles des méthodes suivantes sont valides pour charger un modèle à partir du <i>Hub</i> ou de <i>Space</i> ?
+### 6. Lesquelles des méthodes suivantes sont valides pour charger un modèle à partir du Hub ou de Space ?
 
 <Question
 	choices={[
@@ -146,7 +146,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 7. Sélectionnez toutes les étapes nécessaires pour ajouter un état à votre interface <i>Gradio</i>
+### 7. Sélectionnez toutes les étapes nécessaires pour ajouter un état à votre interface Gradio
 
 <Question
 	choices={[
@@ -168,7 +168,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 8. Lesquels des éléments suivants sont des composants inclus dans la bibliothèque <i>Gradio</i> ?
+### 8. Lesquels des éléments suivants sont des composants inclus dans la bibliothèque Gradio ?
 
 <Question
 	choices={[
@@ -221,7 +221,7 @@ Testons ce que vous avez appris dans ce chapitre !
 	]}
 />
 
-### 10. Vous pouvez partager un lien public vers une démo <code>Blocks</code> et accueillir une démo <code>Blocks</code> sur <i>Space</i>
+### 10. Vous pouvez partager un lien public vers une démo <code>Blocks</code> et accueillir une démo <code>Blocks</code> sur Space
 
 <Question
 	choices={[

--- a/chapters/fr/events/2.mdx
+++ b/chapters/fr/events/2.mdx
@@ -2,7 +2,7 @@
 
 Pour la sortie de la deuxième partie du cours, nous avons organisé un événement en direct consistant en deux jours de conférences suivies d’un *sprint* de *finetuning*. Si vous l'avez manqué, vous pouvez rattraper les présentations qui sont toutes listées ci-dessous !
 
-## Jour 1 : Une vue d'ensemble des <i>transformers</i> et comment les entraîner
+## Jour 1 : Une vue d'ensemble des transformers et comment les entraîner
 
 
 **Thomas Wolf :** *L'apprentissage par transfert et la naissance de la bibliothèque 🤗 Transformers*


### PR DESCRIPTION
### Problem

On the French pages, inline HTML shows up verbatim in headings. For example, chapter 6's end-of-chapter quiz displays

> ### 1. Quand devez-vous entraîner un nouveau `<i>` tokenizer `</i>` ?

7 of that quiz's 10 question titles were affected. The tags also leak into the generated anchors: `#4-comment-le-pipeline-token-classification-gère-t-il-les-entités-qui-sétendent-sur-plusieurs-i-tokens-i-`.

### Cause

`doc-builder` flattens heading text to plain text (it needs it for the sidebar, the table of contents and the anchors). Inline HTML is escaped there, so `<i>` and `<code>` are rendered as literal text.

Italics are simply not available in headings: markdown emphasis is dropped too, and it leaves a stray space next to punctuation — still visible today on headings this PR does not touch, e.g. `instruction ( prompt ) ?` in `fr/chapter1/10`.

### Fix

- `<i>x</i>` → `x` in headings: the words are kept and the tags dropped, since no emphasis can render there anyway.
- `<code>x</code>` → `` `x` `` in headings: the English source uses backticks in these exact 4 headings, and 34 other French headings already do.
- **`<i>` in body text, tip boxes and quiz answers renders correctly and is left untouched** (251 occurrences).

114 headings across 50 files. No wording changed, no line added or removed.

### Verification

Built `chapters/fr` locally with `doc-builder build --html` and compared against `main`:

| | before | after |
|---|---|---|
| escaped (visible) inline tags in the built HTML | 520 | **0** |
| real `<i>` italics in the built HTML | 135 | **135** |

`make quality` reports the same result as `main` (pre-existing failures, from a newer `black` than the one pinned in CI).
