### PR TITLE
Add a readable BERT paper link

### DIFF
--- a/chapters/en/chapter1/4.mdx
+++ b/chapters/en/chapter1/4.mdx
@@ -23,7 +23,7 @@ The [Transformer architecture](https://arxiv.org/abs/1706.03762) was introduced 
 
 - **June 2018**: [GPT](https://cdn.openai.com/research-covers/language-unsupervised/language_understanding_paper.pdf), the first pretrained Transformer model, used for fine-tuning on various NLP tasks and obtained state-of-the-art results
 
-- **October 2018**: [BERT](https://arxiv.org/abs/1810.04805), another large pretrained model, this one designed to produce better summaries of sentences (more on this in the next chapter!)
+- **October 2018**: [BERT](https://arxiv.org/abs/1810.04805) ([read online](https://webeditions.page/works/bert-pre-training/)), another large pretrained model, this one designed to produce better summaries of sentences (more on this in the next chapter!)
 
 - **February 2019**: [GPT-2](https://cdn.openai.com/better-language-models/language_models_are_unsupervised_multitask_learners.pdf), an improved (and bigger) version of GPT that was not immediately publicly released due to ethical concerns
 


### PR DESCRIPTION
Adds an optional HTML read-online companion beside the existing arXiv BERT link in the Transformer timeline.

The arXiv paper remains the source of record. The companion is section-addressable, mobile-friendly, and keeps the original ACL source attached.

Closes #1297.
