### PR TITLE
Fix outdated MRPC dataset identifier in Chapter 3

### DIFF
--- a/chapters/en/chapter3/2.mdx
+++ b/chapters/en/chapter3/2.mdx
@@ -51,7 +51,7 @@ The 🤗 Datasets library provides a very simple command to download and cache a
 ```py
 from datasets import load_dataset
 
-raw_datasets = load_dataset("glue", "mrpc")
+raw_datasets = load_dataset("nyu-mll/glue", "mrpc")
 raw_datasets
 ```
 


### PR DESCRIPTION
The Chapter 3 MRPC example uses an outdated Hugging Face dataset repository identifier.

Changed:

load_dataset("glue", "mrpc")

to:

load_dataset("nyu-mll/glue", "mrpc")

This prevents the `HfUriError` encountered when running the example with current versions of the Hugging Face libraries.

Fixes #926