### PR TITLE
[FR] Fix grammar and translation errors in chapter2/5

### DIFF
--- a/chapters/fr/chapter2/5.mdx
+++ b/chapters/fr/chapter2/5.mdx
@@ -92,7 +92,7 @@ InvalidArgumentError: Input to reshape is a tensor with 14 values, but the reque
 ```
 {/if}
 
-Pourquoi cela a échoué ? Nous avons suivi les étapes du pipeline de la section 2.
+Pourquoi cela a-t-il échoué ? Nous avons suivi les étapes du pipeline de la section 2.
 
 Le problème est que nous avons envoyé une seule séquence au modèle, alors que les modèles de l’API 🤗 *Transformers* attendent plusieurs phrases par défaut. Ici, nous avons essayé de faire ce que le *tokenizer* fait en coulisses lorsque nous l'avons appliqué à une `sequence`. Cependant si vous regardez de près, vous verrez qu'il n'a pas seulement converti la liste des identifiants d'entrée en un tenseur mais aussi ajouté une dimension par-dessus :
 

--- a/chapters/fr/chapter2/5.mdx
+++ b/chapters/fr/chapter2/5.mdx
@@ -94,7 +94,7 @@ InvalidArgumentError: Input to reshape is a tensor with 14 values, but the reque
 
 Pourquoi cela a échoué ? Nous avons suivi les étapes du pipeline de la section 2.
 
-Le problème est que nous avons envoyé une seule séquence au modèle, alors que les modèles de l’API 🤗 *Transformers* attendent plusieurs phrases par défaut. Ici, nous avons essayé de faire ce que le *tokenizer* fait en coulisses lorsque nous l'avons appliqué à une `séquence`. Cependant si vous regardez de près, vous verrez qu'il n'a pas seulement converti la liste des identifiants d'entrée en un tenseur mais aussi ajouté une dimension par-dessus :
+Le problème est que nous avons envoyé une seule séquence au modèle, alors que les modèles de l’API 🤗 *Transformers* attendent plusieurs phrases par défaut. Ici, nous avons essayé de faire ce que le *tokenizer* fait en coulisses lorsque nous l'avons appliqué à une `sequence`. Cependant si vous regardez de près, vous verrez qu'il n'a pas seulement converti la liste des identifiants d'entrée en un tenseur mais aussi ajouté une dimension par-dessus :
 
 
 {#if fw === 'pt'}

--- a/chapters/fr/chapter2/5.mdx
+++ b/chapters/fr/chapter2/5.mdx
@@ -337,7 +337,7 @@ Remarquez comment la dernière valeur de la deuxième séquence est un identifia
 
 ## Séquences plus longues
 
-Les *transformers* acceptent en entrée que des séquences d’une longueur limitée. La plupart des modèles traitent des séquences allant jusqu'à 512 ou 1024 *tokens* et plantent lorsqu'on leur demande de traiter des séquences plus longues. Il existe deux solutions à ce problème :
+Les *transformers* n'acceptent en entrée que des séquences d’une longueur limitée. La plupart des modèles traitent des séquences allant jusqu'à 512 ou 1024 *tokens* et plantent lorsqu'on leur demande de traiter des séquences plus longues. Il existe deux solutions à ce problème :
 
 - utiliser un modèle avec une longueur de séquence supportée plus longue,
 - tronquer les séquences.

--- a/chapters/fr/chapter2/5.mdx
+++ b/chapters/fr/chapter2/5.mdx
@@ -37,7 +37,7 @@ Dans la section précédente, nous avons exploré le cas d'utilisation le plus s
 - comment gérer plusieurs séquences ?
 - comment gérer plusieurs séquences *de longueurs différentes* ?
 - les indices du vocabulaire sont-ils les seules entrées qui permettent à un modèle de bien fonctionner ?
-- existe-t-il une séquence trop longue ?
+- une séquence peut-elle être trop longue ?
 
 Voyons quels types de problèmes ces questions posent et comment nous pouvons les résoudre en utilisant l'API 🤗 *Transformers*.
 

--- a/chapters/fr/chapter2/5.mdx
+++ b/chapters/fr/chapter2/5.mdx
@@ -34,8 +34,8 @@
 
 Dans la section précédente, nous avons exploré le cas d'utilisation le plus simple : faire une inférence sur une seule séquence de petite longueur. Cependant, certaines questions émergent déjà :
 
-- comment gérer de plusieurs séquences ?
-- comment gérer de plusieurs séquences *de longueurs différentes* ?
+- comment gérer plusieurs séquences ?
+- comment gérer plusieurs séquences *de longueurs différentes* ?
 - les indices du vocabulaire sont-ils les seules entrées qui permettent à un modèle de bien fonctionner ?
 - existe-t-il une séquence trop longue ?
 


### PR DESCRIPTION
Six line fixes in `chapters/fr/chapter2/5.mdx`. No line added or removed, no code snippet touched.

### The intro question list

| line | before | after | why |
|---|---|---|---|
| 37 | comment gérer **de** plusieurs séquences ? | comment gérer plusieurs séquences ? | `gérer` takes a direct object, the partitive `de` is ungrammatical |
| 38 | comment gérer **de** plusieurs séquences *de longueurs différentes* ? | comment gérer plusieurs séquences *de longueurs différentes* ? | same |
| 40 | existe-t-il une séquence trop longue ? | une séquence peut-elle être trop longue ? | see below |

The third bullet ("les indices du vocabulaire sont-ils les seules entrées…") is a faithful translation and is left as is.

On line 40: the English is idiomatic — "Is there such a thing as too long a sequence?" asks whether a sequence *can* be too long. The literal French reads as "does one particular over-long sequence exist?", which is not the question the "Séquences plus longues" section goes on to answer. Worth noting that `es`, `it` and `pt` made the same literal choice, so a French reviewer may well prefer to keep it — happy to drop this one commit if so.

### Three other errors in the same file

| line | before | after | why |
|---|---|---|---|
| 340 | Les *transformers* **acceptent** en entrée que des séquences… | Les *transformers* **n'acceptent** en entrée que des séquences… | the `ne` of the restrictive `ne … que` was missing; dropping it is common in speech but incorrect in writing |
| 97 | appliqué à une `` `séquence` `` | appliqué à une `` `sequence` `` | the backticked identifier is the `sequence` variable defined in the snippet above, so it must not be translated |
| 95 | Pourquoi cela **a** échoué ? | Pourquoi cela **a-t-il** échoué ? | missing subject inversion in a direct question |

### Verification

- Built `chapters/fr` with `doc-builder build --html` — builds clean, and the rendered list and snippet were checked against the page.
- `make quality` reports the same result as `main` (pre-existing failures, from a newer `black` than the one pinned in CI).
- Emphasis, backticks, links and MDX tags are unchanged on every edited line.
